### PR TITLE
Fixed the issue with the options usage for dependencies and dependents.

### DIFF
--- a/change/@lage-run-cli-cc220a90-78d4-41ea-86a4-f8d38786f182.json
+++ b/change/@lage-run-cli-cc220a90-78d4-41ea-86a4-f8d38786f182.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\u0016Making these corrections so that the dependencies and --no-dependents (dependents option) are correctly parsed and used in the program.",
+  "packageName": "@lage-run/cli",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -22,8 +22,8 @@ addLoggerOptions(runCommand)
   )
   // Common Options
   .option("--scope <scope...>", "scopes the run to a subset of packages (by default, includes the dependencies and dependents as well)")
-  .option("--no-dependents|--no-deps", "disables running any dependents of the scoped packages")
-  .option("--dependencies|--include-dependencies", 'adds the scoped packages dependencies as the "entry points" for the target graph run')
+  .option("--no-deps|--no-dependents", "disables running any dependents of the scoped packages")
+  .option("--include-dependencies|--dependencies", 'adds the scoped packages dependencies as the "entry points" for the target graph run')
   .option("--since <since>", "only runs packages that have changed since the given commit, tag, or branch")
   .option("--to <scope...>", "runs up to a package (shorthand for --scope=<scope...> --no-dependents)")
 

--- a/packages/cli/src/filter/getFilteredPackages.ts
+++ b/packages/cli/src/filter/getFilteredPackages.ts
@@ -115,6 +115,7 @@ export function filterPackages(options: {
 
   // adds dependencies of all filtered package thus far
   if (includeDependencies) {
+    logger.verbose(`filterPackages running with dependencies`);
     filtered = filtered.concat(getTransitiveDependencies(filtered, packageInfos));
   }
 


### PR DESCRIPTION
In commander the option flags follow the following convention :
   * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
  
The shorter flag always precedes the original option flag. The original flag is the one which gets used in the program.

Making these corrections so that the dependencies and --no-dependents (dependents option) are correctly parsed and used in the program.

Tested Scenarios: 
![image](https://user-images.githubusercontent.com/93791633/191609397-d46eb0e3-9eb1-477b-89c5-2a6c2bfd14d4.png)
![image](https://user-images.githubusercontent.com/93791633/191609503-17efdc8e-2969-41aa-9b1a-8b8797b1de17.png)
![image](https://user-images.githubusercontent.com/93791633/191609237-6d2dbba3-5ff0-4e07-b99b-a6f9d53f7439.png)
![image](https://user-images.githubusercontent.com/93791633/191609751-c80663e6-1218-4dd9-bb47-aad841089f0d.png)

