### PR TITLE
Include full stacks with error messages

### DIFF
--- a/change/lage-2020-10-12-11-45-36-log.json
+++ b/change/lage-2020-10-12-11-45-36-log.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Include full stacks with error messages",
+  "packageName": "lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T18:45:36.449Z"
+}

--- a/src/command/run.ts
+++ b/src/command/run.ts
@@ -33,7 +33,7 @@ export async function run(cwd: string, config: Config, reporters: Reporter[]) {
   try {
     await runTasks({ graph, workspace, context, config });
   } catch (e) {
-    logger.error("runTasks: " + e);
+    logger.error("runTasks: " + (e.stack || e.message || e));
   }
 
   if (config.profile) {


### PR DESCRIPTION
If there's an error running a task, log the whole stack not just the message.