### PR TITLE
Fix v1 defaults: remote fallback write flag + the skip local cache flag

### DIFF
--- a/change/lage-2fe101c7-f7e8-47cc-9c2e-fa14d83538bc.json
+++ b/change/lage-2fe101c7-f7e8-47cc-9c2e-fa14d83538bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "The defaults for CI environments is completely wrong, we need to make sure the defaults are correct for CI so it will write remote cache and skip local download remote cache",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/src/cache/cacheConfig.ts
+++ b/packages/lage/src/cache/cacheConfig.ts
@@ -1,5 +1,6 @@
 import { getEnvConfig, createDefaultConfig } from "backfill-config";
 import { Logger, makeLogger } from "backfill-logger";
+import { isRunningFromCI } from "../isRunningFromCI";
 import { CacheOptions } from "../types/CacheOptions";
 import { RemoteFallbackCacheProvider } from "./RemoteFallbackCacheProvider";
 
@@ -16,7 +17,8 @@ export function getCacheConfig(cwd: string, cacheOptions: CacheOptions) {
     ...defaultCacheConfig,
     ...cacheOptions,
     ...envConfig,
-    writeRemoteCache: cacheOptions.writeRemoteCache || !!process.env.LAGE_WRITE_REMOTE_CACHE,
+    writeRemoteCache: cacheOptions.writeRemoteCache || !!process.env.LAGE_WRITE_REMOTE_CACHE || isRunningFromCI,
+    skipLocalCache: cacheOptions.skipLocalCache ?? isRunningFromCI
   };
 
   const configWithFallback: CacheOptions = {

--- a/packages/lage/src/cache/cacheConfig.ts
+++ b/packages/lage/src/cache/cacheConfig.ts
@@ -18,7 +18,7 @@ export function getCacheConfig(cwd: string, cacheOptions: CacheOptions) {
     ...cacheOptions,
     ...envConfig,
     writeRemoteCache: cacheOptions.writeRemoteCache || !!process.env.LAGE_WRITE_REMOTE_CACHE || isRunningFromCI,
-    skipLocalCache: cacheOptions.skipLocalCache ?? isRunningFromCI
+    skipLocalCache: cacheOptions.skipLocalCache ?? isRunningFromCI,
   };
 
   const configWithFallback: CacheOptions = {

--- a/packages/lage/src/isRunningFromCI.ts
+++ b/packages/lage/src/isRunningFromCI.ts
@@ -1,0 +1,1 @@
+export const isRunningFromCI = (process.env.NODE_ENV !== "test" && !!process.env.CI) || !!process.env.TF_BUILD;


### PR DESCRIPTION
For a CI environment (env var of CI or TF_BUILD), we should auto select the defaults that make sense. If a remote cache provider has been defined, we should try to write to it in CI. We also should not then try to fill the local cache with the "remote cache" in CI.