### PR TITLE
Fixes the tasks that have a package in its name

### DIFF
--- a/change/lage-f1fdb01e-c4db-4208-8c5c-4fecafaf139b.json
+++ b/change/lage-f1fdb01e-c4db-4208-8c5c-4fecafaf139b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes the tasks that have the package in its id",
+  "packageName": "lage",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/src/task/WrappedTarget.ts
+++ b/src/task/WrappedTarget.ts
@@ -80,7 +80,7 @@ export class WrappedTarget implements LoggableTarget {
 
     const { target, root, config, cacheOptions } = this;
 
-    if (config.cache) {
+    if (config.cache && target.cache) {
       hash = await cacheHash(target.id, target.cwd, root, cacheOptions, config.args);
 
       if (hash && !config.resetCache) {


### PR DESCRIPTION
the tasks that have this kind of id:

"app#build"

is currently not working - they don't get treated specially in the pipeline target conversion process.