### PR TITLE
Fix Lage overwriting Backfill defaults when options are not set

### DIFF
--- a/change/lage-cb3b0f28-8a48-4dfa-9f12-f74e2eb3dcb2.json
+++ b/change/lage-cb3b0f28-8a48-4dfa-9f12-f74e2eb3dcb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Lage overwriting Backfill defaults when no options are set",
+  "packageName": "lage",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/src/task/WrappedTarget.ts
+++ b/src/task/WrappedTarget.ts
@@ -31,9 +31,10 @@ export class WrappedTarget implements LoggableTarget {
     this.status = "pending";
     this.logger = new TaskLogger(target.packageName || "[GLOBAL]", target.packageName ? target.task : target.id);
 
+    const outputGlob = target.outputGlob || config.cacheOptions.outputGlob;
     this.cacheOptions = {
       ...config.cacheOptions,
-      outputGlob: target.outputGlob || config.cacheOptions.outputGlob,
+      ...(outputGlob && { outputGlob }),
     };
 
     this.context.targets.set(target.id, this);


### PR DESCRIPTION
A recent change made Lage overwrite Backfill's default settings even though nothing was set.

## Before

Value of `WrappedTarget.cacheOptions`:

```js
{ outputGlob: undefined }
```

Returned from `getCacheConfig()`:

```js
{
  cacheStorageConfig: { provider: [Function: provider], name: 'remote-fallback-provider' },
  clearOutput: false,
  internalCacheFolder: '/~/packages/eslint-plugin/node_modules/.cache/backfill',
  logFolder: '/~/packages/eslint-plugin/node_modules/.cache/backfill',
  logLevel: 'info',
  name: '@rnx-kit/eslint-plugin',
  mode: 'READ_WRITE',
  outputGlob: undefined,
  packageRoot: '/~/packages/eslint-plugin',
  producePerformanceLogs: false,
  validateOutput: false,
  writeRemoteCache: false
}
```

## After

Value of `WrappedTarget.cacheOptions`:

```js
{}
```

Returned from `getCacheConfig()`:

```js
{
  cacheStorageConfig: { provider: [Function: provider], name: 'remote-fallback-provider' },
  clearOutput: false,
  internalCacheFolder: '/~/packages/eslint-plugin/node_modules/.cache/backfill',
  logFolder: '/~/packages/eslint-plugin/node_modules/.cache/backfill',
  logLevel: 'info',
  name: '@rnx-kit/eslint-plugin',
  mode: 'READ_WRITE',
  outputGlob: [ 'lib/**' ],
  packageRoot: '/~/packages/eslint-plugin',
  producePerformanceLogs: false,
  validateOutput: false,
  writeRemoteCache: false
}
```