### PR TITLE
upgrade lage self-dependency to update vulnerable versions of parse-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "beachball": "2.26.0",
     "gh-pages": "2.2.0",
     "jest": "^27.2.0",
-    "lage-npm": "npm:lage@1.7.2"
+    "lage-npm": "npm:lage@1.7.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,18 +3627,6 @@ backfill-config@^6.3.0:
     fs-extra "^8.1.0"
     pkg-dir "^4.2.0"
 
-backfill-hasher@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.npmjs.org/backfill-hasher/-/backfill-hasher-6.4.1.tgz"
-  integrity sha512-ZiIo77UCBgTnojK9+4DQVEn9yeJQn2+KW9gh22coS45I3pNqAHflxALIyfIosQwz7Fos/peGj8iuWHw2Ieuurg==
-  dependencies:
-    "@rushstack/package-deps-hash" "^3.2.4"
-    backfill-config "^6.3.0"
-    backfill-logger "^5.1.3"
-    find-up "^5.0.0"
-    fs-extra "^8.1.0"
-    workspace-tools "^0.18.2"
-
 backfill-hasher@^6.4.2:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.4.2.tgz#bb037506d7c3197cb4a2beef29316e1c58e5ac06"
@@ -3667,23 +3655,6 @@ backfill-utils-dotenv@^5.1.1:
   dependencies:
     dotenv "^8.1.0"
     find-up "^5.0.0"
-
-backfill@^6.1.20:
-  version "6.1.20"
-  resolved "https://registry.npmjs.org/backfill/-/backfill-6.1.20.tgz"
-  integrity sha512-sD4DPugvZodbgNTfDc6so3VXIjpyY4e+5S/+wDXsjc6I/tEtT+pu7U/WxLGajMXsvusU3wM7wqgtGHZhxvSrIw==
-  dependencies:
-    anymatch "^3.0.3"
-    backfill-cache "^5.6.1"
-    backfill-config "^6.3.0"
-    backfill-hasher "^6.4.1"
-    backfill-logger "^5.1.3"
-    backfill-utils-dotenv "^5.1.1"
-    chokidar "^3.2.1"
-    execa "^4.0.0"
-    fs-extra "^8.1.0"
-    globby "^11.0.0"
-    yargs "^16.1.1"
 
 backfill@^6.1.21:
   version "6.1.21"
@@ -6367,14 +6338,6 @@ gh-pages@2.2.0:
     fs-extra "^8.1.0"
     globby "^6.1.0"
 
-git-up@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz"
-  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
-  dependencies:
-    is-ssh "^1.3.0"
-    parse-url "^5.0.0"
-
 git-up@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-6.0.0.tgz#dbd6e4eee270338be847a0601e6d0763c90b74db"
@@ -6382,13 +6345,6 @@ git-up@^6.0.0:
   dependencies:
     is-ssh "^1.4.0"
     parse-url "^7.0.2"
-
-git-url-parse@^11.1.2:
-  version "11.1.2"
-  resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz"
-  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
-  dependencies:
-    git-up "^4.0.0"
 
 git-url-parse@^12.0.0:
   version "12.0.0"
@@ -7285,7 +7241,7 @@ is-root@^2.1.0:
   resolved "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
-is-ssh@^1.3.0, is-ssh@^1.4.0:
+is-ssh@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.4.0.tgz#4f8220601d2839d8fa624b3106f8e8884f01b8b2"
   integrity sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==
@@ -8221,14 +8177,15 @@ klona@^2.0.5:
   resolved "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-"lage-npm@npm:lage@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-1.7.2.tgz#249585a03b054551d74d798aa2b6f2aada749438"
-  integrity sha512-Vfw7uOz5qqHXNPV1cLnJiFhcL/e9kMR+xX56UTRK23KYaQ3sFurAMtMfvUNJnn++qUP64JE+nXZ6JMMiUxo2Ww==
+"lage-npm@npm:lage@1.7.7":
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-1.7.7.tgz#252f375c1c75a84f48c88476fa00485d5ab94551"
+  integrity sha512-fJbAsCbltotfGMhVMIWv8VnvjQP6ZQoWie7x7ayB5ziOZuGeQo45pooTVSwO2WVyl/0KW+KcQ+wtNSgU6LMo8A==
   dependencies:
