### PR TITLE
Refactors discoverTaskDeps into not using File I/O

### DIFF
--- a/change/lage-2020-05-28-11-55-47-refactor.json
+++ b/change/lage-2020-05-28-11-55-47-refactor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "internal refactoring for discoverTaskDeps",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-28T18:55:47.239Z"
+}

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -37,8 +37,6 @@ export async function fetchBackfill(info: PackageInfo, context: RunContext) {
   const logger = backfill.makeLogger("error", process.stdout, process.stderr);
   const hash = hashes[info.name];
 
-  log.verbose("fetchBackfill", `fetch started for ${info.name}`);
-
   try {
     const cacheHit = await backfill.fetch(
       packagePath,
@@ -50,8 +48,6 @@ export async function fetchBackfill(info: PackageInfo, context: RunContext) {
   } catch (e) {
     log.error(`${info.name} fetchBackfill`, e);
   }
-
-  log.verbose("fetchBackfill", `fetch done for ${info.name}`);
 }
 
 export async function putBackfill(info: PackageInfo, context: RunContext) {
@@ -60,15 +56,11 @@ export async function putBackfill(info: PackageInfo, context: RunContext) {
   const logger = backfill.makeLogger("warn", process.stdout, process.stderr);
   const hash = hashes[info.name];
 
-  log.verbose("putBackfill", `put started for ${info.name}`);
-
   try {
     await backfill.put(packagePath, hash, logger, cacheConfig);
   } catch (e) {
     // sometimes outputGlob don't match any files, so skipping this
   }
-
-  log.verbose("putBackfill", `put done for ${info.name}`);
 }
 
 export { cacheHits };

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -37,6 +37,8 @@ export async function fetchBackfill(info: PackageInfo, context: RunContext) {
   const logger = backfill.makeLogger("error", process.stdout, process.stderr);
   const hash = hashes[info.name];
 
+  log.verbose("fetchBackfill", `fetch started for ${info.name}`);
+
   try {
     const cacheHit = await backfill.fetch(
       packagePath,
@@ -48,6 +50,8 @@ export async function fetchBackfill(info: PackageInfo, context: RunContext) {
   } catch (e) {
     log.error(`${info.name} fetchBackfill`, e);
   }
+
+  log.verbose("fetchBackfill", `fetch done for ${info.name}`);
 }
 
 export async function putBackfill(info: PackageInfo, context: RunContext) {
@@ -56,11 +60,15 @@ export async function putBackfill(info: PackageInfo, context: RunContext) {
   const logger = backfill.makeLogger("warn", process.stdout, process.stderr);
   const hash = hashes[info.name];
 
+  log.verbose("putBackfill", `put started for ${info.name}`);
+
   try {
     await backfill.put(packagePath, hash, logger, cacheConfig);
   } catch (e) {
     // sometimes outputGlob don't match any files, so skipping this
   }
+
+  log.verbose("putBackfill", `put done for ${info.name}`);
 }
 
 export { cacheHits };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,31 @@
+import { PackageInfos, PackageInfo } from "workspace-tools";
+import path from "path";
+import { cosmiconfigSync } from "cosmiconfig";
+import { Pipeline } from "./types/RunContext";
+
+const ConfigModuleName = "lage";
+
+function getPipeline(info: PackageInfo) {
+  const results = cosmiconfigSync(ConfigModuleName).search(
+    path.dirname(info.packageJsonPath)
+  );
+
+  if (results && results.config) {
+    return results.config.pipeline;
+  }
+
+  return null;
+}
+
+export function getPackagePipelines(allPackages: PackageInfos) {
+  const packagePipelines = new Map<string, Pipeline>();
+
+  for (const pkg of Object.keys(allPackages)) {
+    const pipeline = getPipeline(allPackages[pkg]);
+    if (pipeline) {
+      packagePipelines.set(pkg, pipeline);
+    }
+  }
+
+  return packagePipelines;
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,13 +1,14 @@
 import { Arguments } from "yargs-parser";
 import { CosmiconfigResult } from "cosmiconfig/dist/types";
 import { RunContext } from "./types/RunContext";
-import { getPackageInfos } from "workspace-tools";
+import { getPackageInfos, getChangedPackages } from "workspace-tools";
 import os from "os";
 import Profiler from "p-profiler";
 import PQueue from "p-queue";
 import { arrifyArgs, getPassThroughArgs } from "./args";
 import { EventEmitter } from "events";
 import { findNpmClient } from "./task/findNpmClient";
+import { getPackagePipelines } from "./config";
 
 export function createContext(options: {
   parsedArgs: Arguments;
@@ -19,9 +20,15 @@ export function createContext(options: {
   const concurrency = os.cpus().length - 1;
   const command = parsedArgs._;
   const npmClient = configResults?.config.npmClient || "npm";
+  const since = parsedArgs.since || undefined;
+  const ignore = parsedArgs.ignore || configResults?.config.ignoreGlob || [];
+  const changedPackages = getChangedPackages(root, since, ignore);
+  const allPackages = getPackageInfos(root);
+  const packagePipelines = getPackagePipelines(allPackages);
 
   return {
     root,
+    pipeline: {},
     cacheOptions: configResults?.config.cacheOptions || {},
     allPackages: getPackageInfos(root),
     command,
@@ -29,14 +36,16 @@ export function createContext(options: {
       parsedArgs.concurrency ||
       configResults?.config.concurrency ||
       concurrency,
-    pipeline: configResults?.config.pipeline || {
+    defaultPipeline: configResults?.config.pipeline || {
       build: ["^build"],
       clean: [],
     },
+    packagePipelines,
     taskDepsGraph: [],
     tasks: new Map(),
-    since: parsedArgs.since || undefined,
-    ignore: parsedArgs.ignore || configResults?.config.ignoreGlob || [],
+    since,
+    ignore,
+    changedPackages,
     deps: parsedArgs.deps || configResults?.config.deps || false,
     scope: parsedArgs.scope || configResults?.config.scope || [],
     measures: {

--- a/src/task/discoverTaskDeps.ts
+++ b/src/task/discoverTaskDeps.ts
@@ -49,7 +49,7 @@ function generateTaskDepsGraph(
 }
 
 /**
- * A functio
+ * A function that creates dependency relationship within the context.tasks and context.taskDepsGraph
  * @param fromTaskId
  * @param toTaskId
  * @param context

--- a/src/task/filterPackages.ts
+++ b/src/task/filterPackages.ts
@@ -1,0 +1,41 @@
+import logger from "npmlog";
+import { RunContext } from "../types/RunContext";
+import { getScopedPackages, getTransitiveDependencies } from "workspace-tools";
+
+export function filterPackages(context: RunContext) {
+  const { allPackages, scope, since, deps, changedPackages } = context;
+
+  let scopes = ([] as string[]).concat(scope);
+
+  let filtered: string[] = [];
+  let hasScopes = scopes && scopes.length > 0;
+  let hasSince = typeof since !== "undefined";
+
+  // If NOTHING is specified, use all packages
+  if (!hasScopes && !hasSince) {
+    logger.verbose("filterPackages", "scope: all packages");
+    filtered = Object.keys(allPackages);
+  }
+
+  // If scoped is defined, get scoped packages
+  if (hasScopes) {
+    const scoped = getScopedPackages(scopes, allPackages);
+    filtered = filtered.concat(scoped);
+    logger.verbose("filterPackages", `scope: ${scoped.join(",")}`);
+  }
+
+  if (hasSince) {
+    filtered = filtered.concat(changedPackages);
+    logger.verbose("filterPackages", `changed: ${changedPackages.join(",")}`);
+  }
+
+  if (deps) {
+    filtered = filtered.concat(
+      getTransitiveDependencies(filtered, allPackages)
+    );
+  }
+
+  const unique = new Set(filtered);
+
+  return [...unique];
+}

--- a/src/task/isValidTaskId.ts
+++ b/src/task/isValidTaskId.ts
@@ -1,0 +1,16 @@
+import { PackageInfos } from "workspace-tools";
+import { getPackageTaskFromId } from "./taskId";
+import {
+  ComputeHashTask,
+  CachePutTask,
+  CacheFetchTask,
+} from "../cache/cacheTasks";
+export function isValidTaskId(taskId: string, allPackages: PackageInfos) {
+  const [pkg, task] = getPackageTaskFromId(taskId);
+  return (
+    taskId === "" ||
+    task === "" ||
+    [ComputeHashTask, CachePutTask, CacheFetchTask].includes(task) ||
+    Object.keys(allPackages[pkg].scripts || {}).includes(task)
+  );
+}

--- a/src/task/npmTask.ts
+++ b/src/task/npmTask.ts
@@ -7,7 +7,12 @@ import { RunContext } from "../types/RunContext";
 import logger, { NpmLogWritable } from "../logger";
 import { taskWrapper } from "./taskWrapper";
 import { abort } from "./abortSignal";
-import os from "os";
+
+function wait(time: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, time);
+  });
+}
 
 export function npmTask(taskId: TaskId, context: RunContext) {
   const [pkg, task] = getPackageTaskFromId(taskId);
@@ -58,7 +63,7 @@ export function npmTask(taskId: TaskId, context: RunContext) {
             queue.clear();
             cp.kill("SIGKILL");
           }
-        }),
+        }).then(() => wait(100)),
       context
     )
   );

--- a/src/types/RunContext.ts
+++ b/src/types/RunContext.ts
@@ -19,12 +19,18 @@ interface Measures {
   taskStats: TaskStats[];
 }
 
+export interface Pipeline {
+  [task: string]: string[];
+}
+
 export interface RunContext extends CliOptions, ConfigOptions {
   root: string;
   taskDepsGraph: TaskDepsGraph;
   tasks: Tasks;
   allPackages: PackageInfos;
-  pipeline: { [task: string]: string[] };
+  changedPackages: string[];
+  defaultPipeline: Pipeline;
+  packagePipelines: Map<string, Pipeline>;
   measures: Measures;
   profiler: Profiler;
   taskLogs: Map<TaskId, string[]>;


### PR DESCRIPTION
discoverTaskDeps is a core piece of logic that needs to be unit testable. As such, it would be very much be refactored to not touch file i/o. All the inputs are moved out into the RunContext. There will need to be a further refactor to reduce what the functions take in as args in a separate PR.