### PR TITLE
Replaces SIGKILL with SIGTERM and then timesout to SIGKILL

### DIFF
--- a/change/lage-2020-10-19-12-45-09-sigterm.json
+++ b/change/lage-2020-10-19-12-45-09-sigterm.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding a sigterm -> sigkill strategy for killing active processes",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T19:45:09.455Z"
+}


### PR DESCRIPTION
This gives a bit more graceful handling of wrapping a process up when a failed task is detected. Fixes #81 