### PR TITLE
fixing flakey tests by making asserts on when tasks are started rather than completed

### DIFF
--- a/tests/e2e/transitiveTaskDeps.test.ts
+++ b/tests/e2e/transitiveTaskDeps.test.ts
@@ -132,7 +132,7 @@ describe("transitive task deps test", () => {
 
     for (const pkg of ["a", "b", "c"]) {
       for (const task of ["transpile", "bundle"]) {
-        const index = jsonOutput.findIndex((e) => filterEntry(e.data, pkg, task, "completed"));
+        const index = jsonOutput.findIndex((e) => filterEntry(e.data, pkg, task, "started"));
         if (index > -1) {
           indices[getTargetId(pkg, task)] = index;  
         }
@@ -193,10 +193,9 @@ describe("transitive task deps test", () => {
 
     const indices: { [taskId: string]: number } = {};
 
-
     for (const pkg of ["a", "b", "c"]) {
       for (const task of ["transpile", "bundle"]) {
-        const index = jsonOutput.findIndex((e) => filterEntry(e.data, pkg, task, "completed"));
+        const index = jsonOutput.findIndex((e) => filterEntry(e.data, pkg, task, "started"));
         if (index > -1) {
           indices[getTargetId(pkg, task)] = index;  
         }


### PR DESCRIPTION
Because we're making assertions of completion of an set of async tests that are trigger around the same time, we're getting race conditions.