### PR TITLE
Fix incremental caching

### DIFF
--- a/change/lage-2f7797b1-de47-4fa1-bacd-7af1aa0a865d.json
+++ b/change/lage-2f7797b1-de47-4fa1-bacd-7af1aa0a865d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix incremental caching",
+  "packageName": "lage",
+  "email": "rnjuguna@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/src/cache/RemoteFallbackCacheProvider.ts
+++ b/packages/lage/src/cache/RemoteFallbackCacheProvider.ts
@@ -6,7 +6,7 @@ import { logger } from "../logger";
 
 export type RemoteFallbackCacheProviderOptions = Pick<
   CacheOptions,
-  "internalCacheFolder" | "cacheStorageConfig" | "writeRemoteCache" | "skipLocalCache"
+  "internalCacheFolder" | "cacheStorageConfig" | "writeRemoteCache" | "skipLocalCache" | "incrementalCaching"
 >;
 
 /**
@@ -29,7 +29,8 @@ export class RemoteFallbackCacheProvider implements ICacheStorage {
       },
       cacheOptions.internalCacheFolder,
       logger,
-      cwd
+      cwd,
+      cacheOptions.incrementalCaching
     );
 
     // Remote providers should have a provider name of something other than "local" OR it is
@@ -45,7 +46,8 @@ export class RemoteFallbackCacheProvider implements ICacheStorage {
         cacheOptions.cacheStorageConfig,
         cacheOptions.internalCacheFolder,
         logger,
-        cwd
+        cwd,
+        cacheOptions.incrementalCaching
       );
     }
   }


### PR DESCRIPTION
Fix incremental caching. The flag was not being forwarded to the appropriate function. Adding it as an argument to the `getCacheStorageProvider` function fixes this