### PR TITLE
Adress spottiness in transitiveTaskDeps tests

### DIFF
--- a/tests/e2e/transitiveTaskDeps.test.ts
+++ b/tests/e2e/transitiveTaskDeps.test.ts
@@ -51,7 +51,7 @@ describe("transitive task deps test", () => {
   });
 
   it("only runs package local dependencies for no-prefix dependencies", () => {
-    const repo = new Monorepo("transitiveDeps");
+    const repo = new Monorepo("transitiveDeps-no-prefix");
 
     repo.init();
     repo.setLageConfig(`module.exports = {
@@ -100,7 +100,7 @@ describe("transitive task deps test", () => {
   });
   
   it("only runs direct dependencies for ^ prefix dependencies -- ", () => {
-    const repo = new Monorepo("transitiveDeps");
+    const repo = new Monorepo("transitiveDeps-carat-prefix");
 
     repo.init();
     repo.setLageConfig(`module.exports = {
@@ -164,6 +164,11 @@ describe("transitive task deps test", () => {
           package: "b",
           task: "transpile",
           priority: 100
+        },
+        {
+          package: "c",
+          task: "transpile",
+          priority: 1
         }
       ],
     }`);


### PR DESCRIPTION
- Sets unique names for each transitiveTaskDeps test to avoid fs
  collisions between tests. This was causing spottiness in test runs.
- Sets consistent priority for c#transpile in transitiveDeps-indirect
  to make the relative priority to b#transpile explicit in the test.