### PR TITLE
feat: Add --include-dependencies option

### DIFF
--- a/change/lage-2020-11-13-08-18-01-include-dependencies.json
+++ b/change/lage-2020-11-13-08-18-01-include-dependencies.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "feat: Add --include-dependencies option",
+  "packageName": "lage",
+  "email": "oliver.kuruma@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-13T07:18:01.581Z"
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -90,7 +90,11 @@ Certain files might need to be changed during the preparation of a build
 job. In that situation, `lage` can ignore those files when calculating what
 has changed with the `--since` flag.
 
-  
+#### include-dependencies
+_type: boolean_
+
+Include all transitive dependencies when running a command regardless of --scope, or --since.
+
 #### node
 _type: string[]_
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -93,7 +93,13 @@ has changed with the `--since` flag.
 #### include-dependencies
 _type: boolean_
 
-Include all transitive dependencies when running a command regardless of --scope, or --since.
+Include all transitive dependencies when running a command(s).
+This is useful for situations where you want to "set up" a package that relies on other packages being set up.
+
+```
+lage setup --scope my-package --include-dependencies
+# my-package and all of its dependencies will be setup
+```
 
 #### node
 _type: string[]_

--- a/src/args.ts
+++ b/src/args.ts
@@ -62,6 +62,7 @@ export function getPassThroughArgs(args: { [key: string]: string | string[] }) {
     "parallel",
     "continue",
     "safeExit",
+    "includeDependencies",
     "_",
   ];
 

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -82,5 +82,6 @@ export function getConfig(cwd: string): Config {
     to: parsedArgs.to || [],
     continue: parsedArgs.continue || configResults?.config.continue,
     safeExit: parsedArgs.safeExit,
+    includeDependencies: parsedArgs.includeDependencies,
   };
 }

--- a/src/task/filterPackages.ts
+++ b/src/task/filterPackages.ts
@@ -1,4 +1,8 @@
-import { getTransitiveConsumers, PackageInfos } from "workspace-tools";
+import {
+  getTransitiveConsumers,
+  getTransitiveDependencies,
+  PackageInfos,
+} from "workspace-tools";
 import { logger } from "../logger";
 
 /**
@@ -8,10 +12,17 @@ import { logger } from "../logger";
 export function filterPackages(options: {
   allPackages: PackageInfos;
   deps: boolean;
+  includeDependencies: boolean;
   scopedPackages: string[] | undefined;
   changedPackages: string[] | undefined;
 }) {
-  const { scopedPackages, changedPackages, allPackages, deps } = options;
+  const {
+    scopedPackages,
+    changedPackages,
+    allPackages,
+    deps,
+    includeDependencies,
+  } = options;
 
   let filtered: string[] = [];
 
@@ -46,6 +57,13 @@ export function filterPackages(options: {
   if (deps) {
     logger.verbose(`filterPackages running with dependents`);
     filtered = filtered.concat(getTransitiveConsumers(filtered, allPackages));
+  }
+
+  // adds dependencies of all filtered package thus far
+  if (includeDependencies) {
+    filtered = filtered.concat(
+      getTransitiveDependencies(filtered, allPackages)
+    );
   }
 
   const unique = new Set(filtered);

--- a/src/task/getPipelinePackages.ts
+++ b/src/task/getPipelinePackages.ts
@@ -6,7 +6,7 @@ import { getChanges } from "../git";
 import * as fg from "fast-glob";
 
 export function getPipelinePackages(workspace: Workspace, config: Config) {
-  const { scope, since, repoWideChanges } = config;
+  const { scope, since, repoWideChanges, includeDependencies } = config;
 
   // If scoped is defined, get scoped packages
   const hasScopes = Array.isArray(scope) && scope.length > 0;
@@ -28,6 +28,7 @@ export function getPipelinePackages(workspace: Workspace, config: Config) {
     deps: config.deps,
     scopedPackages,
     changedPackages,
+    includeDependencies,
   });
 }
 

--- a/src/types/ConfigOptions.ts
+++ b/src/types/ConfigOptions.ts
@@ -40,4 +40,9 @@ export interface ConfigOptions {
    * Should we try to run the task graph as much as we can even though one task has failed
    */
   continue: boolean;
+
+  /**
+   * Run the tasks for the dependencies of scoped tasks
+   */
+  includeDependencies: boolean;
 }

--- a/tests/unit/filterPackages.test.ts
+++ b/tests/unit/filterPackages.test.ts
@@ -16,6 +16,7 @@ describe("filterPackages", () => {
       deps: false,
       changedPackages,
       scopedPackages,
+      includeDependencies: false,
     });
 
     expect(filtered.length).toBe(0);
@@ -35,6 +36,7 @@ describe("filterPackages", () => {
       deps: false,
       changedPackages,
       scopedPackages,
+      includeDependencies: false,
     });
 
     expect(filtered).toContain("foo1");
@@ -56,6 +58,7 @@ describe("filterPackages", () => {
       deps: false,
       changedPackages,
       scopedPackages,
+      includeDependencies: false,
     });
 
     expect(filtered).not.toContain("foo1");

--- a/tests/unit/filterPackages.test.ts
+++ b/tests/unit/filterPackages.test.ts
@@ -81,11 +81,37 @@ describe("filterPackages", () => {
       deps: true,
       changedPackages,
       scopedPackages,
+      includeDependencies: false,
     });
 
     expect(filtered).toContain("foo1");
     expect(filtered).not.toContain("foo2");
     expect(filtered).toContain("bar");
+  });
+
+  it("scoped will include transitive dependencies when includeDependencies is enabled", () => {
+    const allPackages: PackageInfos = {
+      foo1: stubPackage("foo1", ["bar"]),
+      foo2: stubPackage("foo2"),
+      bar: stubPackage("bar", ["baz"]),
+      baz: stubPackage("baz"),
+    };
+
+    const scopedPackages = ["foo1"];
+    const changedPackages = undefined;
+
+    const filtered = filterPackages({
+      allPackages,
+      deps: true,
+      changedPackages,
+      scopedPackages,
+      includeDependencies: true,
+    });
+
+    expect(filtered).toContain("foo1");
+    expect(filtered).not.toContain("foo2");
+    expect(filtered).toContain("bar");
+    expect(filtered).toContain("baz");
   });
 });
 


### PR DESCRIPTION
Add an option to run tasks for transitive dependencies
regardless of --scope or --since