### PR TITLE
Add beachball config to unblock dependabot PRs

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,0 +1,17 @@
+// @ts-check
+/** @type {import('beachball').BeachballConfig}*/
+module.exports = {
+  ignorePatterns: [
+    '.*ignore',
+    '.github/**',
+    'beachball.config.js',
+    'decks/**',
+    'docs/**',
+    'jasmine.json',
+    'jest.config.js',
+    'renovate.json',
+    'tests/**',
+    // This one is especially important (otherwise dependabot would be blocked by change file requirements)
+    'yarn.lock',
+  ],
+};


### PR DESCRIPTION
Add a beachball config with `ignorePatterns` including `yarn.lock` (plus docs, tests, and test-related config files) so that dependabot PRs which only touch `yarn.lock` don't get blocked by the change file requirement.