### PR TITLE
Add support for task prioritization

### DIFF
--- a/change/lage-2020-07-15-07-52-40-chrisgo-priority.json
+++ b/change/lage-2020-07-15-07-52-40-chrisgo-priority.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add support for task prioritization",
+  "packageName": "lage",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T14:52:39.994Z"
+}

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -58,3 +58,17 @@ module.exports = {
   },
 };
 ```
+
+`priorities`
+
+```typescript
+export type Priority = { package: string; task: string; priority: number };
+```
+
+The configuration enables for tasks to be given priorities. These priorities enable the task runner to schedule tasks with a higher priority sooner than tasks with a lower priority. An example use case would be to give tasks that take a long time to execute a high priority so that these tasks (and the tasks these tasks depend on) can be scheduled earlier to reduce overall execution time.
+
+```js
+module.exports = {
+ priorities: [{ package: "build-tools"; task: "build"; priority: 20 }]
+}
+```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "watchpack": "1.6.1"
   },
   "dependencies": {
-    "@microsoft/task-scheduler": "^2.2.0",
+    "@microsoft/task-scheduler": "^2.4.0",
     "abort-controller": "^3.0.0",
     "backfill": "^6.0.0",
     "backfill-config": "^6.0.0",
@@ -38,7 +38,6 @@
     "git-url-parse": "^11.1.2",
     "npmlog": "^4.1.2",
     "p-profiler": "^0.1.2",
-    "p-queue": "^6.4.0",
     "workspace-tools": "^0.8.0",
     "yargs-parser": "^18.1.3"
   },

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -43,6 +43,7 @@ export function getConfig(cwd: string): Config {
     node: parsedArgs.node ? arrifyArgs(parsedArgs.node) : [],
     npmClient: configResults?.config.npmClient || "npm",
     pipeline: configResults?.config.pipeline || {},
+    priorities: configResults?.config.priorities || {},
     profile: parsedArgs.profile,
     scope: parsedArgs.scope || configResults?.config.scope || [],
     since: parsedArgs.since || undefined,

--- a/src/task/npmTask.ts
+++ b/src/task/npmTask.ts
@@ -6,10 +6,8 @@ import { spawn, ChildProcess } from "child_process";
 import { taskLogger, NpmLogWritable } from "../logger";
 import { taskWrapper } from "./taskWrapper";
 import path from "path";
-import PQueue from "p-queue";
 
 let npmCmd: string;
-let queue: PQueue;
 let bail = false;
 let activeProcesses = new Set<ChildProcess>();
 
@@ -20,12 +18,11 @@ export function npmTask(
   context: RunContext,
   root: string
 ) {
-  const { node, args, npmClient, concurrency } = config;
+  const { node, args, npmClient } = config;
 
   const logger = taskLogger(info.name, task);
 
   // cached npmCmd
-  queue = queue || new PQueue({ concurrency });
   npmCmd = npmCmd || findNpmClient(npmClient);
 
   const npmArgs = [...node, "run", task, "--", ...args];
@@ -34,55 +31,53 @@ export function npmTask(
     return Promise.reject();
   }
 
-  return queue.add(() =>
-    taskWrapper(
-      info,
-      task,
-      () =>
-        new Promise((resolve, reject) => {
-          if (!info.scripts || !info.scripts![task]) {
-            logger.info(`Empty script detected, skipping`);
+  return taskWrapper(
+    info,
+    task,
+    () =>
+      new Promise((resolve, reject) => {
+        if (!info.scripts || !info.scripts![task]) {
+          logger.info(`Empty script detected, skipping`);
+          return resolve();
+        }
+
+        logger.verbose(`Running ${[npmCmd, ...npmArgs].join(" ")}`);
+
+        const cp = spawn(npmCmd, npmArgs, {
+          cwd: path.dirname(info.packageJsonPath),
+          stdio: "pipe",
+          env: {
+            ...process.env,
+            ...(process.stdout.isTTY && { FORCE_COLOR: "1" }),
+            LAGE_PACKAGE_NAME: info.name,
+          },
+        });
+
+        activeProcesses.add(cp);
+
+        const stdoutLogger = new NpmLogWritable(info.name, task);
+        cp.stdout.pipe(stdoutLogger);
+
+        const stderrLogger = new NpmLogWritable(info.name, task);
+        cp.stderr.pipe(stderrLogger);
+
+        cp.on("exit", handleChildProcessExit);
+
+        function handleChildProcessExit(code: number) {
+          if (code === 0) {
+            activeProcesses.delete(cp);
             return resolve();
           }
 
-          logger.verbose(`Running ${[npmCmd, ...npmArgs].join(" ")}`);
-
-          const cp = spawn(npmCmd, npmArgs, {
-            cwd: path.dirname(info.packageJsonPath),
-            stdio: "pipe",
-            env: {
-              ...process.env,
-              ...(process.stdout.isTTY && { FORCE_COLOR: "1" }),
-              LAGE_PACKAGE_NAME: info.name,
-            },
-          });
-
-          activeProcesses.add(cp);
-
-          const stdoutLogger = new NpmLogWritable(info.name, task);
-          cp.stdout.pipe(stdoutLogger);
-
-          const stderrLogger = new NpmLogWritable(info.name, task);
-          cp.stderr.pipe(stderrLogger);
-
-          cp.on("exit", handleChildProcessExit);
-
-          function handleChildProcessExit(code: number) {
-            if (code === 0) {
-              activeProcesses.delete(cp);
-              return resolve();
-            }
-
-            bail = true;
-            cp.stdout.destroy();
-            cp.stdin.destroy();
-            reject();
-          }
-        }),
-      config,
-      context,
-      root
-    )
+          bail = true;
+          cp.stdout.destroy();
+          cp.stdin.destroy();
+          reject();
+        }
+      }),
+    config,
+    context,
+    root
   );
 }
 

--- a/src/task/taskRunner.ts
+++ b/src/task/taskRunner.ts
@@ -1,5 +1,9 @@
 import { RunContext } from "../types/RunContext";
-import { createPipeline, TopologicalGraph } from "@microsoft/task-scheduler";
+import {
+  createPipeline,
+  TopologicalGraph,
+  Task,
+} from "@microsoft/task-scheduler";
 import { Config } from "../types/Config";
 import { npmTask } from "./npmTask";
 import { filterPackages } from "./filterPackages";
@@ -10,6 +14,20 @@ import {
   getChangedPackages,
   getTransitiveProviders,
 } from "workspace-tools";
+import { Priority } from "../types/Priority";
+
+/** Returns a map of task name -> */
+function getPriorityMap(priorities: Priority[]) {
+  const result = new Map<string, Task["priorities"]>();
+
+  priorities.forEach((entry) => {
+    const taskPriority = result.get(entry.task) || {};
+    taskPriority[entry.package] = entry.priority;
+    result.set(entry.task, taskPriority);
+  });
+
+  return result;
+}
 
 export async function runTasks(options: {
   graph: TopologicalGraph;
@@ -19,6 +37,8 @@ export async function runTasks(options: {
 }) {
   const { graph, workspace, context, config } = options;
 
+  const priorityMap = getPriorityMap(config.priorities);
+
   let pipeline = createPipeline(graph, {
     // dummy logger for task-scheduler because lage already has logger for its tasks
     logger: {
@@ -27,6 +47,7 @@ export async function runTasks(options: {
     },
     exit: (code) => {},
     targetsOnly: config.only,
+    concurrency: config.concurrency,
   });
 
   const taskNames = Object.keys(config.pipeline);
@@ -41,6 +62,7 @@ export async function runTasks(options: {
       name: task,
       deps,
       topoDeps,
+      priorities: priorityMap.get(task),
       run: async (_location, _stdout, _stderr, pkg) => {
         const scripts = workspace.allPackages[pkg].scripts;
         if (scripts && scripts[task]) {

--- a/src/task/taskRunner.ts
+++ b/src/task/taskRunner.ts
@@ -16,7 +16,7 @@ import {
 } from "workspace-tools";
 import { Priority } from "../types/Priority";
 
-/** Returns a map of task name -> */
+/** Returns a map that maps task name to the priorities config for that task */
 function getPriorityMap(priorities: Priority[]) {
   const result = new Map<string, Task["priorities"]>();
 

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -1,5 +1,6 @@
 import { Config as BackfillCacheOptions } from "backfill-config";
 import { Pipeline } from "./Pipeline";
+import { Priority } from "./Priority";
 
 export type CacheOptions = BackfillCacheOptions & {
   environmentGlob: string[];
@@ -11,6 +12,9 @@ export interface ConfigOptions {
   cacheOptions: CacheOptions;
   ignore: string[];
   npmClient: "npm" | "yarn" | "pnpm";
+
+  /** Optional priority to set on tasks in a package to make the scheduler give priority to tasks on the critical path for high priority tasks */
+  priorities: Priority[];
 }
 
 export interface CliOptions {

--- a/src/types/Priority.ts
+++ b/src/types/Priority.ts
@@ -1,0 +1,1 @@
+export type Priority = { package: string; task: string; priority: number };

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,10 +899,10 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz#8ff71d51053cd5ee4981e5a501d80a536244f7fd"
   integrity sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==
 
-"@microsoft/task-scheduler@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.2.0.tgz#0f568825ccdea0dc2c8d46de1893989a160e05f1"
-  integrity sha512-7XuDRTAyt6TuvnES3FmeZ73Ic+jPl86cVKEbbK4i6kblApxZlImCihUGW16BBkGHqWy9KXmAR6JDW9j4xbDdVA==
+"@microsoft/task-scheduler@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.4.0.tgz#f53ca144036c5089ef1806834b1686ed4b6fc535"
+  integrity sha512-mHEYP45l1CJ6TKNkQqzJPM8UAVQcZkWJybIXIy4QfPAyt77/XvEkrxlYiuvaO4uLkW0a/E3juFYwcbgsZ9Xtww==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -6580,14 +6580,6 @@ p-queue@*:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.3.0.tgz#19bfa4485db7e6a0c135049ff6716375880d9c3a"
   integrity sha512-fg5dJlFpd5+3CgG3/0ogpVZUeJbjiyXFg0nu53hrOYsybqSiDyxyOpad0Rm6tAiGjgztAwkyvhlYHC53OiAJOA==
-  dependencies:
-    eventemitter3 "^4.0.0"
-    p-timeout "^3.1.0"
-
-p-queue@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.4.0.tgz#5050b379393ea1814d6f9613a654f687d92c0466"
-  integrity sha512-X7ddxxiQ+bLR/CUt3/BVKrGcJDNxBr0pEEFKHHB6vTPWNUhgDv36GpIH18RmGM3YGPpBT+JWGjDDqsVGuF0ERw==
   dependencies:
     eventemitter3 "^4.0.0"
     p-timeout "^3.1.0"


### PR DESCRIPTION
Enables repos to give hints to lage via priorities to help provide optimal scheduling. Long term this could be populated automatically by lage based on historical data 