### PR TITLE
Fix exit code - when a npm script task fails, we found that --safe-exit would cause it to not give the correct exit code

### DIFF
--- a/change/lage-d4b2618c-a4a0-44e9-8436-34a0f80bdb25.json
+++ b/change/lage-d4b2618c-a4a0-44e9-8436-34a0f80bdb25.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes the process.exitCode = 1 to happen before any other errors",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/cosmiconfig": "^6.0.0",
     "@types/execa": "^2.0.0",
     "@types/git-url-parse": "^9.0.0",
-    "@types/jasmine": "^3.5.10",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.2",
     "@types/npmlog": "^4.1.2",

--- a/src/command/run.ts
+++ b/src/command/run.ts
@@ -10,9 +10,9 @@ import { Pipeline } from "../task/Pipeline";
 
 /**
  * Prepares and runs a pipeline
- * @param cwd 
- * @param config 
- * @param reporters 
+ * @param cwd
+ * @param config
+ * @param reporters
  */
 export async function run(cwd: string, config: Config, reporters: Reporter[]) {
   const context = createContext(config);
@@ -35,8 +35,15 @@ export async function run(cwd: string, config: Config, reporters: Reporter[]) {
     const pipeline = new Pipeline(workspace, config);
     await pipeline.run(context);
   } catch (e) {
-    logger.error("runTasks: " + (e.stack || e.message || e));
     process.exitCode = 1;
+
+    if (e && e.stack) {
+      logger.error("runTasks: " + e.stack);
+    } else if (e && e.message) {
+      logger.error("runTasks: " + e.message);
+    } else if (e) {
+      logger.error("runTasks: " + e);
+    }
   }
 
   if (config.profile) {
@@ -44,8 +51,10 @@ export async function run(cwd: string, config: Config, reporters: Reporter[]) {
       const profileFile = profiler.output();
       logger.info(`runTasks: Profile saved to ${profileFile}`);
     } catch (e) {
-      logger.error(`An error occured while trying to write profile: ${e.message}`);
       process.exitCode = 1;
+      if (e && e.message) {
+        logger.error(`An error occured while trying to write profile: ${e.message}`);
+      }
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,11 +1710,6 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jasmine@^3.5.10":
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.5.10.tgz#a1a41012012b5da9d4b205ba9eba58f6cce2ab7b"
-  integrity sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew==
-
 "@types/jest@^27.0.1":
   version "27.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.1.tgz#fafcc997da0135865311bb1215ba16dba6bdf4ca"


### PR DESCRIPTION
The mechanism for the npmScriptTask to report failure has changed since the refactor. The failure here is that we reject() with an undefined value which gets translated to a catch(e) block inside run.ts ultimately. The undefined value for "e" is causing the catch block to fail itself. This made it so that we are exiting somehow with a exitCode 0.