### PR TITLE
Added random color for package output

### DIFF
--- a/change/lage-a2289ed4-51e0-41c0-8e21-6e3536d80a82.json
+++ b/change/lage-a2289ed4-51e0-41c0-8e21-6e3536d80a82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added random color for package output",
+  "packageName": "lage",
+  "email": "33559264+nemanjatesic@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/src/logger/reporters/NpmLogReporter.ts
+++ b/packages/lage/src/logger/reporters/NpmLogReporter.ts
@@ -29,8 +29,8 @@ const pkgColors = {
   cyanBright: chalk.cyanBright,
   greenBright: chalk.greenBright,
   yellow: chalk.yellow,
-  magenta: chalk.magenta
-}
+  magenta: chalk.magenta,
+};
 
 function getRandomPkgColor(): Chalk {
   const pkgColorValues = Object.values(pkgColors);
@@ -39,7 +39,7 @@ function getRandomPkgColor(): Chalk {
 
 const pkgNameToPkgColorMap = new Map<string, Chalk>();
 
-function getColorForPkg(pkg: string): Chalk  {
+function getColorForPkg(pkg: string): Chalk {
   if (!pkgNameToPkgColorMap.has(pkg)) {
     const color = getRandomPkgColor();
     pkgNameToPkgColorMap.set(pkg, color);

--- a/packages/lage/src/logger/reporters/NpmLogReporter.ts
+++ b/packages/lage/src/logger/reporters/NpmLogReporter.ts
@@ -8,6 +8,7 @@ import { RunContext } from "../../types/RunContext";
 import { getPackageAndTask, getTargetId } from "../../task/taskId";
 import { LoggerOptions } from "../../types/LoggerOptions";
 import { TargetStatus } from "../../types/TargetStatus";
+import crypto from "crypto";
 
 const maxLengths = {
   pkg: 0,
@@ -23,29 +24,24 @@ const colors = {
   silly: chalk.green,
 };
 
-const pkgColors = {
-  red: chalk.red,
-  blue: chalk.blue,
-  cyanBright: chalk.cyanBright,
-  greenBright: chalk.greenBright,
-  yellow: chalk.yellow,
-  magenta: chalk.magenta,
-};
+const pkgColors: Chalk[] = [chalk.red, chalk.blue, chalk.cyanBright, chalk.greenBright, chalk.yellow, chalk.magenta];
 
-function getRandomPkgColor(): Chalk {
-  const pkgColorValues = Object.values(pkgColors);
-  return pkgColorValues[Math.floor(Math.random() * pkgColorValues.length)];
+function hashStringToNumber(str: string): number {
+  const hash = crypto.createHash("sha256");
+  hash.update(str);
+  const hex = hash.digest("hex").substring(0, 6);
+  return parseInt(hex, 16);
 }
 
-const pkgNameToPkgColorMap = new Map<string, Chalk>();
+const pkgNameToIndexInPkgColorArray = new Map<string, number>();
 
 function getColorForPkg(pkg: string): Chalk {
-  if (!pkgNameToPkgColorMap.has(pkg)) {
-    const color = getRandomPkgColor();
-    pkgNameToPkgColorMap.set(pkg, color);
+  if (!pkgNameToIndexInPkgColorArray.has(pkg)) {
+    const index = hashStringToNumber(pkg) % pkgColors.length;
+    pkgNameToIndexInPkgColorArray.set(pkg, index);
   }
 
-  return pkgNameToPkgColorMap.get(pkg)!;
+  return pkgColors[pkgNameToIndexInPkgColorArray.get(pkg)!];
 }
 
 function getTaskLogPrefix(pkg: string, task: string) {

--- a/packages/lage/src/logger/reporters/NpmLogReporter.ts
+++ b/packages/lage/src/logger/reporters/NpmLogReporter.ts
@@ -27,7 +27,7 @@ const colors = {
 const pkgColors: Chalk[] = [chalk.red, chalk.blue, chalk.cyanBright, chalk.greenBright, chalk.yellow, chalk.magenta];
 
 function hashStringToNumber(str: string): number {
-  const hash = crypto.createHash("sha256");
+  const hash = crypto.createHash("md5");
   hash.update(str);
   const hex = hash.digest("hex").substring(0, 6);
   return parseInt(hex, 16);

--- a/packages/lage/src/logger/reporters/NpmLogReporter.ts
+++ b/packages/lage/src/logger/reporters/NpmLogReporter.ts
@@ -1,5 +1,5 @@
 import log from "npmlog";
-import chalk from "chalk";
+import chalk, { Chalk } from "chalk";
 import { Reporter } from "./Reporter";
 import { LogLevel } from "../LogLevel";
 import { LogEntry, LogStructuredData, TaskData, InfoData } from "../LogEntry";
@@ -23,8 +23,34 @@ const colors = {
   silly: chalk.green,
 };
 
+const pkgColors = {
+  red: chalk.red,
+  blue: chalk.blue,
+  cyanBright: chalk.cyanBright,
+  greenBright: chalk.greenBright,
+  yellow: chalk.yellow,
+  magenta: chalk.magenta
+}
+
+function getRandomPkgColor(): Chalk {
+  const pkgColorValues = Object.values(pkgColors);
+  return pkgColorValues[Math.floor(Math.random() * pkgColorValues.length)];
+}
+
+const pkgNameToPkgColorMap = new Map<string, Chalk>();
+
+function getColorForPkg(pkg: string): Chalk  {
+  if (!pkgNameToPkgColorMap.has(pkg)) {
+    const color = getRandomPkgColor();
+    pkgNameToPkgColorMap.set(pkg, color);
+  }
+
+  return pkgNameToPkgColorMap.get(pkg)!;
+}
+
 function getTaskLogPrefix(pkg: string, task: string) {
-  return `${colors.pkg(pkg.padStart(maxLengths.pkg))} ${colors.task(task.padStart(maxLengths.task))}`;
+  const pkgColor = getColorForPkg(pkg);
+  return `${pkgColor(pkg.padStart(maxLengths.pkg))} ${colors.task(task.padStart(maxLengths.task))}`;
 }
 
 function normalize(prefixOrMessage: string, message?: string) {
@@ -95,7 +121,8 @@ export class NpmLogReporter implements Reporter {
     const data = entry.data as TaskData;
 
     if (data.status) {
-      const pkgTask = this.options.grouped ? `${chalk.magenta(pkg)} ${chalk.cyan(task)}` : "";
+      const pkgColor = getColorForPkg(pkg);
+      const pkgTask = this.options.grouped ? `${pkgColor(pkg)} ${chalk.cyan(task)}` : "";
 
       switch (data.status) {
         case "started":


### PR DESCRIPTION
Added printing of different colors for each package for easier spotting of differences
Example for build:
![image](https://user-images.githubusercontent.com/33559264/190880629-b1642d63-199b-46c2-9be8-cfb74d064291.png)
Example for build --grouped:
![image](https://user-images.githubusercontent.com/33559264/190880668-cc2240fc-a46b-428e-ab75-c67ac44d5d01.png)

