### PR TITLE
fixed the case to not over build

### DIFF
--- a/change/lage-2020-08-16-08-51-36-overbuild.json
+++ b/change/lage-2020-08-16-08-51-36-overbuild.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixed the case to not over build",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-16T15:51:36.515Z"
+}

--- a/src/task/getPipelinePackages.ts
+++ b/src/task/getPipelinePackages.ts
@@ -4,7 +4,7 @@ import { Workspace } from "../types/Workspace";
 import {
   getScopedPackages,
   getChangedPackages,
-  getTransitiveProviders,
+  //getTransitiveProviders,
 } from "workspace-tools";
 export function getPipelinePackages(workspace: Workspace, config: Config) {
   // Filter packages per --scope and command(s)
@@ -15,10 +15,6 @@ export function getPipelinePackages(workspace: Workspace, config: Config) {
   let scopedPackages: string[] | undefined = undefined;
   if (hasScopes) {
     scopedPackages = getScopedPackages(scope!, workspace.allPackages);
-    scopedPackages = [
-      ...scopedPackages,
-      ...getTransitiveProviders(scopedPackages, workspace.allPackages),
-    ];
   }
 
   const hasSince = typeof since !== "undefined";

--- a/src/task/getPipelinePackages.ts
+++ b/src/task/getPipelinePackages.ts
@@ -1,11 +1,7 @@
 import { Config } from "../types/Config";
 import { filterPackages } from "./filterPackages";
 import { Workspace } from "../types/Workspace";
-import {
-  getScopedPackages,
-  getChangedPackages,
-  //getTransitiveProviders,
-} from "workspace-tools";
+import { getScopedPackages, getChangedPackages } from "workspace-tools";
 export function getPipelinePackages(workspace: Workspace, config: Config) {
   // Filter packages per --scope and command(s)
   const { scope, since } = config;


### PR DESCRIPTION
Right now, the scope parser is overreaching what it should have done with regards to transitive providers. It should let the task-scheduler figure out what is needed to satisfy the scope. The only place scope definition should do transitive traversal is in determining consumer packages (by default = true). 