### PR TITLE
Hoist widely-used devDependencies to the repo root

### DIFF
--- a/change/@lage-run-cache-dab0c9de-9617-4a61-bc15-ef8cb71c661e.json
+++ b/change/@lage-run-cache-dab0c9de-9617-4a61-bc15-ef8cb71c661e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/cache",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-cli-4c4aa7c8-2479-488f-8c94-1412f7b2a695.json
+++ b/change/@lage-run-cli-4c4aa7c8-2479-488f-8c94-1412f7b2a695.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/cli",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-lage-d5741f56-f3b2-4e06-b528-972419d66b9a.json
+++ b/change/@lage-run-lage-d5741f56-f3b2-4e06-b528-972419d66b9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-logger-6ed08f03-0b16-4bc6-93c2-05dfb111024b.json
+++ b/change/@lage-run-logger-6ed08f03-0b16-4bc6-93c2-05dfb111024b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/logger",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-reporters-e9ca7eb6-6ffb-4549-907a-b7a33c91dc91.json
+++ b/change/@lage-run-reporters-e9ca7eb6-6ffb-4549-907a-b7a33c91dc91.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/reporters",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-scheduler-95785230-979e-487d-8d9b-18db7bc70d01.json
+++ b/change/@lage-run-scheduler-95785230-979e-487d-8d9b-18db7bc70d01.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/scheduler",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-target-graph-3d07f6b3-ece5-475b-9bc4-c7fde2bcf946.json
+++ b/change/@lage-run-target-graph-3d07f6b3-ece5-475b-9bc4-c7fde2bcf946.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/target-graph",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@lage-run-worker-threads-pool-c2383d68-c957-4293-ad4a-5d06e155ec25.json
+++ b/change/@lage-run-worker-threads-pool-c2383d68-c957-4293-ad4a-5d06e155ec25.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/lage-58b64c06-ed9d-4f79-9d4d-cc9a79b82563.json
+++ b/change/lage-58b64c06-ed9d-4f79-9d4d-cc9a79b82563.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Hoist widely-used devDependencies to the repo root",
+  "packageName": "lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,8 +31,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.1.0",
     "@tsconfig/docusaurus": "1.0.6",
-    "identity-obj-proxy": "3.0.0",
-    "typescript": "4.6.4"
+    "identity-obj-proxy": "3.0.0"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -27,10 +27,14 @@
     "format:check": "prettier --config .prettierrc packages/**/*.ts **/*.json --check --ignore-path .gitignore"
   },
   "devDependencies": {
-    "prettier": "2.7.1",
+    "@types/jest": "29.0.3",
+    "@types/node": "14.18.29",
     "beachball": "2.30.2",
     "gh-pages": "4.0.0",
     "jest": "29.0.3",
-    "lage-npm": "npm:@lage-run/lage@latest"
+    "lage-npm": "npm:@lage-run/lage@2.1.7",
+    "prettier": "2.7.1",
+    "ts-jest": "29.0.1",
+    "typescript": "4.6.4"
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -26,9 +26,7 @@
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",
-    "@types/jest": "29.0.3",
     "@types/mock-fs": "4.13.1",
-    "@types/node": "14.18.29",
     "monorepo-scripts": "*",
     "mock-fs": "5.1.4"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -25,7 +25,7 @@
     "workspace-tools": "^0.27.0"
   },
   "devDependencies": {
-    "@lage-run/monorepo-fixture": "^0.1.0",
+    "@lage-run/monorepo-fixture": "*",
     "@types/jest": "29.0.3",
     "@types/mock-fs": "4.13.1",
     "@types/node": "14.18.29",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,12 +26,7 @@
     "workspace-tools": "^0.27.0"
   },
   "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
-    "@lage-run/monorepo-fixture": "*",
-    "jest": "29.0.3",
-    "ts-jest": "29.0.1",
-    "typescript": "4.6.4"
+    "@lage-run/monorepo-fixture": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/jest": "29.0.3",
     "@types/node": "14.18.29",
-    "@lage-run/monorepo-fixture": "^0.1.0",
+    "@lage-run/monorepo-fixture": "*",
     "jest": "29.0.3",
     "ts-jest": "29.0.1",
     "typescript": "4.6.4"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -21,11 +21,6 @@
     "@lage-run/cli": "^0.3.8"
   },
   "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
-    "jest": "29.0.3",
-    "memory-streams": "0.1.3",
-    "ts-jest": "29.0.1",
-    "typescript": "4.6.4"
+    "memory-streams": "0.1.3"
   }
 }

--- a/packages/lage/package.json
+++ b/packages/lage/package.json
@@ -50,16 +50,9 @@
     "@types/cosmiconfig": "6.0.0",
     "@types/execa": "2.0.0",
     "@types/ioredis": "4.28.10",
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
     "@types/npmlog": "4.1.4",
     "@types/p-queue": "3.2.1",
     "@types/yargs-parser": "15.0.0",
-    "beachball": "2.30.2",
-    "gh-pages": "4.0.0",
-    "jest": "29.0.3",
-    "ts-jest": "29.0.1",
-    "ts-node": "8.10.2",
-    "typescript": "4.6.4"
+    "ts-node": "8.10.2"
   }
 }

