### PR TITLE
Send the profiler's output to the system's tmp dir

### DIFF
--- a/change/lage-2020-07-09-17-38-42-philip-scott-profile-to-tmp.json
+++ b/change/lage-2020-07-09-17-38-42-philip-scott-profile-to-tmp.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move profiler output to the system tmp dir",
+  "packageName": "lage",
+  "email": "feescoto@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-10T00:38:42.424Z"
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@ import { RunContext } from "./types/RunContext";
 import Profiler from "p-profiler";
 import { join } from "path";
 import { tmpdir } from "os";
-import { mkdirSync } from 'fs';
+import { mkdirSync } from "fs";
 
 export function createContext(config: Pick<Config, "concurrency">): RunContext {
   const { concurrency } = config;
@@ -16,12 +16,12 @@ export function createContext(config: Pick<Config, "concurrency">): RunContext {
       start: [0, 0],
       duration: [0, 0],
       taskStats: [],
-      failedTask: undefined
+      failedTask: undefined,
     },
     profiler: new Profiler({
       concurrency,
       prefix: "lage",
-      outDir: profilerOutputDir
+      outDir: profilerOutputDir,
     })
   };
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,21 +1,27 @@
 import { Config } from "./types/Config";
 import { RunContext } from "./types/RunContext";
 import Profiler from "p-profiler";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdirSync } from 'fs';
 
 export function createContext(config: Pick<Config, "concurrency">): RunContext {
   const { concurrency } = config;
+
+  const profilerOutputDir = join(tmpdir(), "lage", "profiles");
+  mkdirSync(profilerOutputDir, { recursive: true });
 
   return {
     measures: {
       start: [0, 0],
       duration: [0, 0],
       taskStats: [],
-      failedTask: undefined,
+      failedTask: undefined
     },
     profiler: new Profiler({
       concurrency,
       prefix: "lage",
-      outDir: process.cwd(),
-    }),
+      outDir: profilerOutputDir
+    })
   };
 }


### PR DESCRIPTION
I wanted to add the profiles as an artifact of the Pipelines, but it currently it saves it to the current working directory, with a side effect of pouting the repo. 

I set the output of the profiler's  to `/tmp/lage/profiles` with the thought that you could later use `/tmp/lage/bar` for any other output that you want to save. 

Note: I haven't tested the change on Windows :stuck_out_tongue: But it should™ work since I am not building the path manually and I'm fetching the tmp dir from OS, but let me know if there are any issues or if instead we should allow setting the output dir instead/as well.