### PR TITLE
Fixing the issue with scope & since getting incorrect filtered package results

### DIFF
--- a/decks/lage-deck.md
+++ b/decks/lage-deck.md
@@ -186,9 +186,12 @@ https://microsoft.github.io/lage/guide/getting-started.html
 # Future
 
 - `lage` is a great solution for a **single machine**, not distributed builds
-- For MSFT is [buildxl](https://github.com/microsoft/buildxl)
-  - lage needs to spit out [dscript](https://github.com/microsoft/BuildXL/blob/master/Documentation/Wiki/DScript/Introduction.md) or json config for buildxl
-- Alternative: also investigate bazel
+- Microsoft solution is [buildxl](https://github.com/microsoft/buildxl)
+  - lage spits out info for `buildxl` now!
+    ```
+    lage info build --reporter json
+    ```
+- Another popular distributed build solution: bazel
   - lage can potentially spit out WORKSPACE & BUILD
 
 ---

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "git-url-parse": "^11.1.2",
     "npmlog": "^4.1.2",
     "p-profiler": "^0.1.2",
-    "workspace-tools": "^0.9.1",
+    "workspace-tools": "^0.9.3",
     "yargs-parser": "^18.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9935,10 +9935,10 @@ workspace-tools@^0.9.0:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
-workspace-tools@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.1.tgz#86d8d9affbb29ee0ded94a1eed2165c5bb206dbb"
-  integrity sha512-yVYslHnDGr1b13ldBUly23W+FUxt4f7s/ovWZThw3YNPW3tcvJ9jDC5UYEWAqRXRbLXOMYFHRgQ1S1Iom/Ze6Q==
+workspace-tools@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.3.tgz#96f3b6c4acf579d2ddd2a5ece7ef1e799ab0b44b"
+  integrity sha512-73K1r42Uzp/mVcHRA+Nh7iG56Bv+e675SoxlNfl1Nko9m5O2DjHSnLzna2MLwNGr0JE8GX/sQUJkg8NSRtw/Sg==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"


### PR DESCRIPTION
This will allow a sensible way of doing scoping a subgraph of packages while targeting some changed packages.

Previously, the scope was done with transitive providers, but this resulted in too many scripts being run when submitted to task-scheduler. We need to be more accurate in the graph understanding when dealing with scope + since.