+    "@lage-run/logger" "*"
     "@xmldom/xmldom" "^0.8.0"
     abort-controller "^3.0.0"
-    backfill "^6.1.20"
+    backfill "^6.1.21"
     backfill-cache "^5.6.1"
     backfill-config "^6.3.0"
     backfill-logger "^5.1.3"
@@ -8237,13 +8194,12 @@ klona@^2.0.5:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"
     fast-glob "^3.2.2"
-    git-url-parse "^11.1.2"
     ioredis "^4.28.0"
     npmlog "^4.1.2"
     p-graph "^1.1.1"
     p-limit "^3.1.0"
     p-profiler "^0.2.1"
-    workspace-tools "^0.23.0"
+    workspace-tools "^0.26.0"
     yargs-parser "^18.1.3"
 
 latest-version@^5.1.0:
@@ -8904,11 +8860,6 @@ normalize-url@^1.0.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-normalize-url@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz"
-  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-
 normalize-url@^4.1.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz"
@@ -9221,30 +9172,12 @@ parse-numeric-range@^1.3.0:
   resolved "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz"
   integrity sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==
 
-parse-path@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz"
-  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
-  dependencies:
-    is-ssh "^1.3.0"
-    protocols "^1.4.0"
-
 parse-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-5.0.0.tgz#f933152f3c6d34f4cf36cfc3d07b138ac113649d"
   integrity sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==
   dependencies:
     protocols "^2.0.0"
-
-parse-url@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz"
-  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
-  dependencies:
-    is-ssh "^1.3.0"
-    normalize-url "^3.3.0"
-    parse-path "^4.0.0"
-    protocols "^1.4.0"
 
 parse-url@^7.0.2:
   version "7.0.2"
@@ -9917,11 +9850,6 @@ property-information@^5.0.0, property-information@^5.3.0:
   integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
   dependencies:
     xtend "^4.0.0"
-
-protocols@^1.4.0:
-  version "1.4.7"
-  resolved "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz"
-  integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
 
 protocols@^2.0.0, protocols@^2.0.1:
   version "2.0.1"
@@ -12217,32 +12145,6 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
-workspace-tools@^0.18.2:
-  version "0.18.4"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.18.4.tgz#a59ca6dc864d07aafc06a9ff4a9ff093456b8765"
-  integrity sha512-ZdhlB4NEC3uJ4eW7snyHKOfzMC00HXWO2QbIU3aY8XBdtE+VrU2ajv+oxDUIZfCLD4Wlk3ltWaPt4Jk6IC9bMA==
-  dependencies:
-    "@yarnpkg/lockfile" "^1.1.0"
-    find-up "^4.1.0"
-    git-url-parse "^11.1.2"
-    globby "^11.0.0"
-    jju "^1.4.0"
-    multimatch "^4.0.0"
-    read-yaml-file "^2.0.0"
-
-workspace-tools@^0.23.0:
-  version "0.23.3"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.23.3.tgz#1833c848170d1370675535963778524d0ad0aef4"
-  integrity sha512-8JWfnW9Kj24X8l4sOvwN77cxExBM57fpbjo+UqvFzY7L9FeyY4MUCqpLKpKARkK8okF/PFPOL9Dl1QgsEMT4yw==
-  dependencies:
-    "@yarnpkg/lockfile" "^1.1.0"
-    find-up "^4.1.0"
-    git-url-parse "^12.0.0"
-    globby "^11.0.0"
-    jju "^1.4.0"
-    multimatch "^4.0.0"
-    read-yaml-file "^2.0.0"
 
 workspace-tools@^0.24.0:
   version "0.24.0"


### PR DESCRIPTION
Updates lage's self-dependency to 1.7.7 to incorporate #327

This should remove the vulnerable versions of parse-path from the dev environment for lage