### PR TITLE
fix: Use Node version for the hash salt

### DIFF
--- a/change/lage-2021-01-05-11-35-41-node-version-salt.json
+++ b/change/lage-2021-01-05-11-35-41-node-version-salt.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: Use Node version for the hash salt",
+  "packageName": "lage",
+  "email": "oliver.kuruma@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-05T10:35:41.447Z"
+}

--- a/src/cache/salt.ts
+++ b/src/cache/salt.ts
@@ -3,6 +3,7 @@ import * as crypto from "crypto";
 import * as fg from "fast-glob";
 import * as fs from "fs";
 import os from "os";
+import process from "process";
 
 let envHash: string[];
 
@@ -14,6 +15,7 @@ export function salt(
   return hashStrings([
     ...getEnvHash(environmentGlobFiles, repoRoot),
     os.platform(),
+    process.version,
     command,
   ]);
 }


### PR DESCRIPTION
The cache should not be shared across different versions of node.
Adding the node version ensures that, in the case of a cache hit, it was created with the same node version.