### PR TITLE
Fix handling of stdio chunks that don't end in a new line

### DIFF
--- a/change/lage-2ea2bd72-12f5-43f0-a8d1-aeff3c0b7142.json
+++ b/change/lage-2ea2bd72-12f5-43f0-a8d1-aeff3c0b7142.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix handling of stdio chunks that don't end in a new line",
+  "packageName": "lage",
+  "email": "4015993+KyleDavidE@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/src/logger/TaskLogWritable.ts
+++ b/src/logger/TaskLogWritable.ts
@@ -17,19 +17,31 @@ export class TaskLogWritable extends Writable {
     let curr = 0;
     while (curr < chunk.byteLength) {
       if (chunk[curr] === 13 || (chunk[curr] === 10 && curr - prev > 1)) {
-        this.buffer =
-          this.buffer +
-          chunk
-            .slice(prev, curr)
-            .toString()
-            .replace(/^(\r\n|\n|\r)|(\r\n|\n|\r)$/g, "")
-            .trimRight();
-        this.taskLogger.verbose(this.buffer);
-        this.buffer = "";
+        this.buffer += chunk
+          .slice(prev, curr)
+          .toString()
+          .replace(/^(\r\n|\n|\r)|(\r\n|\n|\r)$/g, "");
+        this.flushLine();
         prev = curr;
       }
       curr++;
     }
+    this.buffer += chunk
+      .slice(prev, curr)
+      .toString()
+      .replace(/^(\r\n|\n|\r)|(\r\n|\n|\r)$/g, "");
     callback();
+  }
+
+  _final(callback: (error?: Error | null) => void) {
+    if (this.buffer.length) {
+      this.flushLine();
+    }
+    callback();
+  }
+
+  private flushLine() {
+    this.taskLogger.verbose(this.buffer.trimRight());
+    this.buffer = "";
   }
 }


### PR DESCRIPTION
TaskLogWritable would cause the parts of chucks after the final new line in the chuck to be dropped. This change makes it so that they get correctly added to the buffer and logged on the next newline.