### PR TITLE
The configuration for ignore glob should be keyed as "ignore" instead of "ignoreGlob"

### DIFF
--- a/change/lage-2020-06-04-09-57-13-ignore-config.json
+++ b/change/lage-2020-06-04-09-57-13-ignore-config.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixed the ignore param so that it works!",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T16:57:13.847Z"
+}

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -38,7 +38,7 @@ export function getConfig(cwd: string): Config {
       configResults?.config.concurrency ||
       os.cpus().length - 1,
     deps,
-    ignore: parsedArgs.ignore || configResults?.config.ignoreGlob || [],
+    ignore: parsedArgs.ignore || configResults?.config.ignore || [],
     node: parsedArgs.node ? arrifyArgs(parsedArgs.node) : [],
     npmClient: configResults?.config.npmClient || "npm",
     pipeline: configResults?.config.pipeline || {},


### PR DESCRIPTION
this bug prevents proper configuration from a `lage.config.js` file.