### PR TITLE
Add aggregate prioritization to the target graph

### DIFF
--- a/change/@lage-run-target-graph-f83d7b14-4457-4d1b-ba36-4b43b4d070c8.json
+++ b/change/@lage-run-target-graph-f83d7b14-4457-4d1b-ba36-4b43b4d070c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding some prioritize tests",
+  "packageName": "@lage-run/target-graph",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
     ]
   },
   "scripts": {
-    "build": "lage build --scope=!@lage/docs --scope=lage --scope=@lage-run/* --verbose",
+    "build": "lage build --scope=!docs --verbose",
     "change": "beachball change",
     "checkchange": "beachball check",
     "release": "beachball publish -y --tag latest",
-    "start": "lage start --scope=!@lage/docs --scope=lage --scope=@lage-run/* --verbose",
-    "test": "lage test --scope !@lage/docs --scope=lage --scope=@lage-run/* --verbose",
+    "start": "lage start --scope=!docs --verbose",
+    "test": "lage test --scope=!docs --verbose",
     "lint": "lage lint",
-    "docs": "yarn workspace @lage/docs start",
-    "docs:build": "yarn workspace @lage/docs build",
+    "docs": "yarn workspace @lage-run/docs start",
+    "docs:build": "yarn workspace @lage-run/docs build",
     "gh-pages": "gh-pages",
     "format": "prettier --config .prettierrc packages/**/*.ts **/*.json --write --ignore-path .gitignore",
     "format:check": "prettier --config .prettierrc packages/**/*.ts **/*.json --check --ignore-path .gitignore"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "beachball": "2.31.2",
     "gh-pages": "4.0.0",
     "jest": "29.1.1",
-    "lage-npm": "npm:@lage-run/lage@2.1.9",
+    "lage-npm": "npm:@lage-run/lage@2.1.13",
     "prettier": "2.7.1",
     "ts-jest": "29.0.3",
     "typescript": "4.6.4"

--- a/packages/cache/tests/BackfillCacheProvider.test.ts
+++ b/packages/cache/tests/BackfillCacheProvider.test.ts
@@ -27,6 +27,8 @@ describe("BackfillCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(monorepo.root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",
@@ -69,6 +71,8 @@ describe("BackfillCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(monorepo.root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",

--- a/packages/cache/tests/RemoteFallbackCacheProvider.test.ts
+++ b/packages/cache/tests/RemoteFallbackCacheProvider.test.ts
@@ -39,6 +39,8 @@ describe("RemoteFallbackCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",
@@ -81,6 +83,8 @@ describe("RemoteFallbackCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",
@@ -116,6 +120,8 @@ describe("RemoteFallbackCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",
@@ -158,6 +164,8 @@ describe("RemoteFallbackCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",
@@ -203,6 +211,8 @@ describe("RemoteFallbackCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",
@@ -248,6 +258,8 @@ describe("RemoteFallbackCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(root, "packages/a"),
+      depSpecs: [],
+      dependents: [],
       dependencies: [],
       task: "command",
       label: "a - command",

--- a/packages/cache/tests/TargetHasher.test.ts
+++ b/packages/cache/tests/TargetHasher.test.ts
@@ -27,7 +27,9 @@ describe("BackfillCacheProvider", () => {
     const target: Target = {
       id: "a",
       cwd: path.join(monorepo.root, "packages/a"),
+      depSpecs: [],
       dependencies: [],
+      dependents: [],
       task: "command",
       label: "a - command",
     };

--- a/packages/reporters/tests/AdoReporter.test.ts
+++ b/packages/reporters/tests/AdoReporter.test.ts
@@ -11,6 +11,8 @@ function createTarget(packageName: string, task: string) {
     id: `${packageName}#${task}`,
     cwd: `/repo/root/packages/${packageName}`,
     dependencies: [],
+    dependents: [],
+    depSpecs: [],
     packageName,
     task,
     label: `${packageName} - ${task}`,

--- a/packages/reporters/tests/ChromeTraceEventsReporter.test.ts
+++ b/packages/reporters/tests/ChromeTraceEventsReporter.test.ts
@@ -11,6 +11,8 @@ function createTarget(packageName: string, task: string) {
     id: `${packageName}#${task}`,
     cwd: `/repo/root/packages/${packageName}`,
     dependencies: [],
+    dependents: [],
+    depSpecs: [],
     packageName,
     task,
     label: `${packageName} - ${task}`,

--- a/packages/reporters/tests/JsonReporter.test.ts
+++ b/packages/reporters/tests/JsonReporter.test.ts
@@ -10,6 +10,8 @@ function createTarget(packageName: string, task: string) {
     id: `${packageName}#${task}`,
     cwd: `/repo/root/packages/${packageName}`,
     dependencies: [],
+    dependents: [],
+    depSpecs: [],
     packageName,
     task,
     label: `${packageName} - ${task}`,
@@ -68,7 +70,9 @@ describe("JsonReporter", () => {
             "status": "running",
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#build",
               "label": "a - build",
               "packageName": "a",
@@ -92,7 +96,9 @@ describe("JsonReporter", () => {
             "status": "running",
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#test",
               "label": "a - test",
               "packageName": "a",
@@ -116,7 +122,9 @@ describe("JsonReporter", () => {
             "status": "running",
             "target": {
               "cwd": "/repo/root/packages/b",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "b#build",
               "label": "b - build",
               "packageName": "b",
@@ -132,7 +140,9 @@ describe("JsonReporter", () => {
             "pid": 1,
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#build",
               "label": "a - build",
               "packageName": "a",
@@ -148,7 +158,9 @@ describe("JsonReporter", () => {
             "pid": 1,
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#test",
               "label": "a - test",
               "packageName": "a",
@@ -164,7 +176,9 @@ describe("JsonReporter", () => {
             "pid": 1,
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#build",
               "label": "a - build",
               "packageName": "a",
@@ -180,7 +194,9 @@ describe("JsonReporter", () => {
             "pid": 1,
             "target": {
               "cwd": "/repo/root/packages/b",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "b#build",
               "label": "b - build",
               "packageName": "b",
@@ -196,7 +212,9 @@ describe("JsonReporter", () => {
             "pid": 1,
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#test",
               "label": "a - test",
               "packageName": "a",
@@ -212,7 +230,9 @@ describe("JsonReporter", () => {
             "pid": 1,
             "target": {
               "cwd": "/repo/root/packages/b",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "b#build",
               "label": "b - build",
               "packageName": "b",
@@ -236,7 +256,9 @@ describe("JsonReporter", () => {
             "status": "success",
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#test",
               "label": "a - test",
               "packageName": "a",
@@ -260,7 +282,9 @@ describe("JsonReporter", () => {
             "status": "success",
             "target": {
               "cwd": "/repo/root/packages/b",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "b#build",
               "label": "b - build",
               "packageName": "b",
@@ -284,7 +308,9 @@ describe("JsonReporter", () => {
             "status": "failed",
             "target": {
               "cwd": "/repo/root/packages/a",
+              "depSpecs": [],
               "dependencies": [],
+              "dependents": [],
               "id": "a#build",
               "label": "a - build",
               "packageName": "a",

--- a/packages/reporters/tests/LogReporter.test.ts
+++ b/packages/reporters/tests/LogReporter.test.ts
@@ -12,6 +12,8 @@ function createTarget(packageName: string, task: string) {
     id: `${packageName}#${task}`,
     cwd: `/repo/root/packages/${packageName}`,
     dependencies: [],
+    dependents: [],
+    depSpecs: [],
     packageName,
     task,
     label: `${packageName} - ${task}`,

--- a/packages/scheduler/tests/NpmScriptRunner.test.ts
+++ b/packages/scheduler/tests/NpmScriptRunner.test.ts
@@ -36,6 +36,8 @@ function createTarget(packageName: string): Target {
   return {
     cwd: path.resolve(__dirname, "fixtures/package-a"),
     dependencies: [],
+    dependents: [],
+    depSpecs: [],
     label: "",
     id: `${packageName}#build`,
     task: "build",

--- a/packages/scheduler/tests/SimpleScheduler.test.ts
+++ b/packages/scheduler/tests/SimpleScheduler.test.ts
@@ -35,7 +35,9 @@ class TestTargetGraph implements TargetGraph {
       packageName,
       task,
       cwd: `packages/${packageName}`,
-      dependencies: [], // this is unused by schedulers
+      dependencies: [],
+      dependents: [],
+      depSpecs: [],
     } as Target);
 
     // auto inject the start target id to each target

--- a/packages/scheduler/tests/WorkerRunner.test.ts
+++ b/packages/scheduler/tests/WorkerRunner.test.ts
@@ -34,6 +34,8 @@ describe("WorkerRunner", () => {
       packageName: "a",
       cwd: "/repo/dummy/cwd",
       dependencies: [],
+      dependents: [],
+      depSpecs: [],
       label: "a - work",
       type: "worker",
     } as Target;
@@ -44,6 +46,8 @@ describe("WorkerRunner", () => {
       packageName: "b",
       cwd: "/repo/dummy/cwd",
       dependencies: [],
+      dependents: [],
+      depSpecs: [],
       label: "b - work",
       type: "worker",
     } as Target;

--- a/packages/scheduler/tests/WrappedTarget.test.ts
+++ b/packages/scheduler/tests/WrappedTarget.test.ts
@@ -13,6 +13,8 @@ function createTarget(packageName: string): Target {
   return {
     cwd: path.resolve(__dirname, "fixtures/package-a"),
     dependencies: [],
+    dependents: [],
+    depSpecs: [],
     label: "",
     id: `${packageName}#build`,
     task: "build",

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -1,5 +1,7 @@
 import { createDependencyMap } from "workspace-tools/lib/graph/createDependencyMap";
 import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId";
+import { prioritize } from "./prioritize";
+import { expandDepSpecs } from "./expandDepSpecs";
 
 import path from "path";
 
@@ -22,9 +24,6 @@ import type { TargetConfig } from "./types/TargetConfig";
  * ```
  */
 export class TargetGraphBuilder {
-  /** Cached transitive task dependency */
-  private cachedTransitiveTaskDependencies: Map<string, "walk-in-progress" | Set<string>> = new Map();
-
   /** A map of targets - used internally for looking up generated targets from the target configurations */
   private targets: Map<string, Target> = new Map();
 
@@ -62,7 +61,9 @@ export class TargetGraphBuilder {
       // NOTE: We should force cache inputs to be defined for global targets
       cache: false,
       cwd: this.root,
-      dependencies: dependsOn ?? deps ?? [],
+      depSpecs: dependsOn ?? deps ?? [],
+      dependencies: [],
+      dependents: [],
       inputs,
       outputs,
       priority,
@@ -89,187 +90,15 @@ export class TargetGraphBuilder {
       task,
       cache: cache !== false,
       cwd: path.dirname(info.packageJsonPath),
-      dependencies: dependsOn ?? deps ?? [],
+      depSpecs: dependsOn ?? deps ?? [],
+      dependencies: [],
+      dependents: [],
       inputs,
       outputs,
       priority,
       run,
       options,
     };
-  }
-
-  /**
-   * Generates new `Target`, indexed by the id based on a new target configuration.
-   *
-   * @param id
-   * @param targetDefinition
-   */
-  addTargetConfig(id: string, config: TargetConfig = {}): void {
-    // Generates a target definition from the target config
-    if (id.startsWith("//") || id.startsWith("#")) {
-      const target = this.createGlobalTarget(id, config);
-      this.targets.set(target.id, target);
-    } else if (id.includes("#")) {
-      const { packageName, task } = getPackageAndTask(id);
-      const target = this.createPackageTarget(packageName!, task, config);
-      this.targets.set(target.id, target);
-    } else {
-      const packages = Object.keys(this.packageInfos);
-      for (const packageName of packages) {
-        const task = id;
-        const target = this.createPackageTarget(packageName!, task, config);
-        this.targets.set(target.id, target);
-      }
-    }
-  }
-
-  /**
-   * Expands the dependency graph by adding all transitive dependencies of the given targets.
-   */
-  private expandDependencies() {
-    /**
-     * Adds a dependency in the form of [from, to] to the dependency list.
-     * @param from
-     * @param to
-     */
-    const addDependency = (from: string, to: string) => {
-      this.dependencies.push([from, to]);
-    };
-
-    /**
-     * Finds all transitive dependencies, given a task and optionally a dependency list.
-     * @param task
-     * @param dependencies
-     * @returns
-     */
-    const findDependenciesByTask = (task: string, dependencies?: string[]) => {
-      if (!dependencies) {
-        return targets.filter((needle) => needle.task === task).map((needle) => needle.id);
-      }
-
-      return targets
-        .filter((needle) => {
-          const { task: needleTask, packageName: needlePackageName } = needle;
-          return needleTask === task && dependencies.some((depPkg) => depPkg === needlePackageName);
-        })
-        .map((needle) => needle.id);
-    };
-
-    const targets = [...this.targets.values()];
-
-    for (const target of targets) {
-      const { dependencies, packageName, id: to } = target;
-
-      // Always start with a root node with a special "START_TARGET_ID"
-      // because any node could potentially be part of the entry point in building the scoped target subgraph
-      this.dependencies.push([getStartTargetId(), to]);
-
-      // Skip any targets that have no "deps" specified
-      if (!dependencies || dependencies.length === 0) {
-        continue;
-      }
-
-      /**
-       * Now for every deps defined, we need to "interpret" it based on the syntax:
-       * - for any deps like package#task, we simply add the singular dependency (source could be a single package or all packages)
-       * - for anything that starts with a "^", we add the package-tasks according to the topological package graph
-       *    NOTE: in a non-strict mode (TODO), the dependencies can come from transitive task dependencies
-       * - for anything that starts with a "^^", we add the package-tasks from the transitive dependencies in the topological
-       *    package graph.
-       * - for {"pkgA#task": ["dep"]}, we interpret to add "pkgA#dep"
-       * - for anything that is a string without a "^", we treat that string as the name of a task, adding all targets that way
-       *    NOTE: in a non-strict mode (TODO), the dependencies can come from transitive task dependencies
-       *
-       * We interpret anything outside of these conditions as invalid
-       */
-      for (const dependencyTargetId of dependencies) {
-        if (dependencyTargetId.includes("#")) {
-          // id's with a # are package-task dependencies, or global
-          // therefore, we must use getPackageAndTask() & getTargetId() to normalize the target id
-          // (e.g. "build": ["build-tool#build"])
-          const { packageName, task } = getPackageAndTask(dependencyTargetId);
-          const normalizedDependencyTargetId = getTargetId(packageName, task);
-          addDependency(normalizedDependencyTargetId, to);
-        } else if (dependencyTargetId.startsWith("^^") && packageName) {
-          // Transitive depdency (e.g. bundle: ['^^transpile'])
-          const depTask = dependencyTargetId.substring(2);
-          const targetDependencies = [...(this.getTransitiveGraphDependencies(packageName) ?? [])];
-          const dependencyTargetIds = findDependenciesByTask(depTask, targetDependencies);
-          for (const from of dependencyTargetIds) {
-            addDependency(from, to);
-          }
-        } else if (dependencyTargetId.startsWith("^") && packageName) {
-          // Topological dependency (e.g. build: ['^build'])
-          const depTask = dependencyTargetId.substring(1);
-          const targetDependencies = [...(this.dependencyMap.dependencies.get(packageName) ?? [])];
-          const dependencyTargetIds = findDependenciesByTask(depTask, targetDependencies);
-          for (const from of dependencyTargetIds) {
-            addDependency(from, to);
-          }
-        } else if (packageName) {
-          // Add dependency on a specific package and given task name as dependency
-          // (e.g. bundle: ['build'])
-          const task = dependencyTargetId;
-          if (this.targets.has(getTargetId(packageName, task))) {
-            addDependency(getTargetId(packageName, task), to);
-          }
-        } else if (!dependencyTargetId.startsWith("^")) {
-          // Global dependency - add all targets that match task name as dependency
-          // (e.g. "#bundle": ['build'])
-          const task = dependencyTargetId;
-          const dependencyIds = findDependenciesByTask(task);
-          for (const dependencyId of dependencyIds) {
-            addDependency(dependencyId, to);
-          }
-        } else {
-          throw new Error(`invalid pipeline config detected: ${target.id}, packageName: ${packageName}, dep: ${dependencyTargetId}`);
-        }
-      }
-    }
-  }
-
-  /**
-   * Gets a list of package names that are direct or indirect dependencies of rootPackageName in this.graph,
-   * and caches them on the Pipeline.
-   *
-   * For example, this is useful for a bundling target that depends on all transitive dependencies to have been built.
-   *
-   * @param packageName the root package to begin walking from
-   */
-  private getTransitiveGraphDependencies(packageName: string): Set<string> {
-    const cachedResult = this.cachedTransitiveTaskDependencies.get(packageName);
-    if (cachedResult) {
-      return cachedResult === "walk-in-progress"
-        ? // There is a recursive walk over this set of dependencies in progress.
-          // If we hit this case, that means that a dependency of this package depends on it.
-          //
-          // In this case we return an empty set to omit this package and it's downstream from its
-          // dependency
-          new Set()
-        : // we already computed this for this package, return the cached result.
-          cachedResult;
-    } else {
-      // No cached result. Compute now with a recursive walk
-
-      // mark that we are traversing this package to prevent infinite recursion
-      // in cases of circular dependencies
-      this.cachedTransitiveTaskDependencies.set(packageName, "walk-in-progress");
-
-      const immediateDependencies = [...(this.dependencyMap.dependencies.get(packageName) ?? [])];
-
-      // build the set of transitive dependencies by recursively walking the
-      // immediate dependencies' dependencies.
-      const transitiveDepSet = new Set<string>(immediateDependencies);
-      for (const immediateDependency of immediateDependencies) {
-        for (const transitiveSubDependency of this.getTransitiveGraphDependencies(immediateDependency)) {
-          transitiveDepSet.add(transitiveSubDependency);
-        }
-      }
-
-      // Cache the result and return
-      this.cachedTransitiveTaskDependencies.set(packageName, transitiveDepSet);
-      return transitiveDepSet;
-    }
   }
 
   /**
@@ -347,6 +176,31 @@ export class TargetGraphBuilder {
   }
 
   /**
+   * Generates new `Target`, indexed by the id based on a new target configuration.
+   *
+   * @param id
+   * @param targetDefinition
+   */
+  addTargetConfig(id: string, config: TargetConfig = {}): void {
+    // Generates a target definition from the target config
+    if (id.startsWith("//") || id.startsWith("#")) {
+      const target = this.createGlobalTarget(id, config);
+      this.targets.set(target.id, target);
+    } else if (id.includes("#")) {
+      const { packageName, task } = getPackageAndTask(id);
+      const target = this.createPackageTarget(packageName!, task, config);
+      this.targets.set(target.id, target);
+    } else {
+      const packages = Object.keys(this.packageInfos);
+      for (const packageName of packages) {
+        const task = id;
+        const target = this.createPackageTarget(packageName!, task, config);
+        this.targets.set(target.id, target);
+      }
+    }
+  }
+
+  /**
    * Builds a scoped target graph for given tasks and packages
    *
    * Steps:
@@ -360,7 +214,7 @@ export class TargetGraphBuilder {
    * @returns
    */
   buildTargetGraph(tasks: string[], scope?: string[]) {
-    this.expandDependencies();
+    this.dependencies = expandDepSpecs(this.targets, this.dependencyMap);
 
     const startId = getStartTargetId();
     this.targets.set(startId, {
@@ -369,20 +223,38 @@ export class TargetGraphBuilder {
       cwd: "",
       label: "Start",
       hidden: true,
+      dependencies: [],
+      dependents: [],
+      depSpecs: [],
     } as Target);
 
     const subGraphEdges = this.createSubGraph(tasks, scope);
     const subGraphTargets: Map<string, Target> = new Map();
 
+    // Delay setting up the "dependents" and "dependencies" of the targets until the subgraph is defined
+    // This will ensure that the only dependencies present in the returned results are from the subgraph
     for (const [from, to] of subGraphEdges) {
       if (this.targets.has(from)) {
-        subGraphTargets.set(from, this.targets.get(from)!);
+        const target = this.targets.get(from)!;
+
+        subGraphTargets.set(from, target);
+
+        target.dependents = target.dependents ?? [];
+        target.dependents.push(to);
       }
 
       if (this.targets.has(to)) {
-        subGraphTargets.set(to, this.targets.get(to)!);
+        const target = this.targets.get(to)!;
+        subGraphTargets.set(to, target);
+
+        target.dependencies = target.dependencies ?? [];
+        target.dependencies.push(from);
       }
     }
+
+    // Add priority to the SUB-GRAPH, because the aggregated priorities are in the context of the final graph
+    // The full graph might produce a different aggregated priority value for a target
+    prioritize(subGraphTargets);
 
     return {
       targets: subGraphTargets,

--- a/packages/target-graph/src/expandDepSpecs.ts
+++ b/packages/target-graph/src/expandDepSpecs.ts
@@ -112,7 +112,7 @@ export function expandDepSpecs(targets: Map<string, Target>, dependencyMap: Depe
 }
 
 /** Cached transitive task dependency */
-let cachedTransitiveTaskDependencies: Map<string, "walk-in-progress" | Set<string>> = new Map();
+const cachedTransitiveTaskDependencies: Map<string, "walk-in-progress" | Set<string>> = new Map();
 
 /**
  * Gets a list of package names that are direct or indirect dependencies of rootPackageName in this.graph,

--- a/packages/target-graph/src/expandDepSpecs.ts
+++ b/packages/target-graph/src/expandDepSpecs.ts
@@ -1,0 +1,159 @@
+import type { Target } from "./types/Target";
+import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap";
+import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId";
+
+/**
+ * Expands the dependency graph by adding all transitive dependencies of the given targets.
+ */
+export function expandDepSpecs(targets: Map<string, Target>, dependencyMap: DependencyMap) {
+  const dependencies: [string, string][] = [];
+
+  /**
+   * Adds a dependency in the form of [from, to] to the dependency list.
+   * @param from
+   * @param to
+   */
+  const addDependency = (from: string, to: string) => {
+    dependencies.push([from, to]);
+  };
+
+  /**
+   * Finds all transitive dependencies, given a task and optionally a dependency list.
+   * @param task
+   * @param dependencies
+   * @returns
+   */
+  const findDependenciesByTask = (task: string, dependencies?: string[]) => {
+    if (!dependencies) {
+      return targetList.filter((needle) => needle.task === task).map((needle) => needle.id);
+    }
+
+    return targetList
+      .filter((needle) => {
+        const { task: needleTask, packageName: needlePackageName } = needle;
+        return needleTask === task && dependencies.some((depPkg) => depPkg === needlePackageName);
+      })
+      .map((needle) => needle.id);
+  };
+
+  const targetList = [...targets.values()];
+
+  for (const target of targetList) {
+    const { depSpecs, packageName, id: to } = target;
+
+    // Always start with a root node with a special "START_TARGET_ID"
+    // because any node could potentially be part of the entry point in building the scoped target subgraph
+    dependencies.push([getStartTargetId(), to]);
+
+    // Skip any targets that have no "deps" specified
+    if (!depSpecs || depSpecs.length === 0) {
+      continue;
+    }
+
+    /**
+     * Now for every deps defined, we need to "interpret" it based on the syntax:
+     * - for any deps like package#task, we simply add the singular dependency (source could be a single package or all packages)
+     * - for anything that starts with a "^", we add the package-tasks according to the topological package graph
+     *    NOTE: in a non-strict mode (TODO), the dependencies can come from transitive task dependencies
+     * - for anything that starts with a "^^", we add the package-tasks from the transitive dependencies in the topological
+     *    package graph.
+     * - for {"pkgA#task": ["dep"]}, we interpret to add "pkgA#dep"
+     * - for anything that is a string without a "^", we treat that string as the name of a task, adding all targets that way
+     *    NOTE: in a non-strict mode (TODO), the dependencies can come from transitive task dependencies
+     *
+     * We interpret anything outside of these conditions as invalid
+     */
+    for (const dependencyTargetId of depSpecs) {
+      if (dependencyTargetId.includes("#")) {
+        // id's with a # are package-task dependencies, or global
+        // therefore, we must use getPackageAndTask() & getTargetId() to normalize the target id
+        // (e.g. "build": ["build-tool#build"])
+        const { packageName, task } = getPackageAndTask(dependencyTargetId);
+        const normalizedDependencyTargetId = getTargetId(packageName, task);
+        addDependency(normalizedDependencyTargetId, to);
+      } else if (dependencyTargetId.startsWith("^^") && packageName) {
+        // Transitive depdency (e.g. bundle: ['^^transpile'])
+        const depTask = dependencyTargetId.substring(2);
+        const targetDependencies = [...(getTransitiveGraphDependencies(packageName, dependencyMap) ?? [])];
+        const dependencyTargetIds = findDependenciesByTask(depTask, targetDependencies);
+        for (const from of dependencyTargetIds) {
+          addDependency(from, to);
+        }
+      } else if (dependencyTargetId.startsWith("^") && packageName) {
+        // Topological dependency (e.g. build: ['^build'])
+        const depTask = dependencyTargetId.substring(1);
+        const targetDependencies = [...(dependencyMap.dependencies.get(packageName) ?? [])];
+        const dependencyTargetIds = findDependenciesByTask(depTask, targetDependencies);
+        for (const from of dependencyTargetIds) {
+          addDependency(from, to);
+        }
+      } else if (packageName) {
+        // Add dependency on a specific package and given task name as dependency
+        // (e.g. bundle: ['build'])
+        const task = dependencyTargetId;
+        if (targets.has(getTargetId(packageName, task))) {
+          addDependency(getTargetId(packageName, task), to);
+        }
+      } else if (!dependencyTargetId.startsWith("^")) {
+        // Global dependency - add all targets that match task name as dependency
+        // (e.g. "#bundle": ['build'])
+        const task = dependencyTargetId;
+        const dependencyIds = findDependenciesByTask(task);
+        for (const dependencyId of dependencyIds) {
+          addDependency(dependencyId, to);
+        }
+      } else {
+        throw new Error(`invalid pipeline config detected: ${target.id}, packageName: ${packageName}, dep: ${dependencyTargetId}`);
+      }
+    }
+  }
+
+  return dependencies;
+}
+
+/** Cached transitive task dependency */
+let cachedTransitiveTaskDependencies: Map<string, "walk-in-progress" | Set<string>> = new Map();
+
+/**
+ * Gets a list of package names that are direct or indirect dependencies of rootPackageName in this.graph,
+ * and caches them on the Pipeline.
+ *
+ * For example, this is useful for a bundling target that depends on all transitive dependencies to have been built.
+ *
+ * @param packageName the root package to begin walking from
+ */
+function getTransitiveGraphDependencies(packageName: string, dependencyMap: DependencyMap): Set<string> {
+  const cachedResult = cachedTransitiveTaskDependencies.get(packageName);
+  if (cachedResult) {
+    return cachedResult === "walk-in-progress"
+      ? // There is a recursive walk over this set of dependencies in progress.
+        // If we hit this case, that means that a dependency of this package depends on it.
+        //
+        // In this case we return an empty set to omit this package and it's downstream from its
+        // dependency
+        new Set()
+      : // we already computed this for this package, return the cached result.
+        cachedResult;
+  } else {
+    // No cached result. Compute now with a recursive walk
+
+    // mark that we are traversing this package to prevent infinite recursion
+    // in cases of circular dependencies
+    cachedTransitiveTaskDependencies.set(packageName, "walk-in-progress");
+
+    const immediateDependencies = [...(dependencyMap.dependencies.get(packageName) ?? [])];
+
+    // build the set of transitive dependencies by recursively walking the
+    // immediate dependencies' dependencies.
+    const transitiveDepSet = new Set<string>(immediateDependencies);
+    for (const immediateDependency of immediateDependencies) {
+      for (const transitiveSubDependency of getTransitiveGraphDependencies(immediateDependency, dependencyMap)) {
+        transitiveDepSet.add(transitiveSubDependency);
+      }
+    }
+
+    // Cache the result and return
+    cachedTransitiveTaskDependencies.set(packageName, transitiveDepSet);
+    return transitiveDepSet;
+  }
+}

--- a/packages/target-graph/src/index.ts
+++ b/packages/target-graph/src/index.ts
@@ -2,5 +2,6 @@ export type { Target } from "./types/Target";
 export type { TargetGraph } from "./types/TargetGraph";
 export type { TargetConfig } from "./types/TargetConfig";
 
+export { sortTargetsByPriority } from "./sortTargetsByPriority";
 export { getPackageAndTask, getTargetId, getStartTargetId } from "./targetId";
 export { TargetGraphBuilder } from "./TargetGraphBuilder";

--- a/packages/target-graph/src/prioritize.ts
+++ b/packages/target-graph/src/prioritize.ts
@@ -1,0 +1,26 @@
+import type { Target } from "./types/Target";
+
+/**
+ * Priorities for a target is actually the MAX of all the priorities of the targets that depend on it.
+ */
+export function prioritize(targets: Map<string, Target>) {
+  const stack: Target[] = [];
+
+  // start with the leaves - the children of the all targets
+  for (const target of targets.values()) {
+    if (target.dependencies.length === 0) {
+      stack.push(target);
+    }
+  }
+
+  // fill every target with the max priority of its dependents
+  while (stack.length > 0) {
+    const currentTarget = stack.pop()!;
+    const currentPriority = currentTarget.priority;
+
+    for (const dependentId of currentTarget.dependents) {
+      const dependent = targets.get(dependentId)!;
+      dependent.priority = Math.max(dependent.priority ?? 0, currentPriority ?? 0);
+    }
+  }
+}

--- a/packages/target-graph/src/prioritize.ts
+++ b/packages/target-graph/src/prioritize.ts
@@ -21,6 +21,8 @@ export function prioritize(targets: Map<string, Target>) {
     for (const dependentId of currentTarget.dependents) {
       const dependent = targets.get(dependentId)!;
       dependent.priority = Math.max(dependent.priority ?? 0, currentPriority ?? 0);
+
+      stack.push(dependent);
     }
   }
 }

--- a/packages/target-graph/src/sortTargetsByPriority.ts
+++ b/packages/target-graph/src/sortTargetsByPriority.ts
@@ -1,0 +1,7 @@
+import type { Target } from "./types/Target";
+
+export function sortTargetsByPriority(targets: Target[]) {
+  return targets.sort((a, b) => {
+    return (b.priority ?? 0) - (a.priority ?? 0);
+  });
+}

--- a/packages/target-graph/src/types/Target.ts
+++ b/packages/target-graph/src/types/Target.ts
@@ -18,9 +18,19 @@ export interface Target {
   packageName?: string;
 
   /**
+   * List of "dependency specs" like "^build", "build", "foo#build"
+   */
+  depSpecs: string[];
+
+  /**
    * Dependencies of the target - these are the targets that must be complete before the target can be complete
    */
   dependencies: string[];
+
+  /**
+   * Dependents of the target - these are the targets that depend on this target
+   */
+  dependents: string[];
 
   /**
    * Any custom priority for the target. A priority of >0 will always be prioritized over the default targets in queue

--- a/packages/target-graph/tests/prioritize.test.ts
+++ b/packages/target-graph/tests/prioritize.test.ts
@@ -1,0 +1,112 @@
+import { getPackageAndTask } from "../src/targetId";
+import { Target } from "../src/types/Target";
+import { prioritize } from "../src/prioritize";
+
+function createTarget({
+  packageName,
+  task,
+  dependencies,
+  dependents,
+  priority,
+}: {
+  packageName: string;
+  task: string;
+  dependencies: string[];
+  dependents: string[];
+  priority: number;
+}): Target {
+  return {
+    id: `${packageName}#${task}`,
+    label: `${packageName} - ${task}`,
+    task,
+    packageName,
+    dependencies,
+    dependents,
+    depSpecs: [],
+    priority: 1,
+    cwd: `packages/${packageName}`,
+  } as Target;
+}
+
+describe("prioritize", () => {
+  it("should prioritize targets", () => {
+    const targets = new Map<string, Target>();
+    const edges = [
+      ["a#build", "b#build"],
+      ["b#build", "c#build"],
+      ["c#build", "d#build"],
+      ["_start", "a#lint"],
+      ["_start", "b#lint"],
+      ["_start", "c#lint"],
+      ["_start", "d#lint"],
+    ];
+
+    for (const [from, to] of edges) {
+      if (!targets.has(from)) {
+        const { packageName, task } = getPackageAndTask(from);
+        targets.set(from, createTarget({ packageName: packageName!, task, dependencies: [], dependents: [], priority: 1 }));
+      }
+
+      if (!targets.has(to)) {
+        const { packageName, task } = getPackageAndTask(to);
+        targets.set(to, createTarget({ packageName: packageName!, task, dependencies: [], dependents: [], priority: 1 }));
+      }
+
+      targets.get(from)!.dependencies.push(to);
+      targets.get(to)!.dependents.push(from);
+    }
+
+    targets.get("c#build")!.priority = 10;
+
+    prioritize(targets);
+
+    expect([...targets.values()].map((t) => ({ id: t.id, priority: t.priority }))).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "a#build",
+          "priority": 10,
+        },
+        {
+          "id": "b#build",
+          "priority": 10,
+        },
+        {
+          "id": "c#build",
+          "priority": 10,
+        },
+        {
+          "id": "d#build",
+          "priority": 1,
+        },
+        {
+          "id": "undefined#_start",
+          "priority": 1,
+        },
+        {
+          "id": "a#lint",
+          "priority": 1,
+        },
+        {
+          "id": "b#lint",
+          "priority": 1,
+        },
+        {
+          "id": "c#lint",
+          "priority": 1,
+        },
+        {
+          "id": "d#lint",
+          "priority": 1,
+        },
+      ]
+    `);
+
+    expect(targets.get("a#build")?.priority).toEqual(10);
+    expect(targets.get("b#build")?.priority).toEqual(10);
+    expect(targets.get("c#build")?.priority).toEqual(10);
+    expect(targets.get("d#build")?.priority).toEqual(1);
+    expect(targets.get("a#lint")?.priority).toEqual(1);
+    expect(targets.get("b#lint")?.priority).toEqual(1);
+    expect(targets.get("c#lint")?.priority).toEqual(1);
+  });
+});

--- a/scripts/worker/lint.js
+++ b/scripts/worker/lint.js
@@ -12,7 +12,7 @@ async function run(data) {
   const packageJson = JSON.parse(await readFile(path.join(target.cwd, "package.json"), "utf8"));
 
   if (!packageJson.scripts?.[target.task]) {
-    process.stdout.write(`No script found for ${target.task} in ${target.cwd}\n`);
+    process.stdout.write(`No script found for ${target.task} in ${target.cwd}... skipped`);
     // pass
     return;
   }
@@ -34,7 +34,9 @@ async function run(data) {
   const resultText = await formatter.format(results);
 
   // 4. Output it.
-  process.stdout.write(resultText + "\n");
+  if (resultText) {
+    process.stdout.write(resultText + "\n");
+  }
 
   if (results.some((r) => r.errorCount > 0)) {
     throw new Error(`Linting failed with errors`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7808,10 +7808,10 @@ klona@^2.0.5:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-"lage-npm@npm:@lage-run/lage@2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@lage-run/lage/-/lage-2.1.9.tgz#8a279eafedca71b3a249e2e0ab4dd1ed342526b1"
-  integrity sha512-G2kKPVhysYeK6djgYgZt51G+678X0iIMlfUd+PLtPYEhdQ67Cb9CKjQiQBmABRzTCHr/go8pAOVwAZW5ar2u9w==
+"lage-npm@npm:@lage-run/lage@2.1.13":
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/@lage-run/lage/-/lage-2.1.13.tgz#3eccde62032907591fff9be6d2d3d64374a6fdb0"
+  integrity sha512-9M3RJ4lq9J59AfgBRvvRD13DIXA6HN/jw2X9UYmtO0hcXbDIowdG0O8qiT7XckLeeRrXIeqa4iDV+psGkbHw4g==
 
 latest-version@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
If a dependency has a priority, the value will be Math.max() with a target. This gets recursed from the leaves to the root. In this way, we can prioritize targets somewhere inside the target graph!

1. added a "depSpecs" to preserve the "spec array" from the target config
2. added dependents to track this inside a target
3. updated what dependencies are - they are target to target dependencies rather than specs (a#build vs ^build)
4. updated all dependent usages of these target type definitions