### PR TITLE
assigned the default concurrency to os.cpus().length - 1

### DIFF
--- a/change/lage-af625e96-88ed-45b0-bdc4-af9cfcc2f807.json
+++ b/change/lage-af625e96-88ed-45b0-bdc4-af9cfcc2f807.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "lage",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/lage-af625e96-88ed-45b0-bdc4-af9cfcc2f807.json
+++ b/change/lage-af625e96-88ed-45b0-bdc4-af9cfcc2f807.json
@@ -1,10 +1,10 @@
 {
   "type": "patch",
   "comment": {
-    "title": "",
-    "value": ""
+    "title": "Lage Concurrency",
+    "value": "assigned the default concurrency to os.cpus().length - 1"
   },
   "packageName": "lage",
-  "email": "email not defined",
+  "email": "pushkargupta@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/docs/docs/Guide/cli.md
+++ b/docs/docs/Guide/cli.md
@@ -62,7 +62,7 @@ _type: number_
 
 number of parallel tasks that can be run at a time
 
-By default, this is the number of CPU cores detected by `os.cpus().length`,
+By default, this is the number of CPU cores detected by `os.cpus().length` - 1,
 change to any number to achieve desired concurrency.
 
   

--- a/packages/lage/src/config/getConfig.ts
+++ b/packages/lage/src/config/getConfig.ts
@@ -36,7 +36,7 @@ export function getConfig(cwd: string): Config {
   }
 
   const dist = parsedArgs.experimentDist || false;
-  const concurrency = parsedArgs.concurrency || configResults?.config.concurrency || os.cpus().length;
+  const concurrency = parsedArgs.concurrency || configResults?.config.concurrency || os.cpus().length - 1;
 
   return {
     reporter: parsedArgs.reporter || "npmLog",

--- a/packages/lage/src/types/CliOptions.ts
+++ b/packages/lage/src/types/CliOptions.ts
@@ -15,7 +15,7 @@ export interface CliOptions {
   /**
    * number of parallel tasks that can be run at a time
    *
-   * By default, this is the number of CPU cores detected by `os.cpus().length`,
+   * By default, this is the number of CPU cores detected by `os.cpus().length` - 1,
    * change to any number to achieve desired concurrency.
    */
   concurrency: number;


### PR DESCRIPTION
Sometimes when running a large number of tasks using lage, we may run into memory issues and hangs when all the availableCPU cores are loaded. This change is to reduce the number of allocated cores by 1.

assigned the default concurrency to os.cpus().length - 1. 


