### PR TITLE
Ensure cache --clear respects internalCacheFolder when it's passed in

### DIFF
--- a/change/lage-43911c65-bac9-4842-9d0e-9cab7fb3642e.json
+++ b/change/lage-43911c65-bac9-4842-9d0e-9cab7fb3642e.json
@@ -1,8 +1,7 @@
 {
-    "type": "patch",
-    "comment": "Ensure cache --clear respects internalCacheFolder when it's passed in",
-    "packageName": "lage",
-    "email": "branth@microsoft.com",
-    "dependentChangeType": "patch"
-  }
-  
+  "type": "patch",
+  "comment": "Ensure cache --clear respects internalCacheFolder when it's passed in",
+  "packageName": "lage",
+  "email": "branth@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/lage-43911c65-bac9-4842-9d0e-9cab7fb3642e.json
+++ b/change/lage-43911c65-bac9-4842-9d0e-9cab7fb3642e.json
@@ -5,3 +5,4 @@
     "email": "branth@microsoft.com",
     "dependentChangeType": "patch"
   }
+  

--- a/change/lage-43911c65-bac9-4842-9d0e-9cab7fb3642e.json
+++ b/change/lage-43911c65-bac9-4842-9d0e-9cab7fb3642e.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Ensure cache --clear respects internalCacheFolder when it's passed in",
+    "packageName": "lage",
+    "email": "branth@microsoft.com",
+    "dependentChangeType": "patch"
+  }

