### PR TITLE
Cycles - parity from v1: adding support for detecting cycles

### DIFF
--- a/change/@lage-run-cli-3ddcdbfb-2cb6-43a2-bc14-654c49d4db84.json
+++ b/change/@lage-run-cli-3ddcdbfb-2cb6-43a2-bc14-654c49d4db84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "displays any errors before exiting (from lage itself, not the tasks)",
+  "packageName": "@lage-run/cli",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-7766e09e-cc05-4c6a-897d-fd94e7c95841.json
+++ b/change/@lage-run-target-graph-7766e09e-cc05-4c6a-897d-fd94e7c95841.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "detecting cycles",
+  "packageName": "@lage-run/target-graph",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,5 +12,6 @@ async function main() {
 }
 
 main().catch((err) => {
+  console.error(err);
   process.exitCode = 1;
 });

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -1,6 +1,7 @@
 import { BackfillCacheProvider, RemoteFallbackCacheProvider, TargetHasher } from "@lage-run/cache";
 import { Command } from "commander";
 import { createProfileReporter } from "./createProfileReporter";
+import { detectCycles } from "@lage-run/target-graph";
 import { findNpmClient } from "../../workspace/findNpmClient";
 import { getConfig } from "../../config/getConfig";
 import { getFilteredPackages } from "../../filter/getFilteredPackages";
@@ -83,6 +84,12 @@ export async function runAction(options: RunOptions, command: Command) {
   }
 
   const targetGraph = builder.buildTargetGraph(tasks, packages);
+
+  const cycles = detectCycles(targetGraph.targets);
+  if (cycles.hasCycle) {
+    logger.error("Cycles detected in target graph:\n" + cycles.cycle?.join(" -> "));
+    process.exit(1);
+  }
 
   // Create Cache Provider
 

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -1,7 +1,6 @@
 import { BackfillCacheProvider, RemoteFallbackCacheProvider, TargetHasher } from "@lage-run/cache";
 import { Command } from "commander";
 import { createProfileReporter } from "./createProfileReporter";
-import { detectCycles } from "@lage-run/target-graph";
 import { findNpmClient } from "../../workspace/findNpmClient";
 import { getConfig } from "../../config/getConfig";
 import { getFilteredPackages } from "../../filter/getFilteredPackages";
