### PR TITLE
Cache fixes, adding a reset-cache command

### DIFF
--- a/change/lage-2020-06-16-14-55-04-cache.json
+++ b/change/lage-2020-06-16-14-55-04-cache.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding a resetCache flag to resave cache if something went awry",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T21:55:04.216Z"
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -50,6 +50,7 @@ export function getPassThroughArgs(args: { [key: string]: string | string[] }) {
     since: _sinceArg,
     deps: _depsArg,
     cache: _cacheArg,
+    resetCache: _resetCacheArg,
     ignore: _ignoreArg,
     verbose: _verboseArg,
     _: _positionals,

--- a/src/args.ts
+++ b/src/args.ts
@@ -67,6 +67,7 @@ export function parseArgs() {
     array: ["scope", "node", "ignore"],
     configuration: {
       "populate--": true,
+      "strip-dashed": true,
     },
   });
 }

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -31,6 +31,7 @@ export function getConfig(cwd: string): Config {
   return {
     args: getPassThroughArgs(parsedArgs),
     cache: parsedArgs.cache === false ? false : true,
+    resetCache: parsedArgs.resetCache || false,
     cacheOptions: configResults?.config.cacheOptions || {},
     command,
     concurrency:

--- a/src/task/taskWrapper.ts
+++ b/src/task/taskWrapper.ts
@@ -25,7 +25,7 @@ export async function taskWrapper(
   if (config.cache) {
     hash = await cacheHash(task, info, root, config);
 
-    if (hash) {
+    if (hash && !config.resetCache) {
       cacheHit = await cacheFetch(hash, info, config);
     }
 

--- a/src/task/taskWrapper.ts
+++ b/src/task/taskWrapper.ts
@@ -19,7 +19,7 @@ export async function taskWrapper(
   const logger = taskLogger(pkg, task);
   const start = process.hrtime();
 
-  let cacheHit = true;
+  let cacheHit = false;
   let hash: string | null = null;
 
   if (config.cache) {

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -20,6 +20,7 @@ export interface CliOptions {
   since?: string;
   deps: boolean;
   cache: boolean;
+  resetCache: boolean;
   node: string[];
   args: any;
   verbose: boolean;


### PR DESCRIPTION
We need to make sure cacheHit is false by default and then add a reset-cache command to let lage know to skip fetching but continue to put backfill.

Fixes #25 