### PR TITLE
adding a flag to turn off local cache population

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "node_modules/jest/bin/jest.js",
+      "outFiles": [
+        "${workspaceFolder}/**/*.js"
+      ],
+      "args": ["--runInBand", "${fileBasenameNoExtension}"],
+      "sourceMaps": true,
+    }
+  ]
+}

--- a/change/lage-971fb145-7177-4732-a326-50b9197f1270.json
+++ b/change/lage-971fb145-7177-4732-a326-50b9197f1270.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adding a flag to turn off local cache population",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -70,6 +70,7 @@ export function getPassThroughArgs(
     "cacheKey",
     "dist",
     "experimentDist",
+    "skipLocalCache",
     "_",
   ];
 

--- a/src/cache/backfill.ts
+++ b/src/cache/backfill.ts
@@ -3,7 +3,6 @@ import { logger } from "../logger";
 import { salt } from "./salt";
 import * as backfill from "backfill/lib/api";
 import { CacheOptions } from "../types/CacheOptions";
-import path from 'path';
 
 export async function cacheHash(
   id: string,
@@ -23,7 +22,7 @@ export async function cacheHash(
   const hashKey = salt(
     cacheOptions.environmentGlob || ["lage.config.js"],
     `${id}|${JSON.stringify(args)}`,
-    path.relative(root, cwd),
+    root,
     cacheOptions.cacheKey
   );
 

--- a/src/cache/cacheConfig.ts
+++ b/src/cache/cacheConfig.ts
@@ -8,6 +8,7 @@ export function getCacheConfig(cwd: string, cacheOptions: CacheOptions) {
 
   // in lage, default mode is to CACHE locally
   defaultCacheConfig.cacheStorageConfig.provider = "local";
+  
 
   const logger = makeLogger("warn");
   const envConfig = getEnvConfig(logger);
@@ -18,7 +19,7 @@ export function getCacheConfig(cwd: string, cacheOptions: CacheOptions) {
     ...envConfig,
     writeRemoteCache: cacheOptions.writeRemoteCache || !!process.env.LAGE_WRITE_REMOTE_CACHE
   };
-
+  
   const configWithFallback: CacheOptions = {
     ...configWithEnvOverrides,
     cacheStorageConfig: {

--- a/src/cache/salt.ts
+++ b/src/cache/salt.ts
@@ -2,8 +2,6 @@ import * as path from "path";
 import * as crypto from "crypto";
 import * as fg from "fast-glob";
 import * as fs from "fs";
-// import os from "os";
-// import process from "process";
 
 let envHash: string[];
 
@@ -13,11 +11,7 @@ export function salt(
   repoRoot: string,
   customKey: string = ""
 ): string {
-  return hashStrings([
-    ...getEnvHash(environmentGlobFiles, repoRoot),
-    command,
-    customKey,
-  ]);
+  return hashStrings([...getEnvHash(environmentGlobFiles, repoRoot), command, customKey]);
 }
 
 function getEnvHash(environmentGlobFiles: string[], repoRoot: string) {

--- a/src/command/worker.ts
+++ b/src/command/worker.ts
@@ -133,7 +133,7 @@ async function getCache(target: PipelineTarget, root: string, config: Config) {
 
   const { id, cwd } = target;
   const cacheOptions = getCacheOptions(target, config);
-  hash = await cacheHash(id, root, cwd, cacheOptions, config.args);
+  hash = await cacheHash(id, cwd, root, cacheOptions, config.args);
 
   if (hash && !config.resetCache) {
     cacheHit = await cacheFetch(hash, id, cwd, config.cacheOptions);

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -37,7 +37,7 @@ export function getConfig(cwd: string): Config {
 
   const dist = parsedArgs.experimentDist || false;
   const concurrency = parsedArgs.concurrency || configResults?.config.concurrency || os.cpus().length;
-  
+
   return {
     reporter: parsedArgs.reporter || "npmLog",
     grouped: parsedArgs.grouped || false,
@@ -48,6 +48,7 @@ export function getConfig(cwd: string): Config {
       {
         ...configResults?.config.cacheOptions,
         ...(parsedArgs.cacheKey && { cacheKey: parsedArgs.cacheKey }),
+        ...(parsedArgs.skipLocalCache && { skipLocalCache: true }),
       } || {},
     command,
     concurrency,

--- a/src/types/CacheOptions.ts
+++ b/src/types/CacheOptions.ts
@@ -4,4 +4,5 @@ export type CacheOptions = BackfillCacheOptions & {
   environmentGlob: string[];
   cacheKey: string;
   writeRemoteCache: boolean;
+  skipLocalCache: boolean;
 };

--- a/src/types/CliOptions.ts
+++ b/src/types/CliOptions.ts
@@ -181,11 +181,16 @@ export interface CliOptions {
    */
   logLevel: string;
 
-  /**
-   * Specify a custom cache key salt with this option: --cache-key xyz_build_environemnt
-   */
   cacheOptions: {
+    /**
+     * Specify a custom cache key salt with this option: --cache-key xyz_build_environemnt
+     */
     cacheKey: string;
+
+    /**
+     * whether to populate or skip local cache: --skip-local-cache
+     */
+    skipLocalCache: boolean;
   };
 
   /**

--- a/tests/e2e/remoteFallback.test.ts
+++ b/tests/e2e/remoteFallback.test.ts
@@ -1,8 +1,70 @@
 import { Monorepo } from "../mock/monorepo";
 import { parseNdJson } from "./parseNdJson";
 
-// WIP!!
 describe("RemoteFallbackCacheProvider", () => {
+  it("should skip local cache population if --skip-local-cache is enabled", () => {
+    const repo = new Monorepo("fallback");
+
+    repo.init();
+    repo.setLageConfig(
+      `const fs = require('fs');
+      const path = require('path');
+      module.exports = {
+        pipeline: {
+          build: [],
+        },
+        cache: true,
+        cacheOptions: {
+          writeRemoteCache: true,
+          cacheStorageConfig: {
+            provider: (logger, cwd) => ({
+              async fetch(hash) {
+                return false;
+              },
+
+              async put(hash, filesToCache) {
+              },
+            }),
+          },
+        } 
+      };`
+    );
+
+    repo.install();
+
+    repo.addPackage("a", [], {
+      build: "echo a:build",
+      test: "echo a:test",
+    });
+    repo.addPackage("b", [], {
+      build: "echo b:build",
+    });
+    repo.linkPackages();
+
+    const results = repo.run("test", ["--verbose", "--skip-local-cache"]);
+
+    const output = results.stdout + results.stderr;
+    const jsonOutput = parseNdJson(output);
+
+    expect(
+      jsonOutput.find((entry) => entry.msg?.includes("local cache fetch"))
+    ).toBeFalsy();
+
+    expect(
+      jsonOutput.find((entry) => entry.msg?.includes("remote fallback fetch"))
+    ).toBeTruthy();
+
+    expect(
+      jsonOutput.find((entry) => entry.msg?.includes("local cache put"))
+    ).toBeFalsy();
+
+    expect(
+      jsonOutput.find((entry) => entry.msg?.includes("remote fallback put"))
+    ).toBeTruthy();
+
+    repo.cleanup();
+  })
+
   it("should operate with local provider ONLY by default", () => {
     const repo = new Monorepo("fallback");
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "noUnusedLocals": false,
+    "sourceMap": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
We currently enabled remote cache -> local cache population step. This may not work in some cases when a repo sometimes saves the "source" also as and "output". We will run into race conditions. This flag allows you to turn off writing to local cache. It's likely most useful to be used inside CI environment where we want to have remote cache, but not to populate anything locally.

```
lage build --skip-local-cache
```