### PR TITLE
Add targetGraph to profileData

### DIFF
--- a/change/lage-8c73755c-b1c1-441a-b03c-3c2990d35253.json
+++ b/change/lage-8c73755c-b1c1-441a-b03c-3c2990d35253.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add taskGraph to profileData",
+  "packageName": "lage",
+  "email": "\"ronakjain@microsoft.com\"",
+  "dependentChangeType": "patch"
+}

--- a/src/task/Pipeline.ts
+++ b/src/task/Pipeline.ts
@@ -12,6 +12,7 @@ import { getPipelinePackages } from "./getPipelinePackages";
 import { getPackageAndTask, getTargetId } from "./taskId";
 import { WrappedTarget } from "./WrappedTarget";
 import { DistributedTask } from "./DistributedTask";
+import { logger } from "../logger";
 
 export const START_TARGET_ID = "__start";
 
@@ -463,6 +464,7 @@ export class Pipeline {
 
     const nodeMap: PGraphNodeMap = new Map();
     const targetGraph = this.generateTargetGraph();
+    this.context.profiler.setOtherData("targetGraph", targetGraph);
 
     for (const [from, to] of targetGraph) {
       const fromTarget = this.targets.get(from)!;


### PR DESCRIPTION
Adding targetGraph to profileData so that it's easier to analyze profile and figure out the critical path in the build graph which impacts the build times most.