### PR TITLE
Adds a --cache-key option (also can be placed inside cacheOptions)

### DIFF
--- a/change/lage-2021-02-05-12-08-45-cache-key.json
+++ b/change/lage-2021-02-05-12-08-45-cache-key.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding a cache-key option to allow different custom build env affect cache hash manually",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-05T20:08:45.016Z"
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -67,6 +67,7 @@ export function getPassThroughArgs(
     "safeExit",
     "includeDependencies",
     "logLevel",
+    "cacheKey",
     "_",
   ];
 
@@ -94,6 +95,7 @@ export function parseArgs() {
       "populate--": true,
       "strip-dashed": true,
     },
+    string: ["cacheKey"],
   });
 }
 

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -24,7 +24,8 @@ export async function cacheHash(
   const hashKey = salt(
     cacheOptions.environmentGlob || ["lage.config.js"],
     `${info.name}|${task}|${JSON.stringify(args)}`,
-    root
+    root,
+    cacheOptions.cacheKey
   );
 
   backfillLogger.setName(name);

--- a/src/cache/salt.ts
+++ b/src/cache/salt.ts
@@ -10,13 +10,15 @@ let envHash: string[];
 export function salt(
   environmentGlobFiles: string[],
   command: string,
-  repoRoot: string
+  repoRoot: string,
+  customKey: string = ""
 ): string {
   return hashStrings([
     ...getEnvHash(environmentGlobFiles, repoRoot),
     os.platform(),
     process.version,
     command,
+    customKey,
   ]);
 }
 

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -53,7 +53,11 @@ export function getConfig(cwd: string): Config {
     args: getPassThroughArgs(command, parsedArgs),
     cache: parsedArgs.cache === false ? false : true,
     resetCache: parsedArgs.resetCache || false,
-    cacheOptions: configResults?.config.cacheOptions || {},
+    cacheOptions:
+      {
+        ...configResults?.config.cacheOptions,
+        ...(parsedArgs.cacheKey && { cacheKey: parsedArgs.cacheKey }),
+      } || {},
     command,
     concurrency:
       parsedArgs.concurrency ||
@@ -86,6 +90,6 @@ export function getConfig(cwd: string): Config {
     clear: parsedArgs.clear || false,
     prune: parsedArgs.prune,
     logLevel: parsedArgs.logLevel,
-    loggerOptions: configResults?.config.loggerOptions || {}
+    loggerOptions: configResults?.config.loggerOptions || {},
   };
 }

--- a/src/types/CacheOptions.ts
+++ b/src/types/CacheOptions.ts
@@ -2,4 +2,5 @@ import { Config as BackfillCacheOptions } from "backfill-config";
 
 export type CacheOptions = BackfillCacheOptions & {
   environmentGlob: string[];
+  cacheKey: string;
 };

--- a/src/types/CliOptions.ts
+++ b/src/types/CliOptions.ts
@@ -179,4 +179,11 @@ export interface CliOptions {
    * Specifying "verbose" is equivalent to running with the `--verbose` argument.
    */
   logLevel: string;
+
+  /**
+   * Specify a custom cache key salt with this option: --cache-key xyz_build_environemnt
+   */
+  cacheOptions: {
+    cacheKey: string;
+  };
 }


### PR DESCRIPTION
Fixes #126 - allows a runtime option to use a different cache if wanted (build env, env vars, whatever was needed at the time)