### PR TITLE
Allow parallel scheduling of transitive dependencies with ^^ prefix

### DIFF
--- a/change/lage-c8bec68a-78cd-4811-b9d4-b3b923c93858.json
+++ b/change/lage-c8bec68a-78cd-4811-b9d4-b3b923c93858.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow explicit parralel scheduling of transitive dependencies with ^^ prefix",
+  "packageName": "lage",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -45,7 +45,11 @@ Which NPM Client to use when running npm lifecycle scripts
 #### pipeline
 _type: [Pipeline](#Pipeline)_
 
-Defines the task pipeline, prefix with "^" character to denote a topological dependency
+Defines the task pipeline.
+
+- Use a tasks's name with no prefix to denote a package-local dependency.
+- Prefix with "^" character to denote a direct topological dependency.
+- Prefix with `^^` to denote a transitive topological dependency (This includes tasks from dependencies of dependencies).
 
 Example:
 
@@ -54,6 +58,9 @@ Example:
   build: ["^build"],
   test: ["build"],
   lint: []
+
+  bundle: ["^^transpile"],
+  transpile: []
 }
 ```
 

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -48,7 +48,7 @@ _type: [Pipeline](#Pipeline)_
 Defines the task pipeline.
 
 - Use a tasks's name with no prefix to denote a package-local dependency.
-- Prefix with "^" character to denote a direct topological dependency.
+- Prefix with `^` character to denote a direct topological dependency.
 - Prefix with `^^` to denote a transitive topological dependency (This includes tasks from dependencies of dependencies).
 
 Example:

--- a/src/task/Pipeline.ts
+++ b/src/task/Pipeline.ts
@@ -318,7 +318,13 @@ export class Pipeline {
         const graphEntry = this.graph[currentPackageName];
         if(graphEntry) {
           visited.add(currentPackageName)
-          frontier.push(...graphEntry.dependencies)
+          // paranoid check against getting stuck in a loop
+          // in case this somehow runs on a workspace
+          // with circular dependencies
+          let newDependencies = graphEntry.dependencies.filter(
+            candidate => !visited.has(candidate) && !frontier.includes(candidate)
+          )
+          frontier.push(...newDependencies)
         }
       }
     }

--- a/src/types/ConfigOptions.ts
+++ b/src/types/ConfigOptions.ts
@@ -9,8 +9,9 @@ export type NpmClient = "npm" | "yarn" | "pnpm";
 
 export interface ConfigOptions {
   /**
-   * Defines the task pipeline, prefix with "^" character to denote a topological dependency
-   *
+   * Defines the task pipeline, prefix with "^" character to denote a direct topological dependency,
+   * prefix with ^^ to denote a transitive topological dependency.
+   * 
    * Example:
    *
    * ```
@@ -18,6 +19,8 @@ export interface ConfigOptions {
    *   build: ["^build"],
    *   test: ["build"],
    *   lint: []
+   *   bundle: ["^^transpile"],
+   *   transpile: [],
    * }
    * ```
    */

--- a/tests/e2e/transitiveTaskDeps.test.ts
+++ b/tests/e2e/transitiveTaskDeps.test.ts
@@ -155,11 +155,11 @@ describe("transitive task deps test", () => {
     // own package transpilation should not be run, since we only want to to consider transitive
     // dependencies with a ^^ dependency.
     expect(indices[getTargetId("a", "transpile")]).toBeUndefined();
-    // despite b depending on c, there is no dependency between transpile tasks, so they should
-    // be runnable in either order.
+    // despite b depending on c as a package, there is no dependency between the b#transpile and c#transpile
+    // tasks, so they should be runnable in either order.
     //
-    // In this test we use priority to ensure that b#transpile it will always run before
-    // c#transpile if they do not have an explicit transpile -> transpile dependency.
+    // In this test we use priority to ensure that b#transpile will always run before
+    // c#transpile if they do not have an explicit task dependency.
     expect(indices[getTargetId("b", "transpile")]).toBeLessThan(indices[getTargetId("c", "transpile")]);
 
     repo.cleanup();

--- a/tests/e2e/transitiveTaskDeps.test.ts
+++ b/tests/e2e/transitiveTaskDeps.test.ts
@@ -90,8 +90,6 @@ describe("transitive task deps test", () => {
       }
     }
 
-    console.log(indices)
-
     // own package transpilation should be run
     expect(indices[getTargetId("a", "transpile")]).toBeLessThan(indices[getTargetId("a", "bundle")]);
     // b & c#transpile should not be queued, since we only take a local dependency

--- a/tests/mock/monorepo.ts
+++ b/tests/mock/monorepo.ts
@@ -80,9 +80,9 @@ export class Monorepo {
         private: true,
         workspaces: ["packages/*"],
         scripts: {
-          build: `node "${lagePath}" build --reporter json --log-level silly`,
-          transpile: `node "${lagePath}" transpile --reporter json --log-level silly`,
           bundle: `node "${lagePath}" bundle --reporter json --log-level silly`,
+          transpile: `node "${lagePath}" transpile --reporter json --log-level silly`,
+          build: `node "${lagePath}" build --reporter json --log-level silly`,
           test: `node "${lagePath}" test --reporter json --log-level silly`,
           lint: `node "${lagePath}" lint --reporter json --log-level silly`,
         },
@@ -94,8 +94,6 @@ export class Monorepo {
         pipeline: {
           build: ['^build'],
           test: ['build'],
-          bundle: ['^^transpile']
-          transpile: []
           lint: []
         }
       };`,
