### PR TITLE
Fix handling of stdio chunks that don't end in a new line

### DIFF
--- a/change/@lage-run-logger-28f77ff3-7b54-4732-85d6-eeed5272083e.json
+++ b/change/@lage-run-logger-28f77ff3-7b54-4732-85d6-eeed5272083e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix handling of stdio chunks that don't end in a new line",
+  "packageName": "@lage-run/logger",
+  "email": "4015993+KyleDavidE@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/logger/src/LogWritable.ts
+++ b/packages/logger/src/LogWritable.ts
@@ -17,19 +17,31 @@ export class LogWritable extends Writable {
     let curr = 0;
     while (curr < chunk.byteLength) {
       if (chunk[curr] === 13 || (chunk[curr] === 10 && curr - prev > 1)) {
-        this.buffer =
-          this.buffer +
-          chunk
-            .slice(prev, curr)
-            .toString()
-            .replace(/^(\r\n|\n|\r)|(\r\n|\n|\r)$/g, "")
-            .trimRight();
-        this.logger.verbose(this.buffer);
-        this.buffer = "";
+        this.buffer += chunk
+          .slice(prev, curr)
+          .toString()
+          .replace(/^(\r\n|\n|\r)|(\r\n|\n|\r)$/g, "");
+        this.flushLine();
         prev = curr;
       }
       curr++;
     }
+    this.buffer += chunk
+      .slice(prev, curr)
+      .toString()
+      .replace(/^(\r\n|\n|\r)|(\r\n|\n|\r)$/g, "");
     callback();
+  }
+
+  _final(callback: (error?: Error | null) => void) {
+    if (this.buffer.length) {
+      this.flushLine();
+    }
+    callback();
+  }
+
+  private flushLine() {
+    this.logger.verbose(this.buffer.trimRight());
+    this.buffer = "";
   }
 }


### PR DESCRIPTION
LogWritable would cause the parts of chucks after the final new line in the chuck to be dropped. This change makes it so that they get correctly added to the buffer and logged on the next newline.

Version for stable is #265 