### PR TITLE
Unknown command handling

### DIFF
--- a/change/lage-2020-10-19-16-54-35-unknown.json
+++ b/change/lage-2020-10-19-16-54-35-unknown.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding an ability to deal with unknown commands",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T23:54:35.842Z"
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -59,6 +59,7 @@ export function getPassThroughArgs(args: { [key: string]: string | string[] }) {
     "grouped",
     "reporter",
     "to",
+    "parallel",
     "_",
   ];
 

--- a/src/command/run.ts
+++ b/src/command/run.ts
@@ -9,7 +9,7 @@ import { runTasks } from "../task/taskRunner";
 import { NpmScriptTask } from "../task/NpmScriptTask";
 import { Reporter } from "../logger/reporters/Reporter";
 
-// Create context
+// Run multiple
 export async function run(cwd: string, config: Config, reporters: Reporter[]) {
   const context = createContext(config);
   const workspace = getWorkspace(cwd, config);

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -13,7 +13,9 @@ export function getConfig(cwd: string): Config {
   // Verify presence of git
   const root = getWorkspaceRoot(cwd);
   if (!root) {
-    throw new Error("This must be called inside a codebase that is part of a JavaScript workspace.");
+    throw new Error(
+      "This must be called inside a codebase that is part of a JavaScript workspace."
+    );
   }
 
   // Search for lage.config.js file
@@ -67,6 +69,7 @@ export function getConfig(cwd: string): Config {
     scope,
     since: parsedArgs.since || undefined,
     verbose: parsedArgs.verbose,
+    parallel: parsedArgs.parallel,
     only: false,
     repoWideChanges: configResults?.config.repoWideChanges || [
       "lage.config.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,21 +11,21 @@ import { version } from "./command/version";
 const cwd = process.cwd();
 try {
   const config = getConfig(cwd);
-  const reporters = initReporters(config)
+  const reporters = initReporters(config);
 
-  switch(config.command[0]) {
-    case 'init':
+  switch (config.command[0]) {
+    case "init":
       init(cwd);
       break;
 
-    case 'info':
+    case "info":
       info(cwd, config);
       break;
 
-    case 'version':
+    case "version":
       version();
       break;
-    
+
     default:
       logger.info(`Lage task runner - let's make it`);
       run(cwd, config, reporters);

--- a/src/task/taskRunner.ts
+++ b/src/task/taskRunner.ts
@@ -84,9 +84,11 @@ export async function runTasks(options: {
   }
 
   // Collect unknown commands
-  for (const unknown of config.command.filter(
+  const unknownCommands = config.command.filter(
     (command) => !knownTasks.includes(command)
-  )) {
+  );
+
+  for (const unknown of unknownCommands) {
     unknownTasks.add(unknown);
   }
 

--- a/src/task/taskRunner.ts
+++ b/src/task/taskRunner.ts
@@ -13,9 +13,11 @@ import { NpmScriptTask } from "./NpmScriptTask";
 import { getPipelinePackages } from "./getPipelinePackages";
 import { parsePipelineConfig } from "./parsePipelineConfig";
 
+type PriorityMap = Map<string, Task["priorities"]>;
+
 /** Returns a map that maps task name to the priorities config for that task */
-function getPriorityMap(priorities: Priority[]) {
-  const result = new Map<string, Task["priorities"]>();
+function getPriorityMap(priorities: Priority[]): PriorityMap {
+  const result: PriorityMap = new Map();
 
   priorities.forEach((entry) => {
     const taskPriority = result.get(entry.task) || {};
@@ -48,49 +50,88 @@ export async function runTasks(options: {
   });
 
   const pipelineConfig = parsePipelineConfig(config.pipeline);
+  const knownTasks = Object.keys(pipelineConfig.taskDeps);
+  let unknownTasks = new Set<string>();
 
   // Add in the task deps based on package graph
   for (const [taskName, taskDeps] of Object.entries(pipelineConfig.taskDeps)) {
     const { deps, topoDeps } = taskDeps;
-
     pipeline = pipeline.addTask({
       name: taskName,
       deps,
       topoDeps,
       priorities: priorityMap.get(taskName),
-      run: async (_location, _stdout, _stderr, pkg) => {
-        const info = workspace.allPackages[pkg];
-        const scripts = info.scripts;
-        if (scripts && scripts[taskName]) {
-          const npmTask = new NpmScriptTask(
-            taskName,
-            workspace.root,
-            info,
-            config,
-            context
-          );
-
-          context.tasks.set(getTaskId(info.name, taskName), npmTask);
-
-          return await npmTask.run();
-        }
-        return true;
-      },
+      run: runHandler(workspace, taskName, config, context),
     });
+
+    // take note of any tasks deps that are not defined
+    const unknownTaskDeps = deps
+      .filter((dep) => !knownTasks.includes(dep))
+      .concat(topoDeps.filter((dep) => !knownTasks.includes(dep)));
+    for (const unknown of unknownTaskDeps) {
+      unknownTasks.add(unknown);
+    }
   }
 
   // adding specific package task dependencies
   for (const packageTaskDep of pipelineConfig.packageTaskDeps) {
     const from = getPackageTaskFromId(packageTaskDep[0]);
     const to = getPackageTaskFromId(packageTaskDep[1]);
-    pipeline.addDep(
+    pipeline = pipeline.addDep(
       { package: from[0], task: from[1] },
       { package: to[0], task: to[1] }
     );
+  }
+
+  // Collect unknown commands
+  for (const unknown of config.command.filter(
+    (command) => !knownTasks.includes(command)
+  )) {
+    unknownTasks.add(unknown);
+  }
+
+  // Add all unknown commands to be topoDeps
+  for (const taskName of unknownTasks) {
+    const depConfig = config.parallel
+      ? { deps: [], topoDeps: [] }
+      : { topoDeps: [taskName], deps: [] };
+
+    pipeline = pipeline.addTask({
+      ...depConfig,
+      name: taskName,
+      priorities: priorityMap.get(taskName),
+      run: runHandler(workspace, taskName, config, context),
+    });
   }
 
   await pipeline.go({
     packages: getPipelinePackages(workspace, config),
     tasks: config.command,
   });
+}
+
+function runHandler(
+  workspace: Workspace,
+  taskName: string,
+  config: Config,
+  context: RunContext
+) {
+  return async function(_location, _stdout, _stderr, pkg) {
+    const info = workspace.allPackages[pkg];
+    const scripts = info.scripts;
+    if (scripts && scripts[taskName]) {
+      const npmTask = new NpmScriptTask(
+        taskName,
+        workspace.root,
+        info,
+        config,
+        context
+      );
+
+      context.tasks.set(getTaskId(info.name, taskName), npmTask);
+
+      return await npmTask.run();
+    }
+    return true;
+  };
 }

--- a/src/types/CliOptions.ts
+++ b/src/types/CliOptions.ts
@@ -147,4 +147,9 @@ export interface CliOptions {
    * Example: `lage --grouped`
    */
   grouped: boolean;
+
+  /**
+   * Run a single command in parallel
+   */
+  parallel: boolean;
 }


### PR DESCRIPTION
If lage encounters an unknown command, it'll assume "topological order" unless `--parallel` is specified. This will also work with any commands that are in the "deps" array inside the `pipeline` config as well.

Fixes #90 
Relates to #84 - if the command is undefined from lage.config.js, it will still work if it is defined somewhere in the package.json; we don't truly give anything meaningful until something addresses #84 (another PR)