### PR TITLE
Increase default concurrency to os.cpus().length

### DIFF
--- a/change/lage-2020-07-15-11-56-47-chrisgo-moar-cores.json
+++ b/change/lage-2020-07-15-11-56-47-chrisgo-moar-cores.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Increase default concurrency to os.cpus().length",
+  "packageName": "lage",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T18:56:47.390Z"
+}

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -37,7 +37,7 @@ export function getConfig(cwd: string): Config {
     concurrency:
       parsedArgs.concurrency ||
       configResults?.config.concurrency ||
-      os.cpus().length - 1,
+      os.cpus().length,
     deps,
     ignore: parsedArgs.ignore || configResults?.config.ignore || [],
     node: parsedArgs.node ? arrifyArgs(parsedArgs.node) : [],


### PR DESCRIPTION
We haven't seen evidence to support that using os.cpus().length - 1 is better than os.cpu().length and local trials have shown faster builds when using concurrency equal to the number of cores. Switching the default to be equal to the os core count until we have a reason to use less by default.