### PR TITLE
bug fix: WorkerRunner logging out of order

### DIFF
--- a/change/@lage-run-cli-aca511a1-bdd7-40bf-96b2-2da95d7be83e.json
+++ b/change/@lage-run-cli-aca511a1-bdd7-40bf-96b2-2da95d7be83e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing logging in workerpools to not be out of order",
+  "packageName": "@lage-run/cli",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-40d26a11-35da-426b-a9c4-d03cf49e8f54.json
+++ b/change/@lage-run-scheduler-40d26a11-35da-426b-a9c4-d03cf49e8f54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing logging in workerpools to not be out of order",
+  "packageName": "@lage-run/scheduler",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-worker-threads-pool-5b41b25a-b6be-468b-abc8-ecffe0c0a1d5.json
+++ b/change/@lage-run-worker-threads-pool-5b41b25a-b6be-468b-abc8-ecffe0c0a1d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Get rid of unneeded hack around stream pipe",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -5,11 +5,12 @@ import { findNpmClient } from "../../workspace/findNpmClient";
 import { getConfig } from "../../config/getConfig";
 import { getFilteredPackages } from "../../filter/getFilteredPackages";
 import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
-import { NpmScriptRunner, SimpleScheduler, WorkerRunner, TargetRunnerPicker, TargetRunner } from "@lage-run/scheduler";
-import { TargetGraphBuilder } from "@lage-run/target-graph";
-import createLogger, { LogLevel, Reporter } from "@lage-run/logger";
 import { initializeReporters } from "../../reporters/initialize";
-import { ReporterInitOptions } from "../../types/LoggerOptions";
+import { NpmScriptRunner, SimpleScheduler, WorkerRunner, TargetRunnerPicker } from "@lage-run/scheduler";
+import { TargetGraphBuilder } from "@lage-run/target-graph";
+import createLogger from "@lage-run/logger";
+import type { ReporterInitOptions } from "../../types/LoggerOptions";
+import type { TargetRunner } from "@lage-run/scheduler";
 
 function filterArgsForTasks(args: string[]) {
   const optionsPosition = args.findIndex((arg) => arg.startsWith("-"));

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -4,7 +4,7 @@ import os from "os";
 import type { AbortSignal } from "abort-controller";
 import type { Logger } from "@lage-run/logger";
 import type { Target, TargetConfig } from "@lage-run/target-graph";
-import type { TargetCaptureStreams, TargetRunner } from "../types/TargetRunner";
+import type { TargetRunner } from "../types/TargetRunner";
 import type { Worker } from "worker_threads";
 
 export interface WorkerRunnerOptions {
@@ -107,10 +107,9 @@ export class WorkerRunner implements TargetRunner {
   captureStream(target: Target, worker: Worker) {
     const { logger } = this.options;
 
-    let stdout = worker.stdout;
-    let stderr = worker.stderr;
-
-    const onData = (data) => logger.log(LogLevel.info, data, { target });
+    const stdout = worker.stdout;
+    const stderr = worker.stderr;
+    const onData = (data: string) => logger.log(LogLevel.info, data, { target });
 
     stdout.setEncoding("utf-8");
     stdout.on("data", onData);

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -104,53 +104,27 @@ export class WorkerRunner implements TargetRunner {
     return this.pools[id];
   }
 
-  captureStream(target: Target, worker: Worker, captureStreams: TargetCaptureStreams = {}) {
+  captureStream(target: Target, worker: Worker) {
     const { logger } = this.options;
 
     let stdout = worker.stdout;
     let stderr = worker.stderr;
 
-    const releaseStreams = {
-      stdout: () => {
-        // pass
-      },
-      stderr: () => {
-        // pass
-      },
-    };
+    const onData = (data) => logger.log(LogLevel.info, data, { target });
 
-    if (stdout) {
-      if (captureStreams.stdout) {
-        stdout = stdout.pipe(captureStreams.stdout);
-      }
+    stdout.setEncoding("utf-8");
+    stdout.on("data", onData);
 
-      releaseStreams.stdout = logger.stream(LogLevel.verbose, stdout, { target, tid: worker.threadId });
-    }
-
-    if (stderr) {
-      if (captureStreams.stderr) {
-        stderr = stderr.pipe(captureStreams.stderr);
-      }
-
-      releaseStreams.stderr = logger.stream(LogLevel.verbose, stderr, { target, tid: worker.threadId });
-    }
+    stderr.setEncoding("utf-8");
+    stderr.on("data", onData);
 
     return () => {
-      if (captureStreams.stdout && stdout) {
-        stdout.unpipe(captureStreams.stdout);
-        captureStreams.stdout.destroy();
-      }
-
-      if (captureStreams.stderr && stderr) {
-        stderr.unpipe(captureStreams.stderr);
-        captureStreams.stderr.destroy();
-      }
-      releaseStreams.stdout();
-      releaseStreams.stderr();
+      stdout.off("data", onData);
+      stderr.off("data", onData);
     };
   }
 
-  async run(target: Target, abortSignal?: AbortSignal, captureStreams: TargetCaptureStreams = {}) {
+  async run(target: Target, abortSignal?: AbortSignal) {
     if (abortSignal) {
       if (abortSignal.aborted) {
         return;
@@ -171,17 +145,17 @@ export class WorkerRunner implements TargetRunner {
     await pool.exec(
       { target },
       (worker) => {
-        cleanupStreams = this.captureStream(target, worker, captureStreams);
+        cleanupStreams = this.captureStream(target, worker);
       },
-      (worker) => {
+      () => {
         cleanupStreams();
       }
     );
   }
 
-  cleanup() {
+  async cleanup() {
     for (const pool of Object.values(this.pools)) {
-      pool.close();
+      await pool.close();
     }
   }
 }

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -2,17 +2,11 @@ import { parentPort } from "node:worker_threads";
 
 export function registerWorker(fn: (data: any) => Promise<void> | void) {
   parentPort?.on("message", async (task) => {
-    // setTimeout are used below to allow streams to be read by the Logger's stream() API before the "success" or "error" results are posted
     try {
       const results = await fn(task);
-
-      setTimeout(() => {
-        parentPort?.postMessage({ err: undefined, results });
-      }, 0);
+      parentPort?.postMessage({ err: undefined, results });
     } catch (err) {
-      setTimeout(() => {
-        parentPort?.postMessage({ err, results: undefined });
-      }, 0);
+      parentPort?.postMessage({ err, results: undefined });
     }
   });
 }


### PR DESCRIPTION
Due to the nature of streams, we cannot simply pipe() the worker.stdout pipe(). We can opt for something with a bit more control: capturing stream by manually writing the data to the logger. The precedence is done inside `jest-worker`:

https://github.com/facebook/jest/blob/f988721c02e8442b39d6dd92dba9bc2a8dd10ff0/packages/jest-worker/src/workers/NodeThreadsWorker.ts#L121

We set the output to utf-8 encoding & then capture all the data calls & redirect to logger.log.