### PR TITLE
Adds a new env variable LAGE_PACKAGE_NAME

### DIFF
--- a/change/lage-2020-06-18-12-49-42-lage-env.json
+++ b/change/lage-2020-06-18-12-49-42-lage-env.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding a environment variable LAGE_PACKAGE_NAME like Lerna",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-18T19:49:42.438Z"
+}

--- a/src/task/npmTask.ts
+++ b/src/task/npmTask.ts
@@ -53,6 +53,7 @@ export function npmTask(
             env: {
               ...process.env,
               ...(process.stdout.isTTY && { FORCE_COLOR: "1" }),
+              LAGE_PACKAGE_NAME: info.name,
             },
           });
 


### PR DESCRIPTION
Subsequent jobs can use this as a way to coordinate concurrency. A prime example is tell subsequent jest job to runInBand based on this environment variable. 