### PR TITLE
Bump workspace tools

### DIFF
--- a/change/lage-2020-07-17-12-29-42-bump-workspace-tools.json
+++ b/change/lage-2020-07-17-12-29-42-bump-workspace-tools.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "bump workspace tools to get new preferred workspace manager",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T19:29:42.211Z"
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "git-url-parse": "^11.1.2",
     "npmlog": "^4.1.2",
     "p-profiler": "^0.1.2",
-    "workspace-tools": "^0.8.0",
+    "workspace-tools": "^0.9.0",
     "yargs-parser": "^18.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@microsoft/task-scheduler": "^2.4.0",
     "abort-controller": "^3.0.0",
-    "backfill": "^6.0.0",
+    "backfill": "^6.0.1",
     "backfill-config": "^6.0.0",
     "backfill-logger": "^5.0.0",
     "chalk": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9370,10 +9370,10 @@ workspace-tools@^0.7.6:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
-workspace-tools@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.8.0.tgz#18711cb83391a471cf2e061bb5ea3c127a5d7a88"
-  integrity sha512-y5He+EzOhrLXSqYvsFhAD3IxX9QUgE8GR8pbxdAllkJPSSIy75HpA5NFT7j1FtULjTxsI6iCVA/6OLPyvPqStA==
+workspace-tools@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.0.tgz#5ce0680c9bf38544d1f6261d6b0e2834347e676e"
+  integrity sha512-ji9mOpdxyJ1LBnCzfFzAuLw7x0OuqQso/eJFpeyR/W0nXRK3Uhmn0dAaqrlDlrUEW5nOT5nSz0MpsaCmeSyiUA==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,17 +1905,17 @@ backfill-config@^6.0.0:
     fs-extra "^8.1.0"
     pkg-dir "^4.2.0"
 
-backfill-hasher@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.0.0.tgz#78c5aae1b0bdc1dfa2a3e410c1982f31b6bd8df6"
-  integrity sha512-5y3l1rS3CcUoAmh2kHEa6ClEPaCX2YCQMSDQq43ZqORX4wLGb3/BpFS7gUaun6Z4bFHy4vGsYNkLlnn/yjMpSA==
+backfill-hasher@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.0.1.tgz#c7896e44bc08293957e9a7613277e9365d03f224"
+  integrity sha512-ylJE1x72/1ZE4zyVsP6DLeXjv0DHBdDGT2HBwC5gwkcZIM2EIXsKAmsYiXIu5HQKZEoaUT/kg220PKp/3/3g8w==
   dependencies:
     "@rushstack/package-deps-hash" "^2.4.22"
     backfill-config "^6.0.0"
     backfill-logger "^5.0.0"
     find-up "^4.1.0"
     fs-extra "^8.1.0"
-    workspace-tools "^0.7.6"
+    workspace-tools "^0.9.0"
 
 backfill-logger@^5.0.0:
   version "5.0.0"
@@ -1934,15 +1934,15 @@ backfill-utils-dotenv@^5.0.0:
     dotenv "^8.1.0"
     find-up "^4.0.0"
 
-backfill@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/backfill/-/backfill-6.0.0.tgz#0f28fd68ace1f21c99183f928b121fd475b3c84a"
-  integrity sha512-BkS0F1Mt0Xw4a+WRFTvIJz9lj1C41hao2QlXe3hVu563fOMkYK/gelo6+SYz69SttOKNrNWbZNNaKUGJcpBdPQ==
+backfill@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/backfill/-/backfill-6.0.1.tgz#316ee8f13796683c9d3d05491fd0ddfdc1ee59c7"
+  integrity sha512-K49DGPZF7tI1vI/L8V2atH1gMFW5RuqSlNmipz+fW4zPK7ZMJifyaOMqVfOCvsH7pj0E9nEipCH/XSJOtD+0gA==
   dependencies:
     anymatch "^3.0.3"
     backfill-cache "^5.1.3"
     backfill-config "^6.0.0"
-    backfill-hasher "^6.0.0"
+    backfill-hasher "^6.0.1"
     backfill-logger "^5.0.0"
     backfill-utils-dotenv "^5.0.0"
     chokidar "^3.2.1"
@@ -9351,24 +9351,6 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
-
-workspace-tools@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.7.6.tgz#4c3e9880d7f5afd6e650d9e58785f31389f68f74"
-  integrity sha512-iNGCMTr/fnZ7xWNDHro4B5Le7Tx8hywfxfjVZZSIsje5J3hjE76cxHdFRhd0VNJ1dMJ2Zqs3iOqg1scgIwCx+w==
-  dependencies:
-    "@pnpm/lockfile-file" "^3.0.7"
-    "@pnpm/logger" "^3.2.2"
-    "@yarnpkg/lockfile" "^1.1.0"
-    find-up "^4.1.0"
-    find-yarn-workspace-root "^1.2.1"
-    fs-extra "^9.0.0"
-    git-url-parse "^11.1.2"
-    globby "^11.0.0"
-    jju "^1.4.0"
-    matcher "^3.0.0"
-    multimatch "^4.0.0"
-    read-yaml-file "^2.0.0"
 
 workspace-tools@^0.9.0:
   version "0.9.0"


### PR DESCRIPTION
This adds the PREFERRED_WORKSPACE_MANAGER env variable we can now use to swap between which one to use when building with lage.

It overrides any detection done by the workspace-tools lib. 