@@ -85,14 +84,7 @@ export async function runAction(options: RunOptions, command: Command) {
 
   const targetGraph = builder.buildTargetGraph(tasks, packages);
 
-  const cycles = detectCycles(targetGraph.targets);
-  if (cycles.hasCycle) {
-    logger.error("Cycles detected in target graph:\n" + cycles.cycle?.join(" -> "));
-    process.exit(1);
-  }
-
   // Create Cache Provider
-
   const cacheProvider = new RemoteFallbackCacheProvider({
     root,
     logger,

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -9,6 +9,7 @@ import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMa
 import type { PackageInfos } from "workspace-tools";
 import type { Target } from "./types/Target";
 import type { TargetConfig } from "./types/TargetConfig";
+import { detectCycles } from "./detectCycles";
 
 /**
  * TargetGraphBuilder class provides a builder API for registering target configs. It exposes a method called `generateTargetGraph` to
@@ -250,6 +251,12 @@ export class TargetGraphBuilder {
         target.dependencies = target.dependencies ?? [];
         target.dependencies.push(from);
       }
+    }
+
+    // Ensure we do not have cycles in the subgraph
+    const cycleInfo = detectCycles(this.targets);
+    if (cycleInfo.hasCycle) {
+      throw new Error("Cycles detected in the target graph: " + cycleInfo.cycle!.concat(cycleInfo.cycle![0]).join(" -> "));
     }
 
     // Add priority to the SUB-GRAPH, because the aggregated priorities are in the context of the final graph

--- a/packages/target-graph/src/detectCycles.ts
+++ b/packages/target-graph/src/detectCycles.ts
@@ -1,4 +1,4 @@
-import { Target } from "./types/Target";
+import type { Target } from "./types/Target";
 
 /**
  * Checks for any cycles in the dependency graph, returning `{ hasCycle: false }` if no cycles were detected.
@@ -53,7 +53,7 @@ const searchForCycleDFS = (graph: Map<string, Target>, visitMap: Map<string, boo
   while (stack.length > 0) {
     const current = stack[stack.length - 1];
 
-    console.log(current.node)
+    console.log(current.node);
 
     if (!current.traversing) {
       if (visitMap.has(current.node)) {

--- a/packages/target-graph/src/detectCycles.ts
+++ b/packages/target-graph/src/detectCycles.ts
@@ -22,7 +22,7 @@ export function detectCycles(targets: Map<string, Target>) {
        * Test whether the sub-graph of this node has cycles.
        */
       const cycle = searchForCycleDFS(targets, visitMap, nodeId);
-      if (cycle.length) {
+      if (cycle.length > 0) {
         return { hasCycle: true, cycle };
       }
     }
@@ -52,6 +52,9 @@ const searchForCycleDFS = (graph: Map<string, Target>, visitMap: Map<string, boo
   const stack: StackElement[] = [{ node: nodeId, traversing: false }];
   while (stack.length > 0) {
     const current = stack[stack.length - 1];
+
+    console.log(current.node)
+
     if (!current.traversing) {
       if (visitMap.has(current.node)) {
         if (visitMap.get(current.node)) {

--- a/packages/target-graph/src/detectCycles.ts
+++ b/packages/target-graph/src/detectCycles.ts
@@ -1,0 +1,100 @@
+import { Target } from "./types/Target";
+
+/**
+ * Checks for any cycles in the dependency graph, returning `{ hasCycle: false }` if no cycles were detected.
+ * Otherwise it returns the chain of nodes where the cycle was detected.
+ */
+export function detectCycles(targets: Map<string, Target>) {
+  /**
+   *  A map to keep track of the visited and visiting nodes.
+   * <node, true> entry means it is currently being visited.
+   * <node, false> entry means it's sub graph has been visited and is a DAG.
+   * No entry means the node has not been visited yet.
+   */
+  const visitMap = new Map<string, boolean>();
+
+  for (const [nodeId] of targets.entries()) {
+    /**
+     * Test whether this node has already been visited or not.
+     */
+    if (!visitMap.has(nodeId)) {
+      /**
+       * Test whether the sub-graph of this node has cycles.
+       */
+      const cycle = searchForCycleDFS(targets, visitMap, nodeId);
+      if (cycle.length) {
+        return { hasCycle: true, cycle };
+      }
+    }
+  }
+
+  return { hasCycle: false };
+}
+
+/**
+ * Stack element represents an item on the
+ * stack used for depth-first search
+ */
+interface StackElement {
+  /**
+   * The node name
+   */
+  node: string;
+
+  /**
+   * This represents if this instance of the
+   * node on the stack is being traversed or not
+   */
+  traversing: boolean;
+}
+
+const searchForCycleDFS = (graph: Map<string, Target>, visitMap: Map<string, boolean>, nodeId: string): string[] => {
+  const stack: StackElement[] = [{ node: nodeId, traversing: false }];
+  while (stack.length > 0) {
+    const current = stack[stack.length - 1];
+    if (!current.traversing) {
+      if (visitMap.has(current.node)) {
+        if (visitMap.get(current.node)) {
+          /**
+           * The current node has already been visited,
+           * hence there is a cycle.
+           */
+          const listOfCycle = stack.filter((i) => i.traversing).map((a) => a.node);
+          return listOfCycle.slice(listOfCycle.indexOf(current.node));
+        } else {
+          /**
+           * The current node has already been fully traversed
+           */
+          stack.pop();
+          continue;
+        }
+      }
+
+      /**
+       * The current node is starting its traversal
+       */
+      visitMap.set(current.node, true);
+      stack[stack.length - 1] = { ...current, traversing: true };
+
+      /**
+       * Get the current node in the graph
+       */
+      const node = graph.get(current.node);
+      if (!node) {
+        throw new Error(`Could not find node "${current.node}" in the graph`);
+      }
+
+      /**
+       * Add the current node's dependents to the stack
+       */
+      stack.push(...[...node.dependents].map((n) => ({ node: n, traversing: false })));
+    } else {
+      /**
+       * The current node has now been fully traversed.
+       */
+      visitMap.set(current.node, false);
+      stack.pop();
+    }
+  }
+  return [];
+};

--- a/packages/target-graph/src/index.ts
+++ b/packages/target-graph/src/index.ts
@@ -4,4 +4,5 @@ export type { TargetConfig } from "./types/TargetConfig";
 
 export { sortTargetsByPriority } from "./sortTargetsByPriority";
 export { getPackageAndTask, getTargetId, getStartTargetId } from "./targetId";
+export { detectCycles } from "./detectCycles";
 export { TargetGraphBuilder } from "./TargetGraphBuilder";

--- a/packages/target-graph/tests/detectCycles.test.ts
+++ b/packages/target-graph/tests/detectCycles.test.ts
@@ -1,0 +1,135 @@
+import type { Target } from "../src/types/Target";
+import { detectCycles } from "../src/detectCycles";
+import { getPackageAndTask } from "../src/targetId";
+
+function createTarget({
+  packageName,
+  task,
+  dependencies,
+  dependents,
+}: {
+  packageName: string;
+  task: string;
+  dependencies: string[];
+  dependents: string[];
+}): Target {
+  return {
+    id: `${packageName}#${task}`,
+    label: `${packageName} - ${task}`,
+    task,
+    packageName,
+    dependencies,
+    dependents,
+    depSpecs: [],
+    cwd: `packages/${packageName}`,
+  } as Target;
+}
+
+describe("detectCycles", () => {
+  it("should detect cycles", () => {
+    const targets = new Map<string, Target>();
+    const edges = [
+      ["a#build", "b#build"],
+      ["b#build", "c#build"],
+      ["c#build", "d#build"],
+      ["d#build", "a#build"],
+      ["_start", "a#lint"],
+      ["_start", "b#lint"],
+      ["_start", "c#lint"],
+      ["_start", "d#lint"],
+    ];
+
+    for (const [from, to] of edges) {
+      if (!targets.has(from)) {
+        const { packageName, task } = getPackageAndTask(from);
+        targets.set(
+          from,
+          createTarget({
+            packageName: packageName!,
+            task,
+            dependencies: [],
+            dependents: [],
+          })
+        );
+      }
+
+      if (!targets.has(to)) {
+        const { packageName, task } = getPackageAndTask(to);
+        targets.set(
+          to,
+          createTarget({
+            packageName: packageName!,
+            task,
+            dependencies: [],
+            dependents: [],
+          })
+        );
+      }
+
+      targets.get(from)!.dependencies.push(to);
+      targets.get(to)!.dependents.push(from);
+    }
+
+    expect(detectCycles(targets)).toMatchInlineSnapshot(`
+      {
+        "cycle": [
+          "a#build",
+          "d#build",
+          "c#build",
+          "b#build",
+        ],
+        "hasCycle": true,
+      }
+    `);
+  });
+
+  it("should skip non-cycles", () => {
+    const targets = new Map<string, Target>();
+    const edges = [
+      ["a#build", "b#build"],
+      ["b#build", "c#build"],
+      ["c#build", "d#build"],
+      ["_start", "a#lint"],
+      ["_start", "b#lint"],
+      ["_start", "c#lint"],
+      ["_start", "d#lint"],
+    ];
+
+    for (const [from, to] of edges) {
+      if (!targets.has(from)) {
+        const { packageName, task } = getPackageAndTask(from);
+        targets.set(
+          from,
+          createTarget({
+            packageName: packageName!,
+            task,
+            dependencies: [],
+            dependents: [],
+          })
+        );
+      }
+
+      if (!targets.has(to)) {
+        const { packageName, task } = getPackageAndTask(to);
+        targets.set(
+          to,
+          createTarget({
+            packageName: packageName!,
+            task,
+            dependencies: [],
+            dependents: [],
+          })
+        );
+      }
+
+      targets.get(from)!.dependencies.push(to);
+      targets.get(to)!.dependents.push(from);
+    }
+
+    expect(detectCycles(targets)).toMatchInlineSnapshot(`
+      {
+        "hasCycle": false,
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Porting a really simplistic DFS based cycle detection algorithm from `p-graph`, we are going to detect cycles right when we are building the target-graph. It'll throw an error which would have been hidden in lage v2 because it swallowed all the errors. This time around, we are going to just `console.error()`. The reason for "console" as opposed to "logger" is because these messages COULD come from logging itself.