### PR TITLE
Prevent truncation of error logs in summary

### DIFF
--- a/change/lage-883ef88c-06bf-4645-8f28-4f2f3ee61f4f.json
+++ b/change/lage-883ef88c-06bf-4645-8f28-4f2f3ee61f4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent truncation of error summary logs",
+  "packageName": "lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/logger/reporters/NpmLogReporter.ts
+++ b/src/logger/reporters/NpmLogReporter.ts
@@ -197,7 +197,10 @@ export class NpmLogReporter implements Reporter {
         log.error("", `[${chalk.magenta(packageName)} ${chalk.cyan(task)}] ${chalk.redBright("ERROR DETECTED")}`);
 
         if (taskLogs) {
-          log.error("", taskLogs?.map((entry) => entry.msg).join("\n"));
+          for (const entry of taskLogs) {
+            // Log each entry separately to prevent truncation
+            log.error("", entry.msg);
+          }
         }
 
         hr();


### PR DESCRIPTION
When logging errors in the summary, log each line individually, rather than joining the messages into a string and logging it all at once. This will hopefully prevent the summary from being truncated.