### PR TITLE
Summary: make error output more prominent

### DIFF
--- a/change/lage-2020-10-19-14-46-30-summary.json
+++ b/change/lage-2020-10-19-14-46-30-summary.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "have the errors appear more prominently",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T21:46:30.311Z"
+}

--- a/src/logger/reporters/NpmLogReporter.ts
+++ b/src/logger/reporters/NpmLogReporter.ts
@@ -179,25 +179,11 @@ export class NpmLogReporter implements Reporter {
 
     log.info("", chalk.cyanBright(`🏗 Summary\n`));
 
-    if (measures.failedTask) {
-      const { pkg, task } = measures.failedTask;
-      const taskId = getTaskId(pkg, task);
-      const taskLogs = tasks.get(taskId)?.logger.getLogs();
-
-      log.error("", `ERROR DETECTED IN ${pkg} ${task}`);
-
-      if (taskLogs) {
-        log.error("", taskLogs?.map((entry) => entry.msg).join("\n"));
-      }
-
-      hr();
-    }
-
     if (tasks.size > 0) {
       for (const npmScriptTask of tasks.values()) {
         const colorFn = statusColorFn[npmScriptTask.status];
 
-        log.info(
+        log.verbose(
           "",
           getTaskLogPrefix(npmScriptTask.info.name, npmScriptTask.task),
           colorFn(
@@ -220,6 +206,20 @@ export class NpmLogReporter implements Reporter {
     }
 
     hr();
+
+    if (measures.failedTask) {
+      const { pkg, task } = measures.failedTask;
+      const taskId = getTaskId(pkg, task);
+      const taskLogs = tasks.get(taskId)?.logger.getLogs();
+
+      log.error("", `ERROR DETECTED IN ${pkg} ${task}`);
+
+      if (taskLogs) {
+        log.error("", taskLogs?.map((entry) => entry.msg).join("\n"));
+      }
+
+      hr();
+    }
 
     log.info(
       "",

--- a/src/logger/reporters/NpmLogReporter.ts
+++ b/src/logger/reporters/NpmLogReporter.ts
@@ -201,6 +201,22 @@ export class NpmLogReporter implements Reporter {
           )
         );
       }
+
+      const successfulTasks = [...tasks.values()].filter(
+        (t) => t.status === "completed"
+      );
+      const skippedTasks = [...tasks.values()].filter(
+        (t) => t.status === "skipped"
+      );
+
+      log.info(
+        "",
+        `[Tasks Count] success: ${successfulTasks.length}, skipped: ${
+          skippedTasks.length
+        }, incomplete: ${tasks.size -
+          successfulTasks.length -
+          skippedTasks.length}`
+      );
     } else {
       log.info("", "Nothing has been run.");
     }


### PR DESCRIPTION
Fixes #86 - moves the error output to the end of the summary