### PR TITLE
add ado logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ lib
 *.log
 .DS_Store
 *.pdf
+coverage
+.idea/

--- a/change/lage-8d6b4d18-30f1-43ee-b2d4-4fe1a1b24911.json
+++ b/change/lage-8d6b4d18-30f1-43ee-b2d4-4fe1a1b24911.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add ado logger",
+  "packageName": "lage",
+  "email": "cheruiyotbryan@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/logger/initReporters.ts
+++ b/src/logger/initReporters.ts
@@ -3,6 +3,7 @@ import { Logger } from "./Logger";
 import { NpmLogReporter } from "./reporters/NpmLogReporter";
 import { LogLevel } from "./LogLevel";
 import { JsonReporter } from "./reporters/JsonReporter";
+import { AdoReporter } from "./reporters/AdoReporter";
 
 export function initReporters(config: Config) {
   // Initialize logger
@@ -12,15 +13,19 @@ export function initReporters(config: Config) {
     logLevel = LogLevel[config.logLevel as LogLevelString];
   }
 
-  const reporters = [
+  const reporters: Array<AdoReporter | JsonReporter | NpmLogReporter> = [
     config.reporter === "json"
       ? new JsonReporter({ logLevel })
       : new NpmLogReporter({
-          logLevel,
-          grouped: config.grouped,
-          npmLoggerOptions: config.loggerOptions
-        }),
+        logLevel,
+        grouped: config.grouped,
+        npmLoggerOptions: config.loggerOptions
+      }),
   ];
+
+  if (config.reporter === "adoLog") { // Will always include NpmLogReporter and add AdoReporter
+    reporters.push(new AdoReporter())
+  }
 
   Logger.reporters = reporters;
   return reporters;

--- a/src/logger/reporters/AdoReporter.ts
+++ b/src/logger/reporters/AdoReporter.ts
@@ -1,0 +1,47 @@
+import { RunContext } from '../../types/RunContext';
+import { Reporter } from './Reporter';
+import { LogEntry } from '../LogEntry';
+import { getTaskId } from '@microsoft/task-scheduler';
+
+export class AdoReporter implements Reporter {
+
+  log(entry: LogEntry) {}
+
+  summarize(context: RunContext) {
+    const { measures, tasks } = context;
+
+    let packageLogs = '';
+    if (measures.failedTasks && measures.failedTasks.length > 0) {
+      const failedPackages: { pkg?: string; taskLogs?: string; task: string; }[] = [];
+
+      for (const failedTask of measures.failedTasks) {
+        const { pkg, task } = failedTask;
+        const taskId = getTaskId(pkg, task);
+        const taskLogs = tasks.get(taskId)?.logger.getLogs();
+
+        if (taskLogs) {
+          packageLogs += `[${pkg} ${task}]`;
+          for (let i = 0; i < taskLogs.length; i += 1) {
+            packageLogs += taskLogs[i].msg.replace('\n', '');
+          }
+        }
+
+        failedPackages.push({ pkg, taskLogs: packageLogs, task });
+      }
+
+      const logGroup: string[] = [];
+      let packagesMessage = `##vso[task.logissue type=error]Your build failed on the following packages => `;
+      failedPackages.forEach(({ pkg, task, taskLogs }) => {
+        packagesMessage += `[${pkg} ${task}], `;
+        if (taskLogs) {
+          logGroup.push(taskLogs);
+        }
+      });
+
+      packagesMessage += "find the error logs above with the prefix 'ERR!'";
+      console.log(packagesMessage);
+
+      console.log(`##vso[task.logissue type=warning]${logGroup.join(' | ')}`);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces ADO reporter from issue:
#167 

Example of the log:
This is an excerpt of the full error message specific to what this feature introduces
```
info Took a total of 13.39s to complete
##[error]Your build failed on the following packages => [package step], find the error logs above with the prefix 'ERR!'
##[warning] .....rest of the log from npm logger in a single line
error Command failed with exit code 1.
```