### PR TITLE
Improve logging of cache fetch errors

### DIFF
--- a/change/lage-fafbab02-4801-4234-ad9f-2cffc41eea23.json
+++ b/change/lage-fafbab02-4801-4234-ad9f-2cffc41eea23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve logging of cache fetch errors",
+  "packageName": "lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -12,7 +12,7 @@ export async function cacheHash(
   args: any
 ) {
   const cacheConfig = getCacheConfig(cwd, cacheOptions);
-  
+
   const backfillLogger = backfill.makeLogger(
     "error",
     process.stdout,
@@ -63,7 +63,7 @@ export async function cacheFetch(
   try {
     return await backfill.fetch(cwd, hash, backfillLogger, cacheConfig);
   } catch (e) {
-    logger.error(`${id} fetchBackfill`, e);
+    logger.error(`${id} fetchBackfill ${e && e.stack || e && e.message || e}`);
   }
 
   return false;

--- a/src/command/run.ts
+++ b/src/command/run.ts
@@ -41,7 +41,7 @@ export async function run(cwd: string, config: Config, reporters: Reporter[]) {
       logger.error("runTasks: " + e.stack);
     } else if (e && e.message) {
       logger.error("runTasks: " + e.message);
-    } else if (e) {
+    } else {
       logger.error("runTasks: " + e);
     }
   }


### PR DESCRIPTION
Include the error stack/message in the string, not as the second argument (which has a different type).