### PR TITLE
Use getWorkspaceRoot to determine where the root of the Lage project is.

### DIFF
--- a/change/lage-2020-10-19-09-03-25-master.json
+++ b/change/lage-2020-10-19-09-03-25-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Use getWorkspaceRoot to determine where the root of the Lage project is.",
+  "packageName": "lage",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T16:03:25.559Z"
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "git-url-parse": "^11.1.2",
     "npmlog": "^4.1.2",
     "p-profiler": "^0.1.2",
-    "workspace-tools": "^0.9.8",
+    "workspace-tools": "^0.10.0",
     "yargs-parser": "^18.1.3"
   },
   "devDependencies": {

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -1,6 +1,6 @@
 import { Config } from "../types/Config";
 import { cosmiconfigSync } from "cosmiconfig";
-import { findGitRoot } from "workspace-tools";
+import { getWorkspaceRoot } from "workspace-tools";
 import {
   parseArgs,
   arrifyArgs,
@@ -11,9 +11,9 @@ import os from "os";
 
 export function getConfig(cwd: string): Config {
   // Verify presence of git
-  const root = findGitRoot(cwd);
+  const root = getWorkspaceRoot(cwd);
   if (!root) {
-    throw new Error("This must be called inside a git-controlled repo");
+    throw new Error("This must be called inside a codebase that is part of a JavaScript workspace.");
   }
 
   // Search for lage.config.js file

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import { findGitRoot } from "workspace-tools";
+import { getWorkspaceRoot } from "workspace-tools";
 import gitUrlParse from "git-url-parse";
 
 /**
@@ -350,7 +350,7 @@ export function getDefaultRemote(cwd: string) {
 
   try {
     packageJson = JSON.parse(
-      fs.readFileSync(path.join(findGitRoot(cwd)!, "package.json")).toString()
+      fs.readFileSync(path.join(getWorkspaceRoot(cwd)!, "package.json")).toString()
     );
   } catch (e) {
     console.log("failed to read package.json");

--- a/src/workspace/getWorkspace.ts
+++ b/src/workspace/getWorkspace.ts
@@ -1,7 +1,7 @@
 import { Workspace } from "../types/Workspace";
 import {
   getChangedPackages,
-  findGitRoot,
+  getWorkspaceRoot,
   getPackageInfos,
 } from "workspace-tools";
 import { Config } from "../types/Config";
@@ -11,9 +11,9 @@ export function getWorkspace(
   cwd: string,
   config: Pick<Config, "since" | "ignore" | "npmClient">
 ): Workspace {
-  const root = findGitRoot(cwd)!;
+  const root = getWorkspaceRoot(cwd);
   if (!root) {
-    throw new Error("This must be called inside a git-controlled repo");
+    throw new Error("This must be called inside a codebase that is part of a JavaScript workspace.");
   }
 
   const { since, ignore, npmClient } = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,16 +2427,7 @@ binjumper@^0.1.0:
   resolved "https://registry.yarnpkg.com/binjumper/-/binjumper-0.1.2.tgz#a82beb255c51ee631330f69897bc191169905023"
   integrity sha512-zZrQaKsC0h5HflYWM9G9Jisx+XNPs9WU3yMizdcYL91Aw1NNaLze3tKjyNRZPorQLBNDvkavZjB/wxXUZe/8gA==
 
-bl@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
-  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
-
-bl@^4.0.3:
+bl@^4.0.1, bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
   integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
@@ -12094,10 +12085,10 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workspace-tools@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.0.tgz#5ce0680c9bf38544d1f6261d6b0e2834347e676e"
-  integrity sha512-ji9mOpdxyJ1LBnCzfFzAuLw7x0OuqQso/eJFpeyR/W0nXRK3Uhmn0dAaqrlDlrUEW5nOT5nSz0MpsaCmeSyiUA==
+workspace-tools@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.10.0.tgz#82b4a0ec17350cb27df51c3f8b0c2d1e394b3d26"
+  integrity sha512-6rwbc4H6bSn74RfSwzSButqx602rzTTtxA9m+9RSzMpuXrFmNHfJGppn0Pi5J+LgP56ZA5VwfP7/nHN1fS8frg==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"
@@ -12112,10 +12103,10 @@ workspace-tools@^0.9.0:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
-workspace-tools@^0.9.8:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.8.tgz#fe53254bf56da289a8e9a6d9e8a0647f69bd964e"
-  integrity sha512-Vbyuc8fRLnbkE/n7Qb8wKEwexGEujTQamEGNFd/1RmgANCFk1u4FBI2PVoF/Tf32JbbtAlw/JkWtxmemRG4b8g==
+workspace-tools@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.0.tgz#5ce0680c9bf38544d1f6261d6b0e2834347e676e"
+  integrity sha512-ji9mOpdxyJ1LBnCzfFzAuLw7x0OuqQso/eJFpeyR/W0nXRK3Uhmn0dAaqrlDlrUEW5nOT5nSz0MpsaCmeSyiUA==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"


### PR DESCRIPTION
Before Lage assumed it was rooted at the root of a git repo. This excluded
projects outside of git repo's or projects in git that had multiple code bases
at various levels.
This change updates Lage to use `getWorkspaceRoot` from [workspace-tools](https://github.com/microsoft/workspace-tools#readme)
instead of `findGitRoot`. It now finds the closest package manager root,
i.e. find the package.json that declares the `workspace` for Yarn, PNpm, Rush...

Closes #80