### PR TITLE
Update PR workflow OS checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,17 +29,17 @@ jobs:
       - run: yarn
 
       - name: Code Format Check
-        if: ${{ matrix.os.startsWith('ubuntu') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: yarn format:check
 
       - name: Check Change Files
-        if: ${{ matrix.os.startsWith('ubuntu') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: yarn checkchange
 
       - name: Build, Test (Windows)
-        if: ${{ matrix.os.startsWith('windows') }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
         run: yarn lage build test --scope=!@lage-run/lage
 
       - name: Build, Test, Lint (Linux)
-        if: ${{ matrix.os.startsWith('ubuntu') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: yarn lage build test lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,33 +13,33 @@ jobs:
       matrix:
         node-version: [16.x]
         os: [ubuntu-latest, windows-2019]
+
     runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: yarn
+
       - name: Code Format Check
-        run: |
-              if [ "$RUNNER_OS" == "Linux" ]; then
-                yarn format:check
-              fi
-        shell: bash
+        if: ${{ matrix.os.startsWith('ubuntu') }}
+        run: yarn format:check
+
       - name: Check Change Files
-        run: |
-              if [ "$RUNNER_OS" == "Linux" ]; then
-                yarn format:check
-              fi
-        shell: bash
-      - name: Build, Test, Lint
-        run: |
-              if [ "$RUNNER_OS" == "Linux" ]; then
-                yarn lage build test lint
-              elif [ "$RUNNER_OS" == "Windows" ]; then
-                yarn lage build test --scope=!@lage-run/lage
-              fi
-        shell: bash
+        if: ${{ matrix.os.startsWith('ubuntu') }}
+        run: yarn checkchange
+
+      - name: Build, Test (Windows)
+        if: ${{ matrix.os.startsWith('windows') }}
+        run: yarn lage build test --scope=!@lage-run/lage
+
+      - name: Build, Test, Lint (Linux)
+        if: ${{ matrix.os.startsWith('ubuntu') }}
+        run: yarn lage build test lint


### PR DESCRIPTION
Use [conditions](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution) instead of in-task env checks to determine whether to run some of the build steps.