### PR TITLE
adding the --to arg so it's less confusing!

### DIFF
--- a/change/lage-2020-09-14-18-20-28-to-arg.json
+++ b/change/lage-2020-09-14-18-20-28-to-arg.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding cli options",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T01:20:28.436Z"
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -168,6 +168,19 @@ have changed. There is an assumption of all the input files for a package exist
 inside their respective package folders.
 
   
+#### to
+_type: string[]_
+
+Scopes a list of packages, and not built their dependents (consuming packages).
+This implies `--scope` and `--no-deps`.
+
+Just like the `--scope` argument, you can specify multiple packages like this:
+
+```
+lage build --to foo --to bar
+```
+
+  
 #### verbose
 _type: boolean_
 

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -35,7 +35,7 @@ Backfill cache options
 #### ignore
 _type: string[]_
 
-Which files to ignore when calculating scopes
+Which files to ignore when calculating scopes with --since
   
 #### npmClient
 _type: "npm" | "yarn" | "pnpm"_
@@ -62,6 +62,11 @@ Example:
 _type: [Priority](#Priority)[]_
 
 Optional priority to set on tasks in a package to make the scheduler give priority to tasks on the critical path for high priority tasks
+  
+#### repoWideChanges
+_type: string[]_
+
+disables --since flag when any of this list of files changed
   
 ### Pipeline
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -58,6 +58,7 @@ export function getPassThroughArgs(args: { [key: string]: string | string[] }) {
     "profile",
     "grouped",
     "reporter",
+    "to",
     "_",
   ];
 
@@ -76,7 +77,7 @@ export function getPassThroughArgs(args: { [key: string]: string | string[] }) {
 
 export function parseArgs() {
   return yargsParser(process.argv.slice(2), {
-    array: ["scope", "node", "ignore"],
+    array: ["scope", "node", "ignore", "to"],
     configuration: {
       "populate--": true,
       "strip-dashed": true,

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -30,12 +30,20 @@ export function getConfig(cwd: string): Config {
   const command = parsedArgs._;
 
   // deps should be default true, unless exclusively turned off with '--no-deps' or from config file with "deps: false"
-  const deps =
+  let deps =
     parsedArgs.deps === false
       ? false
       : configResults?.config.deps === false
       ? false
       : true;
+
+  let scope = parsedArgs.scope || configResults?.config.scope || [];
+
+  // the --to arg means that we will not build any of the dependents and limit the scope
+  if (parsedArgs.to) {
+    scope = scope.concat(parsedArgs.to);
+    deps = false;
+  }
 
   return {
     reporter: parsedArgs.reporter || "npmLog",
@@ -56,7 +64,7 @@ export function getConfig(cwd: string): Config {
     pipeline: configResults?.config.pipeline || {},
     priorities: configResults?.config.priorities || [],
     profile: parsedArgs.profile,
-    scope: parsedArgs.scope || configResults?.config.scope || [],
+    scope,
     since: parsedArgs.since || undefined,
     verbose: parsedArgs.verbose,
     only: false,

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -76,5 +76,6 @@ export function getConfig(cwd: string): Config {
       "lerna.json",
       "rush.json",
     ],
+    to: parsedArgs.to || [],
   };
 }

--- a/src/types/CliOptions.ts
+++ b/src/types/CliOptions.ts
@@ -35,6 +35,18 @@ export interface CliOptions {
   scope: string[];
 
   /**
+   * Scopes a list of packages, and not built their dependents (consuming packages).
+   * This implies `--scope` and `--no-deps`.
+   *
+   * Just like the `--scope` argument, you can specify multiple packages like this:
+   *
+   * ```
+   * lage build --to foo --to bar
+   * ```
+   */
+  to: string[];
+
+  /**
    * calculate which packages are in scope based on changed packages since a mergebase
    *
    * This uses the `git diff ${target_branch}...` mechanism to identify which packages


### PR DESCRIPTION
By default we build everything (dependents), but it is nice to have a convenience arg that will let you scope and specify no-deps at the same time!