### PR TITLE
RepoWideChanges setting replacing the environment glob - delineate the two concepts

### DIFF
--- a/change/lage-2020-08-19-17-38-28-repowide-2.json
+++ b/change/lage-2020-08-19-17-38-28-repowide-2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Make sure repowidechanges setting is separate from cache hash calculation",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T00:38:28.058Z"
+}

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -21,8 +21,7 @@ export async function cacheHash(
   );
   const name = info.name;
   const hashKey = salt(
-    config.environmentGlob ||
-      config.cacheOptions.environmentGlob || ["lage.config.js"],
+    config.cacheOptions.environmentGlob || ["lage.config.js"],
     `${info.name}|${task}|${JSON.stringify(config.args)}`,
     root
   );

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -60,7 +60,7 @@ export function getConfig(cwd: string): Config {
     since: parsedArgs.since || undefined,
     verbose: parsedArgs.verbose,
     only: false,
-    environmentGlob: configResults?.config.environmentGlob || [
+    repoWideChanges: configResults?.config.repoWideChanges || [
       "lage.config.js",
       "package-lock.json",
       "yarn.lock",

--- a/src/task/getPipelinePackages.ts
+++ b/src/task/getPipelinePackages.ts
@@ -6,7 +6,7 @@ import { getChanges } from "../git";
 import * as fg from "fast-glob";
 
 export function getPipelinePackages(workspace: Workspace, config: Config) {
-  const { scope, since, environmentGlob } = config;
+  const { scope, since, repoWideChanges } = config;
 
   // If scoped is defined, get scoped packages
   const hasScopes = Array.isArray(scope) && scope.length > 0;
@@ -19,7 +19,7 @@ export function getPipelinePackages(workspace: Workspace, config: Config) {
   let changedPackages: string[] | undefined = undefined;
 
   // Be specific with the changed packages only if no repo-wide changes occurred
-  if (hasSince && !hasRepoChanged(since, workspace.root, environmentGlob)) {
+  if (hasSince && !hasRepoChanged(since, workspace.root, repoWideChanges)) {
     changedPackages = getChangedPackages(workspace.root, since, config.ignore);
   }
 

--- a/src/types/CacheOptions.ts
+++ b/src/types/CacheOptions.ts
@@ -1,6 +1,5 @@
 import { Config as BackfillCacheOptions } from "backfill-config";
 
 export type CacheOptions = BackfillCacheOptions & {
-  /** @deprecated please use the environmentGlob at the root level as it is now shared with lage itself */
   environmentGlob: string[];
 };

--- a/src/types/ConfigOptions.ts
+++ b/src/types/ConfigOptions.ts
@@ -24,15 +24,15 @@ export interface ConfigOptions {
   /** Backfill cache options */
   cacheOptions: CacheOptions;
 
-  /** Which files to ignore when calculating scopes */
+  /** Which files to ignore when calculating scopes with --since */
   ignore: string[];
+
+  /** disables --since flag when any of this list of files changed */
+  repoWideChanges: string[];
 
   /** Which NPM Client to use when running npm lifecycle scripts */
   npmClient: "npm" | "yarn" | "pnpm";
 
   /** Optional priority to set on tasks in a package to make the scheduler give priority to tasks on the critical path for high priority tasks */
   priorities: Priority[];
-
-  /** A list of files that if changed will have a repo wide impact, forces the scope to be everything */
-  environmentGlob: string[];
 }


### PR DESCRIPTION
We should optimize cache hashing separately from calculating the --since packages.