@@ -114,8 +112,6 @@ export class Monorepo {
       [`packages/${name}/build.js`]: `console.log('building ${name}');`,
       [`packages/${name}/test.js`]: `console.log('building ${name}');`,
       [`packages/${name}/lint.js`]: `console.log('linting ${name}');`,
-      [`packages/${name}/transpile.js`]: `console.log('transpiling ${name}');`,
-      [`packages/${name}/bundle.js`]: `console.log('bundling ${name}');`,
       [`packages/${name}/package.json`]: {
         name,
         version: "0.1.0",
@@ -123,8 +119,6 @@ export class Monorepo {
           build: "node ./build.js",
           test: "node ./test.js",
           lint: "node ./lint.js",
-          transpile: "node ./transpile.js",
-          bundle: "node ./bundle.js",
         },
         dependencies: {
           ...(internalDeps &&

--- a/tests/mock/monorepo.ts
+++ b/tests/mock/monorepo.ts
@@ -81,6 +81,8 @@ export class Monorepo {
         workspaces: ["packages/*"],
         scripts: {
           build: `node "${lagePath}" build --reporter json --log-level silly`,
+          transpile: `node "${lagePath}" transpile --reporter json --log-level silly`,
+          bundle: `node "${lagePath}" bundle --reporter json --log-level silly`,
           test: `node "${lagePath}" test --reporter json --log-level silly`,
           lint: `node "${lagePath}" lint --reporter json --log-level silly`,
         },
@@ -92,6 +94,8 @@ export class Monorepo {
         pipeline: {
           build: ['^build'],
           test: ['build'],
+          bundle: ['^^transpile']
+          transpile: []
           lint: []
         }
       };`,
@@ -110,6 +114,8 @@ export class Monorepo {
       [`packages/${name}/build.js`]: `console.log('building ${name}');`,
       [`packages/${name}/test.js`]: `console.log('building ${name}');`,
       [`packages/${name}/lint.js`]: `console.log('linting ${name}');`,
+      [`packages/${name}/transpile.js`]: `console.log('transpiling ${name}');`,
+      [`packages/${name}/bundle.js`]: `console.log('bundling ${name}');`,
       [`packages/${name}/package.json`]: {
         name,
         version: "0.1.0",
@@ -117,6 +123,8 @@ export class Monorepo {
           build: "node ./build.js",
           test: "node ./test.js",
           lint: "node ./lint.js",
+          transpile: "node ./transpile.js",
+          bundle: "node ./bundle.js",
         },
         dependencies: {
           ...(internalDeps &&


### PR DESCRIPTION
Addresses #177 by adding an explicit way to specify task dependencies on the tasks of transitive package dependencies.

I opted to expand the existing `^` syntax for direct dependencies by adding `^^` for transitive dependencies, since tasks are already prevented from being prefixed with a `^` because of the direct-dependencies rule. It also neatly encapsulates the intent of "also include dependencies of dependencies" by being the `^` prefix, repeated.

This change:
- implements ^^ with a greedy walk over package dependencies.
- Adds tests defending that ^^ schedules only transitive dependencies, and does not create co-dependencies between those tasks.
- Update pipeline documentation with the new prefix.

