### PR TITLE
Fixing the cache dir calculation for backfill to perform correctly

### DIFF
--- a/change/lage-2020-05-24-14-42-31-fix-cache-dir.json
+++ b/change/lage-2020-05-24-14-42-31-fix-cache-dir.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix cache directory",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-24T21:42:31.081Z"
+}

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -3,6 +3,7 @@ import { PackageInfo } from "workspace-tools";
 import path from "path";
 import { RunContext } from "../types/RunContext";
 import { getCacheConfig } from "./cacheConfig";
+import log from "npmlog";
 
 const hashes: { [key: string]: string } = {};
 const cacheHits: { [key: string]: boolean } = {};
@@ -31,10 +32,7 @@ export async function fetchBackfill(info: PackageInfo, context: RunContext) {
   const cacheConfig = getCacheConfig(packagePath, context);
   const logger = backfill.makeLogger("warn", process.stdout, process.stderr);
   const hash = hashes[info.name];
-  const cwd = path.dirname(packagePath);
-
-  const cacheHit = await backfill.fetch(cwd, hash, logger, cacheConfig);
-
+  const cacheHit = await backfill.fetch(packagePath, hash, logger, cacheConfig);
   cacheHits[info.name] = cacheHit;
 }
 
@@ -43,11 +41,11 @@ export async function putBackfill(info: PackageInfo, context: RunContext) {
   const cacheConfig = getCacheConfig(packagePath, context);
   const logger = backfill.makeLogger("warn", process.stdout, process.stderr);
   const hash = hashes[info.name];
-  const cwd = path.dirname(packagePath);
 
   try {
-    await backfill.put(cwd, hash, logger, cacheConfig);
+    await backfill.put(packagePath, hash, logger, cacheConfig);
   } catch (e) {
+    log.error("", e);
     // here we swallow put errors because backfill will throw just because the output directories didn't exist
   }
 }

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -17,14 +17,18 @@ export async function computeHash(info: PackageInfo, context: RunContext) {
 
   logger.setName(name);
 
-  const hash = await backfill.computeHash(
-    packagePath,
-    logger,
-    context.command + context.args.join(" "),
-    cacheConfig
-  );
+  try {
+    const hash = await backfill.computeHash(
+      packagePath,
+      logger,
+      context.command + context.args.join(" "),
+      cacheConfig
+    );
 
-  hashes[info.name] = hash;
+    hashes[info.name] = hash;
+  } catch (e) {
+    log.error(`${info.name} computeHash`, e);
+  }
 }
 
 export async function fetchBackfill(info: PackageInfo, context: RunContext) {
@@ -32,8 +36,18 @@ export async function fetchBackfill(info: PackageInfo, context: RunContext) {
   const cacheConfig = getCacheConfig(packagePath, context);
   const logger = backfill.makeLogger("warn", process.stdout, process.stderr);
   const hash = hashes[info.name];
-  const cacheHit = await backfill.fetch(packagePath, hash, logger, cacheConfig);
-  cacheHits[info.name] = cacheHit;
+
+  try {
+    const cacheHit = await backfill.fetch(
+      packagePath,
+      hash,
+      logger,
+      cacheConfig
+    );
+    cacheHits[info.name] = cacheHit;
+  } catch (e) {
+    log.error(`${info.name} fetchBackfill`, e);
+  }
 }
 
 export async function putBackfill(info: PackageInfo, context: RunContext) {
@@ -45,8 +59,7 @@ export async function putBackfill(info: PackageInfo, context: RunContext) {
   try {
     await backfill.put(packagePath, hash, logger, cacheConfig);
   } catch (e) {
-    log.error("", e);
-    // here we swallow put errors because backfill will throw just because the output directories didn't exist
+    log.error(`${info.name} putBackfill`, e);
   }
 }
 


### PR DESCRIPTION
azure-blob provider was previous untested. This led to the bug to go unnoticed - now that I've tested it, I have a fix to make use of backfill's config system of override via environment variables.