--- a/packages/lage/src/command/cache.ts
+++ b/packages/lage/src/command/cache.ts
@@ -70,10 +70,9 @@ function pruneCache(cwd: string, config: Config) {
 }
 
 function getCachePath(info: PackageInfo, cacheOptions: CacheOptions) {
-  const cacheFolder =
-    cacheOptions.internalCacheFolder !== ""
-      ? `../${cacheOptions.internalCacheFolder}`
-      : undefined;
+  const cacheFolder = !cacheOptions.internalCacheFolder
+    ? undefined
+    : `../${cacheOptions.internalCacheFolder}`;
 
   return path.join(
     info.packageJsonPath,

--- a/packages/lage/src/command/cache.ts
+++ b/packages/lage/src/command/cache.ts
@@ -2,6 +2,7 @@ import fs, { Stats } from "fs";
 import path from "path";
 import { PackageInfo } from "workspace-tools";
 import { logger } from "../logger";
+import { CacheOptions } from "../types/CacheOptions";
 import { Config } from "../types/Config";
 import { getWorkspace } from "../workspace/getWorkspace";
 
@@ -25,7 +26,7 @@ function clearCache(cwd: string, config: Config) {
   const workspace = getWorkspace(cwd, config);
   const { allPackages } = workspace;
   for (const info of Object.values(allPackages)) {
-    const cachePath = getCachePath(info);
+    const cachePath = getCachePath(info, config.cacheOptions);
 
     if (fs.existsSync(cachePath)) {
       const entries = fs.readdirSync(cachePath);
@@ -46,7 +47,7 @@ function pruneCache(cwd: string, config: Config) {
   const workspace = getWorkspace(cwd, config);
   const { allPackages } = workspace;
   for (const info of Object.values(allPackages)) {
-    const cachePath = getCachePath(info);
+    const cachePath = getCachePath(info, config.cacheOptions);
 
     if (fs.existsSync(cachePath)) {
       const entries = fs.readdirSync(cachePath);
@@ -68,8 +69,16 @@ function pruneCache(cwd: string, config: Config) {
   }
 }
 
-function getCachePath(info: PackageInfo) {
-  return path.join(info.packageJsonPath, "../node_modules/.cache/backfill");
+function getCachePath(info: PackageInfo, cacheOptions: CacheOptions) {
+  const cacheFolder =
+    cacheOptions.internalCacheFolder !== ""
+      ? `../${cacheOptions.internalCacheFolder}`
+      : undefined;
+
+  return path.join(
+    info.packageJsonPath,
+    cacheFolder ?? "../node_modules/.cache/backfill"
+  );
 }
 
 function remove(entryPath: string, entryStat: Stats) {

--- a/packages/lage/tests/e2e/cacheClear.test.ts
+++ b/packages/lage/tests/e2e/cacheClear.test.ts
@@ -2,7 +2,9 @@ import fs from "fs";
 import path from "path";
 
 import { Monorepo } from "../mock/monorepo";
+import { parseNdJson } from "./parseNdJson";
 
+const defaultCacheLocation = 'node_modules/.cache/backfill';
 const cacheLocation = '.cache/backfill';
 
 describe("Cache clear", () => {
@@ -51,6 +53,61 @@ describe("Cache clear", () => {
 
     // Clear the cache
     repo.run("clear");
+
+    // Cache folders should be empty
+    expect(fs.readdirSync(cacheFolderA)).toHaveLength(0);
+    expect(fs.readdirSync(cacheFolderB)).toHaveLength(0);
+
+    repo.cleanup();
+  });
+  
+  it("should clear cache with the default cache location", () => {
+    const repo = new Monorepo("cache");
+
+    repo.init();
+    repo.setLageConfig(
+      `const fs = require('fs');
+      const path = require('path');
+      module.exports = {
+        pipeline: {
+          build: [],
+        },
+        cache: true,
+      };`
+    );
+
+    repo.install();
+
+    repo.addPackage("a", [], {
+      build: "echo a:build",
+      test: "echo a:test",
+    });
+    repo.addPackage("b", [], {
+      build: "echo b:build",
+    });
+    repo.linkPackages();
+
+    // Run build so we get a cache folder
+    repo.run("build");
+
+    const cacheFolderA = path.join(repo.root, `packages/a/${defaultCacheLocation}`);
+    const cacheFolderB = path.join(repo.root, `packages/b/${defaultCacheLocation}`);
+
+    // Cache is created in the right place
+    expect(fs.existsSync(cacheFolderA)).toBeTruthy();
+    expect(fs.existsSync(cacheFolderB)).toBeTruthy();
+
+    // Check that cache folder is actually populated
+    expect(fs.readdirSync(cacheFolderA)).toHaveLength(1);
+    expect(fs.readdirSync(cacheFolderB)).toHaveLength(1);
+
+    // Clear the cache
+    
+    const results = repo.run("clear");
+
+    const output = results.stdout + results.stderr;
+    const jsonOutput = parseNdJson(output);
+    console.log(jsonOutput);
 
     // Cache folders should be empty
     expect(fs.readdirSync(cacheFolderA)).toHaveLength(0);

--- a/packages/lage/tests/e2e/cacheClear.test.ts
+++ b/packages/lage/tests/e2e/cacheClear.test.ts
@@ -1,0 +1,61 @@
+import fs from "fs";
+import path from "path";
+
+import { Monorepo } from "../mock/monorepo";
+
+const cacheLocation = '.cache/backfill';
+
+describe("Cache clear", () => {
+  it("should clear cache when internalCacheFolder is passed", () => {
+    const repo = new Monorepo("cache");
+
+    repo.init();
+    repo.setLageConfig(
+      `const fs = require('fs');
+      const path = require('path');
+      module.exports = {
+        pipeline: {
+          build: [],
+        },
+        cache: true,
+        cacheOptions: {
+          internalCacheFolder: '${cacheLocation}',
+        }
+      };`
+    );
+
+    repo.install();
+
+    repo.addPackage("a", [], {
+      build: "echo a:build",
+      test: "echo a:test",
+    });
+    repo.addPackage("b", [], {
+      build: "echo b:build",
+    });
+    repo.linkPackages();
+
+    // Run build so we get a cache folder
+    repo.run("build");
+
+    const cacheFolderA = path.join(repo.root, `packages/a/${cacheLocation}`);
+    const cacheFolderB = path.join(repo.root, `packages/b/${cacheLocation}`);
+
+    // Cache is created in the right place
+    expect(fs.existsSync(cacheFolderA)).toBeTruthy();
+    expect(fs.existsSync(cacheFolderB)).toBeTruthy();
+
+    // Check that cache folder is actually populated
+    expect(fs.readdirSync(cacheFolderA)).toHaveLength(1);
+    expect(fs.readdirSync(cacheFolderB)).toHaveLength(1);
+
+    // Clear the cache
+    repo.run("clear");
+
+    // Cache folders should be empty
+    expect(fs.readdirSync(cacheFolderA)).toHaveLength(0);
+    expect(fs.readdirSync(cacheFolderB)).toHaveLength(0);
+
+    repo.cleanup();
+  });
+});

--- a/packages/lage/tests/e2e/cacheClear.test.ts
+++ b/packages/lage/tests/e2e/cacheClear.test.ts
@@ -4,8 +4,8 @@ import path from "path";
 import { Monorepo } from "../mock/monorepo";
 import { parseNdJson } from "./parseNdJson";
 
-const defaultCacheLocation = 'node_modules/.cache/backfill';
-const cacheLocation = '.cache/backfill';
+const defaultCacheLocation = "node_modules/.cache/backfill";
+const cacheLocation = ".cache/backfill";
 
 describe("Cache clear", () => {
   it("should clear cache when internalCacheFolder is passed", () => {
@@ -60,7 +60,7 @@ describe("Cache clear", () => {
 
     repo.cleanup();
   });
-  
+
   it("should clear cache with the default cache location", () => {
     const repo = new Monorepo("cache");
 
@@ -90,8 +90,14 @@ describe("Cache clear", () => {
     // Run build so we get a cache folder
     repo.run("build");
 
-    const cacheFolderA = path.join(repo.root, `packages/a/${defaultCacheLocation}`);
-    const cacheFolderB = path.join(repo.root, `packages/b/${defaultCacheLocation}`);
+    const cacheFolderA = path.join(
+      repo.root,
+      `packages/a/${defaultCacheLocation}`
+    );
+    const cacheFolderB = path.join(
+      repo.root,
+      `packages/b/${defaultCacheLocation}`
+    );
 
     // Cache is created in the right place
     expect(fs.existsSync(cacheFolderA)).toBeTruthy();
@@ -102,7 +108,7 @@ describe("Cache clear", () => {
     expect(fs.readdirSync(cacheFolderB)).toHaveLength(1);
 
     // Clear the cache
-    
+
     const results = repo.run("clear");
 
     const output = results.stdout + results.stderr;

--- a/packages/lage/tests/mock/monorepo.ts
+++ b/packages/lage/tests/mock/monorepo.ts
@@ -5,7 +5,6 @@ import execa from "execa";
 
 export class Monorepo {
   static tmpdir = os.tmpdir();
-  static yarnCache = path.join(Monorepo.tmpdir, "yarn-cache-");
 
   root: string;
 
@@ -86,6 +85,7 @@ export class Monorepo {
           writeInfo: `node "${lagePath}" info`,
           test: `node "${lagePath}" test --reporter json --log-level silly`,
           lint: `node "${lagePath}" lint --reporter json --log-level silly`,
+          clear: `node "${lagePath}" cache --clear --reporter json --log-level silly`,
         },
         devDependencies: {
           lage: path.resolve(__dirname, "..", ".."),


### PR DESCRIPTION
This addresses #202 by ensuring the `getCachePath` function in cache.ts accounts for a potential value.

Changes:

- Include `internalCacheFolder` in cache clear path
- Added tests for cache clearing for both default and internalCacheFolder cases
- Update mock repo to include clear script