### PR TITLE
refactor: Create npm script task config

### DIFF
--- a/change/lage-2020-11-11-18-51-42-task-config.json
+++ b/change/lage-2020-11-11-18-51-42-task-config.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "refactor: Create npm script task config",
+  "packageName": "lage",
+  "email": "oliver.kuruma@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-11T17:51:42.175Z"
+}

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -1,19 +1,20 @@
-import { Config } from "../types/Config";
 import { getCacheConfig } from "./cacheConfig";
 import { logger } from "../logger";
 import { PackageInfo } from "workspace-tools";
 import { salt } from "./salt";
 import * as backfill from "backfill/lib/api";
 import path from "path";
+import { CacheOptions } from "../types/CacheOptions";
 
 export async function cacheHash(
   task: string,
   info: PackageInfo,
   root: string,
-  config: Config
+  cacheOptions: CacheOptions,
+  args: any
 ) {
   const packagePath = path.dirname(info.packageJsonPath);
-  const cacheConfig = getCacheConfig(packagePath, config);
+  const cacheConfig = getCacheConfig(packagePath, cacheOptions);
   const backfillLogger = backfill.makeLogger(
     "error",
     process.stdout,
@@ -21,8 +22,8 @@ export async function cacheHash(
   );
   const name = info.name;
   const hashKey = salt(
-    config.cacheOptions.environmentGlob || ["lage.config.js"],
-    `${info.name}|${task}|${JSON.stringify(config.args)}`,
+    cacheOptions.environmentGlob || ["lage.config.js"],
+    `${info.name}|${task}|${JSON.stringify(args)}`,
     root
   );
 
@@ -45,14 +46,14 @@ export async function cacheHash(
 export async function cacheFetch(
   hash: string | null,
   info: PackageInfo,
-  config: Config
+  cacheOptions: CacheOptions
 ) {
   if (!hash) {
     return false;
   }
 
   const packagePath = path.dirname(info.packageJsonPath);
-  const cacheConfig = getCacheConfig(packagePath, config);
+  const cacheConfig = getCacheConfig(packagePath, cacheOptions);
   const backfillLogger = backfill.makeLogger(
     "error",
     process.stdout,
@@ -71,14 +72,14 @@ export async function cacheFetch(
 export async function cachePut(
   hash: string | null,
   info: PackageInfo,
-  config: Config
+  cacheOptions: CacheOptions
 ) {
   if (!hash) {
     return;
   }
 
   const packagePath = path.dirname(info.packageJsonPath);
-  const cacheConfig = getCacheConfig(packagePath, config);
+  const cacheConfig = getCacheConfig(packagePath, cacheOptions);
   const backfillLogger = backfill.makeLogger(
     "warn",
     process.stdout,

--- a/src/cache/cacheConfig.ts
+++ b/src/cache/cacheConfig.ts
@@ -1,8 +1,8 @@
 import { getEnvConfig, createDefaultConfig } from "backfill-config";
 import { makeLogger } from "backfill-logger";
-import { Config } from "../types/Config";
+import { CacheOptions } from "../types/CacheOptions";
 
-export function getCacheConfig(cwd: string, config: Config) {
+export function getCacheConfig(cwd: string, cacheOptions: CacheOptions) {
   const defaultCacheConfig = createDefaultConfig(cwd);
 
   // in lage, default mode is to CACHE locally
@@ -12,7 +12,7 @@ export function getCacheConfig(cwd: string, config: Config) {
   const envConfig = getEnvConfig(logger);
   return {
     ...defaultCacheConfig,
-    ...config.cacheOptions,
+    ...cacheOptions,
     ...envConfig,
   };
 }

--- a/src/command/info.ts
+++ b/src/command/info.ts
@@ -123,7 +123,10 @@ function createPackageTaskInfo(
   if (scripts && scripts[taskName]) {
     return {
       id: taskId,
-      command: [config.npmClient, ...getNpmCommand(config, taskName)],
+      command: [
+        config.npmClient,
+        ...getNpmCommand(config.node, config.args, taskName),
+      ],
       dependencies: [],
       workingDirectory: path
         .relative(

--- a/src/task/NpmScriptTask.ts
+++ b/src/task/NpmScriptTask.ts
@@ -102,10 +102,16 @@ export class NpmScriptTask {
     const { task, info, root, config } = this;
 
     if (config.cache) {
-      hash = await cacheHash(task, info, root, config);
+      hash = await cacheHash(
+        task,
+        info,
+        root,
+        config.cacheOptions,
+        config.args
+      );
 
       if (hash && !config.resetCache) {
-        cacheHit = await cacheFetch(hash, info, config);
+        cacheHit = await cacheFetch(hash, info, config.cacheOptions);
       }
     }
 
@@ -115,7 +121,7 @@ export class NpmScriptTask {
   async saveCache(hash: string | null) {
     const { logger, info, config } = this;
     logger.verbose(`hash put ${hash}`);
-    await cachePut(hash, info, config);
+    await cachePut(hash, info, config.cacheOptions);
   }
 
   runScript() {

--- a/src/task/NpmScriptTask.ts
+++ b/src/task/NpmScriptTask.ts
@@ -58,7 +58,7 @@ export class NpmScriptTask {
     this.status = "pending";
     this.logger = new TaskLogger(info.name, task);
 
-    this.npmArgs = getNpmCommand(config, task);
+    this.npmArgs = getNpmCommand(config.node, config.args, task);
   }
 
   onStart() {

--- a/src/task/getNpmCommand.ts
+++ b/src/task/getNpmCommand.ts
@@ -1,7 +1,9 @@
-import { Config } from "../types/Config";
-
-export function getNpmCommand(config: Config, task: string) {
-  const { node, args } = config;
-  const extraArgs = args.length > 0 ? ["--", ...args] : [];
-  return [...node, "run", task, ...extraArgs];
+export function getNpmCommand(
+  nodeArgs: string[],
+  passThroughArgs: string[],
+  task: string
+) {
+  const extraArgs =
+    passThroughArgs.length > 0 ? ["--", ...passThroughArgs] : [];
+  return [...nodeArgs, "run", task, ...extraArgs];
 }

--- a/src/task/taskRunner.ts
+++ b/src/task/taskRunner.ts
@@ -9,7 +9,7 @@ import {
 import { Config } from "../types/Config";
 import { Workspace } from "../types/Workspace";
 import { Priority } from "../types/Priority";
-import { NpmScriptTask } from "./NpmScriptTask";
+import { NpmScriptTask, NpmScriptTaskConfig } from "./NpmScriptTask";
 import { getPipelinePackages } from "./getPipelinePackages";
 import { parsePipelineConfig } from "./parsePipelineConfig";
 
@@ -62,7 +62,7 @@ export async function runTasks(options: {
       deps,
       topoDeps,
       priorities: priorityMap.get(taskName),
-      run: runHandler(workspace, taskName, config, context),
+      run: runHandler(workspace, taskName, generateTaskConfig(config), context),
     });
 
     // take note of any tasks deps that are not defined
@@ -103,7 +103,7 @@ export async function runTasks(options: {
       ...depConfig,
       name: taskName,
       priorities: priorityMap.get(taskName),
-      run: runHandler(workspace, taskName, config, context),
+      run: runHandler(workspace, taskName, generateTaskConfig(config), context),
     });
   }
 
@@ -116,7 +116,7 @@ export async function runTasks(options: {
 function runHandler(
   workspace: Workspace,
   taskName: string,
-  config: Config,
+  config: NpmScriptTaskConfig,
   context: RunContext
 ) {
   return async function(_location, _stdout, _stderr, pkg) {
@@ -138,3 +138,15 @@ function runHandler(
     return true;
   };
 }
+
+const generateTaskConfig = (config: Config): NpmScriptTaskConfig => ({
+  cache: config.cache,
+  continueOnError: config.continue,
+  safeExit: config.safeExit,
+  npmClient: config.npmClient,
+  cacheOptions: config.cacheOptions,
+  reporter: config.reporter,
+  resetCache: config.resetCache,
+  nodeArgs: config.node,
+  passThroughArgs: config.args,
+});

--- a/src/types/ConfigOptions.ts
+++ b/src/types/ConfigOptions.ts
@@ -2,6 +2,8 @@ import { CacheOptions } from "./CacheOptions";
 import { Priority } from "./Priority";
 import { Pipeline } from "./Pipeline";
 
+export type NpmClient = "npm" | "yarn" | "pnpm";
+
 export interface ConfigOptions {
   /**
    * Defines the task pipeline, prefix with "^" character to denote a topological dependency
@@ -31,7 +33,7 @@ export interface ConfigOptions {
   repoWideChanges: string[];
 
   /** Which NPM Client to use when running npm lifecycle scripts */
-  npmClient: "npm" | "yarn" | "pnpm";
+  npmClient: NpmClient;
 
   /** Optional priority to set on tasks in a package to make the scheduler give priority to tasks on the critical path for high priority tasks */
   priorities: Priority[];


### PR DESCRIPTION
Resolves #107 

Create an interface `NpmScriptTaskConfig` which contains just the config that is required by the `NpmScriptTask`