### PR TITLE
Info command - will add a new command that will make it possible to list out the package task graph

### DIFF
--- a/change/lage-2020-08-13-12-09-17-info.json
+++ b/change/lage-2020-08-13-12-09-17-info.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adds an info command that lists out the package task dep graph",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T19:09:17.773Z"
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watchpack": "1.6.1"
   },
   "dependencies": {
-    "@microsoft/task-scheduler": "^2.4.0",
+    "@microsoft/task-scheduler": "^2.5.0",
     "abort-controller": "^3.0.0",
     "backfill": "^6.0.1",
     "backfill-config": "^6.0.0",

--- a/src/command/info.ts
+++ b/src/command/info.ts
@@ -1,0 +1,135 @@
+import { logger } from "../logger";
+import { Config } from "../types/Config";
+import { getWorkspace } from "../workspace/getWorkspace";
+import { generateTopologicGraph } from "../workspace/generateTopologicalGraph";
+import { generateTaskGraph } from "@microsoft/task-scheduler";
+import { getPipelinePackages } from "../task/getPipelinePackages";
+import { Tasks } from "@microsoft/task-scheduler/lib/types";
+import { parseDepsAndTopoDeps } from "../task/parseDepsAndTopoDeps";
+import { PackageTaskInfo } from "../logger/LogEntry";
+import { getPackageAndTask } from "../task/taskId";
+import path from "path";
+import { Workspace } from "../types/Workspace";
+import { getNpmCommand } from "../task/getNpmCommand";
+
+/**
+ * Generates a graph and spit it out in stdout
+ *
+ * Expected format:
+ * [
+ *   {
+ *       "id": "bar##build",
+ *       "package": "bar",
+ *       "task": "build",
+ *       "command": "npm run build --blah",
+ *       "workingDirectory": "packages/bar",
+ *       "dependencies": []
+ *   },
+ *   {
+ *       "id": "foo##build",
+ *       "package": "foo",
+ *       "task": "build",
+ *       "command": "npm run build --blah",
+ *       "workingDirectory": "packages/foo",
+ *       "dependencies": [
+ *           "bar##build"
+ *       ]
+ *   },
+ *   {
+ *       "id": "foo##test",
+ *       "package": "foo",
+ *       "task": "test",
+ *       "command": "npm run test --blah",
+ *       "workingDirectory": "packages/foo",
+ *       "dependencies": [
+ *           "foo##build"
+ *       ]
+ *   },
+ *   ...
+ * ]
+ */
+
+export async function info(cwd: string, config: Config) {
+  const workspace = getWorkspace(cwd, config);
+  const tasks: Tasks = new Map();
+
+  for (const [taskName, taskDeps] of Object.entries(config.pipeline)) {
+    const { deps, topoDeps } = parseDepsAndTopoDeps(taskDeps);
+
+    tasks.set(taskName, {
+      name: taskName,
+      run: () => Promise.resolve(true),
+      deps,
+      topoDeps,
+    });
+  }
+
+  const graph = generateTopologicGraph(workspace);
+  const packages = getPipelinePackages(workspace, config);
+  const taskDeps = generateTaskGraph(
+    packages,
+    config.command.slice(1),
+    tasks,
+    graph,
+    false
+  );
+
+  const packageTasks = new Map<string, PackageTaskInfo>();
+
+  for (const [fromId, toId] of taskDeps) {
+    let fromPackageTask = packageTasks.get(fromId);
+    let toPackageTask = packageTasks.get(toId);
+
+    // Try creating missing package task info
+    if (!fromPackageTask) {
+      fromPackageTask = createPackageTaskInfo(fromId, config, workspace);
+      if (fromPackageTask) {
+        packageTasks.set(fromId, fromPackageTask);
+      }
+    }
+
+    if (!toPackageTask) {
+      toPackageTask = createPackageTaskInfo(toId, config, workspace);
+      if (toPackageTask) {
+        packageTasks.set(toId, toPackageTask);
+      }
+    }
+
+    // If "from" AND "to" package tasks are valid, then connect them
+    if (fromPackageTask && toPackageTask) {
+      toPackageTask.dependencies.push(fromId);
+    }
+  }
+
+  logger.info(`info`, {
+    command: config.command.slice(1),
+    scope: packages,
+    packageTasks: [...packageTasks.values()],
+  });
+}
+
+function createPackageTaskInfo(
+  taskId: string,
+  config: Config,
+  workspace: Workspace
+) {
+  const task = getPackageAndTask(taskId)!;
+
+  const scripts = workspace.allPackages[task.package].scripts;
+
+  if (scripts && scripts[task.task]) {
+    return {
+      id: taskId,
+      command: getNpmCommand(config, task.task),
+      dependencies: [],
+      workingDirectory: path
+        .relative(
+          workspace.root,
+          path.dirname(workspace.allPackages[task.package].packageJsonPath)
+        )
+        .replace(/\\/g, "/"),
+      package: task.package,
+      task: task.task,
+    };
+  }
+}

--- a/src/command/info.ts
+++ b/src/command/info.ts
@@ -120,7 +120,7 @@ function createPackageTaskInfo(
   if (scripts && scripts[task.task]) {
     return {
       id: taskId,
-      command: getNpmCommand(config, task.task),
+      command: [config.npmClient, ...getNpmCommand(config, task.task)],
       dependencies: [],
       workingDirectory: path
         .relative(

--- a/src/command/version.ts
+++ b/src/command/version.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+import { logger } from '../logger'
+
+export function version() {
+  const lagePackageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8'));
+  logger.info(lagePackageJson.version);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,38 +3,34 @@ import { init } from "./command/init";
 import { run } from "./command/run";
 import { showHelp } from "./showHelp";
 import { logger } from "./logger";
-import { Logger } from "./logger/Logger";
-import { NpmLogReporter } from "./logger/reporters/NpmLogReporter";
-import { LogLevel } from "./logger/LogLevel";
-import { JsonReporter } from "./logger/reporters/JsonReporter";
+import { info } from "./command/info";
+import { initReporters } from "./logger/initReporters";
+import { version } from "./command/version";
 
 // Parse CLI args
 const cwd = process.cwd();
 try {
   const config = getConfig(cwd);
+  const reporters = initReporters(config)
 
-  // Initialize logger
-  const logLevel = config.verbose ? LogLevel.verbose : LogLevel.info;
+  switch(config.command[0]) {
+    case 'init':
+      init(cwd);
+      break;
 
-  const reporters = [
-    config.reporter === "json"
-      ? new JsonReporter({ logLevel })
-      : new NpmLogReporter({
-          logLevel,
-          grouped: config.grouped,
-        }),
-  ];
+    case 'info':
+      info(cwd, config);
+      break;
 
-  Logger.reporters = reporters;
-
-  logger.info(`Lage task runner - let's make it`);
-
-  if (config.command[0] === "init") {
-    init(cwd);
-  } else {
-    run(cwd, config, reporters);
+    case 'version':
+      version();
+      break;
+    
+    default:
+      logger.info(`Lage task runner - let's make it`);
+      run(cwd, config, reporters);
+      break;
   }
 } catch (e) {
-  console.error(e);
   showHelp(e.message);
 }

--- a/src/logger/LogEntry.ts
+++ b/src/logger/LogEntry.ts
@@ -4,8 +4,10 @@ export interface LogEntry {
   timestamp: number;
   level: LogLevel;
   msg: string;
-  data?: TaskData;
+  data?: LogStructuredData;
 }
+
+export type LogStructuredData = TaskData | InfoData;
 
 export interface TaskData {
   status?: "pending" | "started" | "completed" | "failed" | "skipped";
@@ -13,4 +15,26 @@ export interface TaskData {
   task?: string;
   duration?: string;
   hash?: string | null;
+}
+
+/**
+ * LogStructuredData for the `info` command
+ */
+export interface InfoData {
+  command?: string[];
+  scope?: string[];
+  packageTasks?: PackageTaskInfo[];
+}
+
+/**
+ * Only useful for logging purposes for the `info` command
+ * Use task-scheduler types for interacting with the pipelines
+ */
+export interface PackageTaskInfo {
+  id: string;
+  package: string;
+  task: string;
+  command: string[];
+  workingDirectory: string;
+  dependencies: string[];
 }

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -1,4 +1,4 @@
-import { LogEntry, TaskData } from "./LogEntry";
+import { LogEntry, LogStructuredData } from "./LogEntry";
 import { LogLevel } from "./LogLevel";
 import { Reporter } from "./reporters/Reporter";
 import { NpmLogReporter } from "./reporters/NpmLogReporter";
@@ -10,7 +10,7 @@ export class Logger {
 
   logs: LogEntry[] = [];
 
-  log(level: LogLevel, msg: string, data?: TaskData) {
+  log(level: LogLevel, msg: string, data?: LogStructuredData) {
     const entry = {
       timestamp: Date.now(),
       level,
@@ -25,23 +25,23 @@ export class Logger {
     }
   }
 
-  info(msg: string, data?: TaskData) {
+  info(msg: string, data?: LogStructuredData) {
     this.log(LogLevel.info, msg, data);
   }
 
-  warn(msg: string, data?: TaskData) {
+  warn(msg: string, data?: LogStructuredData) {
     this.log(LogLevel.warn, msg, data);
   }
 
-  error(msg: string, data?: TaskData) {
+  error(msg: string, data?: LogStructuredData) {
     this.log(LogLevel.error, msg, data);
   }
 
-  verbose(msg: string, data?: TaskData) {
+  verbose(msg: string, data?: LogStructuredData) {
     this.log(LogLevel.verbose, msg, data);
   }
 
-  silly(msg: string, data?: TaskData) {
+  silly(msg: string, data?: LogStructuredData) {
     this.log(LogLevel.silly, msg, data);
   }
 }

--- a/src/logger/initReporters.ts
+++ b/src/logger/initReporters.ts
@@ -1,0 +1,21 @@
+import { Config } from "../types/Config";
+import { Logger } from "./Logger";
+import { NpmLogReporter } from "./reporters/NpmLogReporter";
+import { LogLevel } from "./LogLevel";
+import { JsonReporter } from "./reporters/JsonReporter";
+
+export function initReporters(config: Config) {
+  // Initialize logger
+  const logLevel = config.verbose ? LogLevel.verbose : LogLevel.info;
+  const reporters = [
+    config.reporter === "json"
+      ? new JsonReporter({ logLevel })
+      : new NpmLogReporter({
+          logLevel,
+          grouped: config.grouped,
+        }),
+  ];
+
+  Logger.reporters = reporters;
+  return reporters;
+}

--- a/src/logger/reporters/NpmLogReporter.ts
+++ b/src/logger/reporters/NpmLogReporter.ts
@@ -173,7 +173,7 @@ export class NpmLogReporter implements Reporter {
       completed: chalk.greenBright,
       failed: chalk.redBright,
       skipped: chalk.gray,
-      started: chalk.redBright,
+      started: chalk.yellow,
       pending: chalk.gray,
     };
 

--- a/src/logger/reporters/NpmLogReporter.ts
+++ b/src/logger/reporters/NpmLogReporter.ts
@@ -2,7 +2,7 @@ import log from "npmlog";
 import chalk from "chalk";
 import { Reporter } from "./Reporter";
 import { LogLevel } from "../LogLevel";
-import { LogEntry } from "../LogEntry";
+import { LogEntry, LogStructuredData, TaskData, InfoData } from "../LogEntry";
 import { formatDuration, hrToSeconds } from "./formatDuration";
 import { getTaskId } from "../../task/taskId";
 import { RunContext } from "../../types/RunContext";
@@ -38,6 +38,14 @@ function normalize(prefixOrMessage: string, message?: string) {
   }
 }
 
+function isTaskData(data?: LogStructuredData): data is TaskData {
+  return data !== undefined && (data as TaskData).task !== undefined;
+}
+
+function isInfoData(data?: LogStructuredData): data is InfoData {
+  return data !== undefined && (data as InfoData).command !== undefined;
+}
+
 export class NpmLogReporter implements Reporter {
   readonly groupedEntries = new Map<string, LogEntry[]>();
 
@@ -48,25 +56,32 @@ export class NpmLogReporter implements Reporter {
 
   log(entry: LogEntry) {
     if (this.options.logLevel! >= entry.level) {
-      const isTaskLogEntry =
-        entry.data && entry.data.package && entry.data.task;
-
-      if (isTaskLogEntry && !this.options.grouped) {
+      if (isTaskData(entry.data) && !this.options.grouped) {
         return this.logTaskEntry(
           entry.data!.package!,
           entry.data!.task!,
           entry
         );
-      } else if (isTaskLogEntry && this.options.grouped) {
+      } else if (isTaskData(entry.data) && this.options.grouped) {
         return this.logTaskEntryInGroup(
           entry.data!.package!,
           entry.data!.task!,
           entry
         );
+      } else if (isInfoData(entry.data)) {
+        return this.logInfoEntry(entry);
       } else {
         return this.logGenericEntry(entry);
       }
     }
+  }
+
+  private logInfoEntry(entry: LogEntry) {
+    const infoData = entry.data as InfoData;
+    const logFn = log[LogLevel[entry.level]];
+    const colorFn = colors[LogLevel[entry.level]];
+
+    return logFn("", colorFn(JSON.stringify(infoData, null, 2)));
   }
 
   private logGenericEntry(entry: LogEntry) {
@@ -84,22 +99,21 @@ export class NpmLogReporter implements Reporter {
       : normalize(getTaskLogPrefix(pkg, task), entry.msg);
     const logFn = log[LogLevel[entry.level]];
     const colorFn = colors[LogLevel[entry.level]];
+    const data = entry.data as TaskData;
 
-    if (entry.data && entry.data.status) {
+    if (data.status) {
       const pkgTask = this.options.grouped
         ? `${chalk.magenta(pkg)} ${chalk.cyan(task)}`
         : "";
 
-      switch (entry.data.status) {
+      switch (data.status) {
         case "started":
           return logFn(normalizedArgs.prefix, colorFn(`▶️ start ${pkgTask}`));
 
         case "completed":
           return logFn(
             normalizedArgs.prefix,
-            colorFn(
-              `✔️ done ${pkgTask} - ${formatDuration(entry.data.duration!)}`
-            )
+            colorFn(`✔️ done ${pkgTask} - ${formatDuration(data.duration!)}`)
           );
 
         case "failed":
@@ -108,7 +122,7 @@ export class NpmLogReporter implements Reporter {
         case "skipped":
           return logFn(
             normalizedArgs.prefix,
-            colorFn(`⏭️ skip ${pkgTask} - ${entry.data.hash!}`)
+            colorFn(`⏭️ skip ${pkgTask} - ${data.hash!}`)
           );
       }
     } else {
@@ -125,16 +139,18 @@ export class NpmLogReporter implements Reporter {
     this.groupedEntries.set(taskId, this.groupedEntries.get(taskId) || []);
     this.groupedEntries.get(taskId)?.push(logEntry);
 
+    const data = logEntry.data as TaskData;
+
     if (
-      logEntry.data &&
-      (logEntry.data.status === "completed" ||
-        logEntry.data.status === "failed" ||
-        logEntry.data.status === "skipped")
+      data &&
+      (data.status === "completed" ||
+        data.status === "failed" ||
+        data.status === "skipped")
     ) {
       const entries = this.groupedEntries.get(taskId)!;
 
       for (const entry of entries) {
-        this.logTaskEntry(entry.data?.package!, entry.data?.task!, entry);
+        this.logTaskEntry(data.package!, data.task!, entry);
       }
 
       if (entries.length > 2) {
@@ -157,7 +173,7 @@ export class NpmLogReporter implements Reporter {
       completed: chalk.greenBright,
       failed: chalk.redBright,
       skipped: chalk.gray,
-      started: chalk.gray,
+      started: chalk.redBright,
       pending: chalk.gray,
     };
 
@@ -185,7 +201,11 @@ export class NpmLogReporter implements Reporter {
           "",
           getTaskLogPrefix(npmScriptTask.info.name, npmScriptTask.task),
           colorFn(
-            `${npmScriptTask.status}${
+            `${
+              npmScriptTask.status === "started"
+                ? "started - incomplete"
+                : npmScriptTask.status
+            }${
               npmScriptTask.duration
                 ? `, took ${formatDuration(
                     hrToSeconds(npmScriptTask.duration)

--- a/src/task/NpmScriptTask.ts
+++ b/src/task/NpmScriptTask.ts
@@ -10,6 +10,7 @@ import { TaskLogWritable } from "../logger/TaskLogWritable";
 import { cacheHash, cacheFetch, cachePut } from "../cache/backfill";
 import { RunContext } from "../types/RunContext";
 import { hrToSeconds } from "../logger/reporters/formatDuration";
+import { getNpmCommand } from "./getNpmCommand";
 
 export type NpmScriptTaskStatus =
   | "completed"
@@ -47,8 +48,7 @@ export class NpmScriptTask {
     this.status = "pending";
     this.logger = new TaskLogger(info.name, task);
 
-    const { node, args } = config;
-    this.npmArgs = [...node, "run", task, "--", ...args];
+    this.npmArgs = getNpmCommand(config, task);
   }
 
   onStart() {

--- a/src/task/NpmScriptTask.ts
+++ b/src/task/NpmScriptTask.ts
@@ -182,8 +182,8 @@ export class NpmScriptTask {
       this.onComplete();
     } catch (e) {
       context.measures.failedTask = { pkg: info.name, task };
-      controller.abort();
       this.onFail();
+      controller.abort();
       return false;
     }
 

--- a/src/task/getNpmCommand.ts
+++ b/src/task/getNpmCommand.ts
@@ -1,0 +1,7 @@
+import { Config } from "../types/Config";
+
+export function getNpmCommand(config: Config, task: string) {
+  const { node, args } = config;
+  const extraArgs = args.length > 0 ? ["--", ...args] : [];
+  return [...node, "run", task, ...extraArgs];
+}

--- a/src/task/getPipelinePackages.ts
+++ b/src/task/getPipelinePackages.ts
@@ -1,0 +1,37 @@
+import { Config } from "../types/Config";
+import { filterPackages } from "./filterPackages";
+import { Workspace } from "../types/Workspace";
+import {
+  getScopedPackages,
+  getChangedPackages,
+  getTransitiveProviders,
+} from "workspace-tools";
+export function getPipelinePackages(workspace: Workspace, config: Config) {
+  // Filter packages per --scope and command(s)
+  const { scope, since } = config;
+
+  // If scoped is defined, get scoped packages
+  const hasScopes = Array.isArray(scope) && scope.length > 0;
+  let scopedPackages: string[] | undefined = undefined;
+  if (hasScopes) {
+    scopedPackages = getScopedPackages(scope!, workspace.allPackages);
+    scopedPackages = [
+      ...scopedPackages,
+      ...getTransitiveProviders(scopedPackages, workspace.allPackages),
+    ];
+  }
+
+  const hasSince = typeof since !== "undefined";
+  let changedPackages: string[] | undefined = undefined;
+
+  if (hasSince) {
+    changedPackages = getChangedPackages(workspace.root, since, config.ignore);
+  }
+
+  return filterPackages({
+    allPackages: workspace.allPackages,
+    deps: config.deps,
+    scopedPackages,
+    changedPackages,
+  });
+}

--- a/src/task/parseDepsAndTopoDeps.ts
+++ b/src/task/parseDepsAndTopoDeps.ts
@@ -1,0 +1,10 @@
+export function parseDepsAndTopoDeps(taskDeps: string[]) {
+  const deps = taskDeps.filter((dep) => !dep.startsWith("^"));
+  const topoDeps = taskDeps
+    .filter((dep) => dep.startsWith("^"))
+    .map((dep) => dep.slice(1));
+  return {
+    deps,
+    topoDeps,
+  };
+}

--- a/src/task/taskId.ts
+++ b/src/task/taskId.ts
@@ -1,3 +1,18 @@
+const DELIMITER = "###";
+
 export function getTaskId(pkg: string, task: string) {
-  return `${pkg}###${task}`;
+  return `${pkg}${DELIMITER}${task}`;
+}
+
+export function getPackageAndTask(taskId: string) {
+  const items = taskId.split(DELIMITER);
+
+  if (items.length === 2) {
+    return {
+      package: items[0],
+      task: items[1],
+    };
+  } else {
+    return undefined;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,10 +956,10 @@
     markdown-it-front-matter "^0.2.1"
     postcss "^7.0.32"
 
-"@microsoft/task-scheduler@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.4.0.tgz#f53ca144036c5089ef1806834b1686ed4b6fc535"
-  integrity sha512-mHEYP45l1CJ6TKNkQqzJPM8UAVQcZkWJybIXIy4QfPAyt77/XvEkrxlYiuvaO4uLkW0a/E3juFYwcbgsZ9Xtww==
+"@microsoft/task-scheduler@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.5.0.tgz#312c8c352e03f0e0d1d420abb57956be07670e17"
+  integrity sha512-VM+GdP80v5TIlLMkXxlZ+KFi907C6U40HoutTd5durW+7FlnZjCAGK59JA2IkNaLjqnHE0ZwbdrMbm1YLObBUw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Fixes #61

adds this:

```
$ lage info build
``` 

Inject info as the first command to get a list of package task graph info. Can be mixed with `--reporter json` to get this in a machine friendly format