### PR TITLE
Fixed rollup bundle output; fixes global targets

### DIFF
--- a/change/@lage-run-lage-bf9bf8fe-4118-4058-9294-6b2b41647e08.json
+++ b/change/@lage-run-lage-bf9bf8fe-4118-4058-9294-6b2b41647e08.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes the bundle output to be with code!",
+  "packageName": "@lage-run/lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-reporters-0ad1bec6-43e6-40f7-87f1-cf7d5be663e6.json
+++ b/change/@lage-run-reporters-0ad1bec6-43e6-40f7-87f1-cf7d5be663e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Logs summary correctly for global targets",
+  "packageName": "@lage-run/reporters",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-b4d7e488-a445-49d3-a7ac-d3b91376cf53.json
+++ b/change/@lage-run-target-graph-b4d7e488-a445-49d3-a7ac-d3b91376cf53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "disables cache for global targets (for now, since backfill doesn't support it)",
+  "packageName": "@lage-run/target-graph",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -14,9 +14,6 @@ module.exports = {
       },
     },
     start: [],
-    "#format": {
-      cache: false
-    },
 
     // TODO: a temporary hack to allow both of these projects to run build with lage
     "@lage-run/docs-beta#build": ["@lage/docs#build"],

--- a/lage.config.js
+++ b/lage.config.js
@@ -14,6 +14,9 @@ module.exports = {
       },
     },
     start: [],
+    "#format": {
+      cache: false
+    },
 
     // TODO: a temporary hack to allow both of these projects to run build with lage
     "@lage-run/docs-beta#build": ["@lage/docs#build"],

--- a/packages/lage2/package.json
+++ b/packages/lage2/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lage-run/lage",
   "version": "2.1.0",
+  "main": "dist/main.js",
   "bin": {
     "lage": "dist/lage.js"
   },

--- a/packages/lage2/rollup.config.js
+++ b/packages/lage2/rollup.config.js
@@ -3,10 +3,9 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { terser } from "rollup-plugin-terser";
 import alias from "@rollup/plugin-alias";
-import multi from "@rollup/plugin-multi-entry";
 
-export default {
-  input: ["@lage-run/cli/lib/cli.js", "index.js"],
+export default [{
+  input: "@lage-run/cli/lib/cli.js",
   output: {
     banner: "#!/usr/bin/env node",
     sourcemap: "inline",
@@ -30,6 +29,25 @@ export default {
     }),
     json(),
     terser(),
-    multi(),
   ],
-};
+}, {
+  input: "./index.js",
+  output: {
+    file: "dist/main.js",
+    format: "cjs",
+    exports: "auto",
+    sourcemap: true,
+  },
+  plugins: [
+    nodeResolve({
+      // Since we are produce CJS, let's resolve main first!
+      mainFields: ["main", "module"],
+      preferBuiltins: true,
+    }),
+    commonjs({
+      ignoreDynamicRequires: true,
+    }),
+    json(),
+    terser(),
+  ]
+}];

--- a/packages/reporters/src/NpmLogReporter.ts
+++ b/packages/reporters/src/NpmLogReporter.ts
@@ -209,7 +209,7 @@ export class NpmLogReporter implements Reporter {
         const { packageName, task } = getPackageAndTask(targetId);
         const failureLogs = this.logEntries.get(targetId);
 
-        this.print(`[${colors.pkg(packageName)} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
+        this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
 
         if (failureLogs) {
           for (const entry of failureLogs) {

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -57,8 +57,10 @@ export class TargetGraphBuilder {
       id: targetId,
       label: targetId,
       type: config.type,
-      task: targetId,
-      cache: cache !== false,
+      task,
+      // TODO: backfill currently cannot cache global targets!
+      // NOTE: We should force cache inputs to be defined for global targets
+      cache: false,
       cwd: this.root,
       dependencies: dependsOn ?? deps ?? [],
       inputs,


### PR DESCRIPTION
1. rollup bundle with the multi-entry plugin was not working as expected - manually specifying multiple bundles, for now. Will investigate this as time permits
2. global targets cannot be cached by backfill - so we must turn that off in order to allow for global targets to execute!