--- a/packages/lage2/package.json
+++ b/packages/lage2/package.json
@@ -9,8 +9,8 @@
     "build": "rollup --config ./rollup.config.js"
   },
   "devDependencies": {
-    "@lage-run/cli": "^0.3.8",
-    "@lage-run/scheduler": "^0.3.5",
+    "@lage-run/cli": "*",
+    "@lage-run/scheduler": "*",
     "rollup": "2.79.0",
     "@rollup/plugin-commonjs": "22.0.2",
     "@rollup/plugin-node-resolve": "13.3.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,13 +13,7 @@
     "start": "tsc -w --preserveWatchOutput",
     "test": "jest"
   },
-  "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
-    "jest": "29.0.3",
-    "ts-jest": "29.0.1",
-    "typescript": "4.6.4"
-  },
+  "devDependencies": {},
   "publishConfig": {
     "access": "public"
   },

--- a/packages/monorepo-fixture/package.json
+++ b/packages/monorepo-fixture/package.json
@@ -18,8 +18,6 @@
     "workspace-tools": "^0.27.0"
   },
   "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
     "execa": "5.1.1",
     "monorepo-scripts": "*"
   }

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -23,12 +23,7 @@
     "gradient-string": "^2.0.1"
   },
   "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
-    "jest": "29.0.3",
-    "memory-streams": "0.1.3",
-    "ts-jest": "29.0.1",
-    "typescript": "4.6.4"
+    "memory-streams": "0.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -26,8 +26,6 @@
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
     "@types/workerpool": "6.1.0",
     "monorepo-scripts": "*"
   },

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -25,7 +25,7 @@
     "workspace-tools": "^0.27.0"
   },
   "devDependencies": {
-    "@lage-run/monorepo-fixture": "^0.1.0",
+    "@lage-run/monorepo-fixture": "*",
     "@types/jest": "29.0.3",
     "@types/node": "14.18.29",
     "@types/workerpool": "6.1.0",

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -18,8 +18,6 @@
     "workspace-tools": "^0.27.0"
   },
   "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
     "monorepo-scripts": "*"
   },
   "publishConfig": {

--- a/packages/worker-threads-pool/package.json
+++ b/packages/worker-threads-pool/package.json
@@ -15,8 +15,6 @@
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {
-    "@types/jest": "29.0.3",
-    "@types/node": "14.18.29",
     "monorepo-scripts": "*"
   },
   "publishConfig": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,10 +17,10 @@
     {
       "fileMatch": ["^package.json$"],
       "matchStrings": [
-        "lage-npm\": \"npm:lage@(?<currentValue>[~^]?\\d+\\.\\d+\\.\\d+)"
+        "lage-npm\": \"npm:@lage-run/lage@(?<currentValue>[~^]?\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "lage-npm",
-      "packageNameTemplate": "lage",
+      "packageNameTemplate": "@lage-run/lage",
       "datasourceTemplate": "npm",
       "depTypeTemplate": "devDependencies"
     }
@@ -37,6 +37,11 @@
       "matchPackageNames": ["backfill", "workspace-tools", "p-graph", "p-profiler"],
       "matchUpdateTypes": ["major", "minor", "patch", "bump"],
       "dependencyDashboardApproval": false
+    },
+    {
+      // Don't try to pin or otherwise modify in-repo deps
+      "matchPackagePrefixes": ["@lage-run/"],
+      "enabled": false
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7690,7 +7690,7 @@ klona@^2.0.5:
   resolved "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-"lage-npm@npm:@lage-run/lage@latest":
+"lage-npm@npm:@lage-run/lage@2.1.7":
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/@lage-run/lage/-/lage-2.1.7.tgz#ba5ec17524bbded2390e7db257b25982fdc5f86e"
   integrity sha512-bN9nvEtv4Otwl5rZviQThm+nPMySp+PFp7Lc9ETRdLq/+SQjUi7UZzvT+0IqekpEPj1ha6gdR+IPFc8YkqfjMw==


### PR DESCRIPTION
This PR makes some changes to how devDependency versions are declared, which I've found to be helpful in other repos:

- Hoist `devDependencies` which are used in most packages to be declared at the repo root rather than in the individual packages. There are pros and cons to this strategy ([discussed here](https://www.npmjs.com/package/better-deps#why)), but I think it's overall a good idea for the following reasons:
  - Ensures that the exact intended version is picked up at build time or as a peer (otherwise yarn may choose an unexpected version to install at the root, which is implicitly picked up and causes hard-to-debug errors)
    - **EDIT:** I guess the custom `monorepo-scripts` wrapper was sort of handling this with custom resolution logic, but why have a wrapper (which might have its own bugs) when there's a simpler way to handle it natively?
  - Reduces noise from Renovate updating dev deps (modifying one package file, not all the package files)
  - One of the possible cons of hoisting dev deps is making it harder to see where deps are used, but for deps that are very widely used, this is not really relevant

- Use `*` as the version for in-repo `devDependencies`, to ensure there are never issues with versions getting out of sync somehow