### PR TITLE
Make sure lage reports & fails on file system (fs) errors when writing profile log

### DIFF
--- a/change/lage-fc74ea21-6c88-4e73-8075-8462ba3eea51.json
+++ b/change/lage-fc74ea21-6c88-4e73-8075-8462ba3eea51.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: handle 'fs' errors while saving profile: forcing lage to fail",
+  "packageName": "lage",
+  "email": "nickykalu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/command/run.ts
+++ b/src/command/run.ts
@@ -38,8 +38,13 @@ export async function run(cwd: string, config: Config, reporters: Reporter[]) {
   }
 
   if (config.profile) {
-    const profileFile = profiler.output();
-    logger.info(`runTasks: Profile saved to ${profileFile}`);
+    try {
+      const profileFile = profiler.output();
+      logger.info(`runTasks: Profile saved to ${profileFile}`);
+    } catch (e) {
+        logger.error(`An error occured while trying to write profile: ${e.message}`);
+        process.exitCode = 1;
+    }
   }
 
   if (!aborted) {


### PR DESCRIPTION
If the profile output name in lage already exists as a folder, lage will fail and it won't report the state of **previously run tasks correctly**, and will even exit with success. This can result to CI & CD pipelines to accept watermelon/failed builds.

- Error Sample

![error](https://user-images.githubusercontent.com/6636950/127354097-a0fee1f9-3cf6-446e-b1de-037545447d4d.png)

- Screenshot with fix

![handled](https://user-images.githubusercontent.com/6636950/127354111-573642b3-e354-447f-ae2b-19ebb9a71c90.png)
