### PR TITLE
updating various aspects of codebase before the scheduler rework

### DIFF
--- a/change/@lage-run-cli-bcca4670-05ee-4e4c-8f28-c8a698bb70af.json
+++ b/change/@lage-run-cli-bcca4670-05ee-4e4c-8f28-c8a698bb70af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "moved reporters init code in @lage-run/reporters",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-lage-a589ac11-3a61-4898-aa8c-0bf682da09ab.json
+++ b/change/@lage-run-lage-a589ac11-3a61-4898-aa8c-0bf682da09ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "deprecating the registerWorker() api with a warning",
+  "packageName": "@lage-run/lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-lage-a589ac11-3a61-4898-aa8c-0bf682da09ab.json
+++ b/change/@lage-run-lage-a589ac11-3a61-4898-aa8c-0bf682da09ab.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "deprecating the registerWorker() api with a warning",
-  "packageName": "@lage-run/lage",
-  "email": "kchau@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@lage-run-reporters-8f160152-fb0e-41d6-89eb-5f07c697c920.json
+++ b/change/@lage-run-reporters-8f160152-fb0e-41d6-89eb-5f07c697c920.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "moved init code into @lage-run/reporters from @lage-run/cli",
+  "packageName": "@lage-run/reporters",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-worker-threads-pool-173fa36d-dbff-4766-8f60-d033ff56ead8.json
+++ b/change/@lage-run-worker-threads-pool-173fa36d-dbff-4766-8f60-d033ff56ead8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adds support for abort signal",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -12,7 +12,6 @@ module.exports = {
         maxWorkers: 4,
         worker: path.join(__dirname, "scripts/worker/lint.js"),
       },
-      dependsOn: ["@lage-run/worker-threads-pool#build"],
     },
     start: [],
   },

--- a/packages/cli/src/commands/cache/action.ts
+++ b/packages/cli/src/commands/cache/action.ts
@@ -1,10 +1,10 @@
 import { clearCache } from "./clearCache";
 import { Command } from "commander";
 import { getConfig } from "../../config/getConfig";
-import { initializeReporters } from "../../reporters/initialize";
 import { pruneCache } from "./pruneCache";
 import createLogger from "@lage-run/logger";
-import { ReporterInitOptions } from "../../types/LoggerOptions";
+import { initializeReporters } from "@lage-run/reporters";
+import type { ReporterInitOptions } from "@lage-run/reporters";
 
 interface CacheOptions extends ReporterInitOptions {
   prune?: number;

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -5,12 +5,12 @@ import { findNpmClient } from "@lage-run/find-npm-client";
 import { getConfig } from "../../config/getConfig";
 import { getFilteredPackages } from "../../filter/getFilteredPackages";
 import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
-import { initializeReporters } from "../../reporters/initialize";
+import { initializeReporters } from "@lage-run/reporters";
 import { isRunningFromCI } from "../isRunningFromCI";
 import { NpmScriptRunner, SimpleScheduler, WorkerRunner, TargetRunnerPicker } from "@lage-run/scheduler";
 import { TargetGraphBuilder } from "@lage-run/target-graph";
 import createLogger from "@lage-run/logger";
-import type { ReporterInitOptions } from "../../types/LoggerOptions";
+import type { ReporterInitOptions } from "@lage-run/reporters";
 import type { TargetRunner } from "@lage-run/scheduler-types";
 
 function filterArgsForTasks(args: string[]) {

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -34,7 +34,7 @@ addLoggerOptions(runCommand)
   .option("--skip-local-cache", "skips caching locally (defaults to true in CI environments)", isRunningFromCI)
   .option("--profile [profile]", "writes a run profile into a file that can be processed by Chromium devtool")
   .option(
-    "--nodearg <nodeArg>",
+    "--nodearg|--node-arg <nodeArg>",
     'arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable'
   )
   .option("--continue", "continues the run even on error")

--- a/packages/cli/src/config/getConfig.ts
+++ b/packages/cli/src/config/getConfig.ts
@@ -26,6 +26,6 @@ export function getConfig(cwd: string): ConfigOptions {
       "lerna.json",
       "rush.json",
     ],
-    loggerOptions: configResults?.config.loggerOptions ?? {}
+    loggerOptions: configResults?.config.loggerOptions ?? {},
   };
 }

--- a/packages/cli/src/config/getConfig.ts
+++ b/packages/cli/src/config/getConfig.ts
@@ -1,6 +1,6 @@
 import { cosmiconfigSync } from "cosmiconfig";
 import { getWorkspaceRoot } from "workspace-tools";
-import { ConfigOptions } from "../types/ConfigOptions";
+import type { ConfigOptions } from "../types/ConfigOptions";
 
 export function getConfig(cwd: string): ConfigOptions {
   // Verify presence of git
@@ -26,6 +26,6 @@ export function getConfig(cwd: string): ConfigOptions {
       "lerna.json",
       "rush.json",
     ],
-    loggerOptions: configResults?.config.loggerOptions ?? {},
+    loggerOptions: configResults?.config.loggerOptions ?? {}
   };
 }

--- a/packages/cli/src/config/getMaxWorkersPerTask.ts
+++ b/packages/cli/src/config/getMaxWorkersPerTask.ts
@@ -10,7 +10,7 @@ export function getMaxWorkersPerTask(pipelineConfig: ConfigOptions["pipeline"]) 
       let maxWorkers = 0;
       if (typeof maxWorkerOptions === "string") {
         if (maxWorkerOptions.endsWith("%")) {
-          maxWorkers = Math.floor((os.cpus().length) * (parseInt(maxWorkerOptions, 10) / 100));
+          maxWorkers = Math.floor(os.cpus().length * (parseInt(maxWorkerOptions, 10) / 100));
         } else {
           maxWorkers = parseInt(maxWorkerOptions, 10);
         }

--- a/packages/cli/src/config/getMaxWorkersPerTask.ts
+++ b/packages/cli/src/config/getMaxWorkersPerTask.ts
@@ -1,0 +1,28 @@
+import os from "os";
+import type { ConfigOptions } from "../types/ConfigOptions";
+
+export function getMaxWorkersPerTask(pipelineConfig: ConfigOptions["pipeline"]) {
+  const maxWorkersPerTask = new Map<string, number>();
+
+  for (const [task, taskConfig] of Object.entries(pipelineConfig)) {
+    if (!Array.isArray(taskConfig) && !task.includes("#")) {
+      const maxWorkerOptions: string | number = taskConfig.options?.maxWorkers ?? os.cpus().length - 1;
+      let maxWorkers = 0;
+      if (typeof maxWorkerOptions === "string") {
+        if (maxWorkerOptions.endsWith("%")) {
+          maxWorkers = Math.floor((os.cpus().length) * (parseInt(maxWorkerOptions, 10) / 100));
+        } else {
+          maxWorkers = parseInt(maxWorkerOptions, 10);
+        }
+      } else {
+        maxWorkers = maxWorkerOptions;
+      }
+
+      maxWorkers = isNaN(maxWorkers) ? os.cpus().length - 1 : maxWorkers;
+
+      maxWorkersPerTask.set(task, Math.min(maxWorkers, os.cpus().length - 1));
+    }
+  }
+
+  return maxWorkersPerTask;
+}

--- a/packages/cli/src/types/LoggerOptions.ts
+++ b/packages/cli/src/types/LoggerOptions.ts
@@ -13,10 +13,3 @@ export interface LoggerOptions {
     [level: string]: LogLevel;
   };
 }
-
-export interface ReporterInitOptions {
-  reporter: string[] | string;
-  verbose: boolean;
-  grouped: boolean;
-  logLevel: keyof typeof LogLevel;
-}

--- a/packages/cli/tests/getMaxWorkersPerTask.test.ts
+++ b/packages/cli/tests/getMaxWorkersPerTask.test.ts
@@ -1,0 +1,60 @@
+// Mock "os" module to return 8 CPUs
+jest.mock("os", () => {
+  const os = jest.requireActual("os");
+  return {
+    ...os,
+    cpus: jest.fn(() => [{}, {}, {}, {}, {}, {}, {}, {}]),
+  };
+});
+
+import { getMaxWorkersPerTask } from "../src/config/getMaxWorkersPerTask";
+
+describe("getMaxWorkersPerTask", () => {
+  it("parses the pipeline config for maxWorkers", () => {
+    const maxWorkersPerTask = getMaxWorkersPerTask({
+      build: {
+        options: {
+          maxWorkers: "5",
+        },
+      },
+    });
+
+    expect(maxWorkersPerTask.get("build")).toBe(5);
+  });
+
+  it("parses for percentage", () => {
+    const maxWorkersPerTask = getMaxWorkersPerTask({
+      build: {
+        options: {
+          maxWorkers: "50%",
+        },
+      },
+    });
+
+    expect(maxWorkersPerTask.get("build")).toBe(4);
+  });
+
+  it("can handle if a passed-in string isn't a percentage", () => {
+    const maxWorkersPerTask = getMaxWorkersPerTask({
+      build: {
+        options: {
+          maxWorkers: "50",
+        },
+      },
+    });
+
+    expect(maxWorkersPerTask.get("build")).toBe(7);
+  });
+
+  it("can handle non-number-like strings", () => {
+    const maxWorkersPerTask = getMaxWorkersPerTask({
+      build: {
+        options: {
+          maxWorkers: "foo",
+        },
+      },
+    });
+
+    expect(maxWorkersPerTask.get("build")).toBe(7);
+  });
+});

--- a/packages/lage2/index.js
+++ b/packages/lage2/index.js
@@ -1,9 +1,1 @@
-/** 
- * @deprecated 
- * The use of registerWorker is no longer necessary! Simply use the default export or module.exports from a script file.
- **/
-function registerWorker() {
-  console.warn("registerWorker is deprecated, it is no longer necessary!");
-};
-
-export { registerWorker } 
+export { registerWorker } from "@lage-run/worker-threads-pool";

--- a/packages/lage2/index.js
+++ b/packages/lage2/index.js
@@ -1,1 +1,9 @@
-export { registerWorker } from "@lage-run/worker-threads-pool";
+/** 
+ * @deprecated 
+ * The use of registerWorker is no longer necessary! Simply use the default export or module.exports from a script file.
+ **/
+function registerWorker() {
+  console.warn("registerWorker is deprecated, it is no longer necessary!");
+};
+
+export { registerWorker } 

--- a/packages/reporters/src/createReporter.ts
+++ b/packages/reporters/src/createReporter.ts
@@ -1,5 +1,7 @@
 import { LogLevel } from "@lage-run/logger";
-import { JsonReporter, AdoReporter, LogReporter } from "@lage-run/reporters";
+import { JsonReporter } from "./JsonReporter";
+import { AdoReporter } from "./AdoReporter";
+import { LogReporter } from "./LogReporter";
 
 export function createReporter({
   reporter = "npmLog",

--- a/packages/reporters/src/index.ts
+++ b/packages/reporters/src/index.ts
@@ -3,4 +3,8 @@ export { JsonReporter } from "./JsonReporter";
 export { LogReporter } from "./LogReporter";
 export { ChromeTraceEventsReporter } from "./ChromeTraceEventsReporter";
 
+export { initializeReporters } from "./initialize";
+export { createReporter } from "./createReporter";
+
 export type { TargetStatusEntry, TargetMessageEntry } from "./types/TargetLogEntry";
+export type { ReporterInitOptions } from "./initialize";

--- a/packages/reporters/src/initialize.ts
+++ b/packages/reporters/src/initialize.ts
@@ -1,7 +1,12 @@
-import type { Reporter } from "@lage-run/logger";
 import { Logger, LogLevel } from "@lage-run/logger";
-import { ReporterInitOptions } from "../types/LoggerOptions";
 import { createReporter } from "./createReporter";
+
+export interface ReporterInitOptions {
+  reporter: string[] | string;
+  verbose: boolean;
+  grouped: boolean;
+  logLevel: keyof typeof LogLevel;
+}
 
 export function initializeReporters(logger: Logger, options: ReporterInitOptions) {
   const { reporter, verbose, grouped, logLevel } = options;

--- a/packages/reporters/src/initialize.ts
+++ b/packages/reporters/src/initialize.ts
@@ -1,5 +1,6 @@
-import { Logger, LogLevel } from "@lage-run/logger";
+import { LogLevel } from "@lage-run/logger";
 import { createReporter } from "./createReporter";
+import type { Logger } from "@lage-run/logger";
 
 export interface ReporterInitOptions {
   reporter: string[] | string;

--- a/packages/scheduler/tests/WorkerRunner.test.ts
+++ b/packages/scheduler/tests/WorkerRunner.test.ts
@@ -8,14 +8,6 @@ describe("WorkerRunner", () => {
     const workerFixture = path.join(__dirname, "./fixtures/worker.js");
     const logger = new Logger();
 
-    const dummyReporter = {
-      log(entry) {
-        console.log(entry);
-      },
-    } as Reporter;
-
-    logger.addReporter(dummyReporter);
-
     const runner = new WorkerRunner({
       logger,
       workerTargetConfigs: {

--- a/packages/worker-threads-pool/src/Pool.ts
+++ b/packages/worker-threads-pool/src/Pool.ts
@@ -1,11 +1,13 @@
 import type { Worker } from "worker_threads";
 import type { Readable } from "stream";
+import type { AbortSignal } from "abort-controller";
 
 export interface Pool {
   exec(
     data: unknown,
-    setup?: (worker?: Worker, stdout?: Readable, stderr?: Readable) => void,
-    cleanup?: (args: any) => void
+    setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
+    cleanup?: (args: any) => void,
+    abortSignal?: AbortSignal
   ): Promise<unknown>;
   close(): Promise<unknown>;
 }

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -13,6 +13,7 @@ import os from "os";
 import type { Pool } from "./Pool";
 import type { Readable } from "stream";
 import type { WorkerOptions } from "worker_threads";
+import type { AbortSignal } from "abort-controller";
 
 const kTaskInfo = Symbol("kTaskInfo");
 const kWorkerFreedEvent = Symbol("kWorkerFreedEvent");
@@ -188,27 +189,36 @@ export class WorkerPool extends EventEmitter implements Pool {
     this.emit(kWorkerFreedEvent);
   }
 
-  exec(task: unknown, setup?: (worker?: Worker, stdout?: Readable, stderr?: Readable) => void, cleanup?: (worker: Worker) => void) {
+  exec(
+    task: unknown,
+    setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
+    cleanup?: (worker: Worker) => void,
+    abortSignal?: AbortSignal
+  ) {
     return new Promise((resolve, reject) => {
       this.queue.push({ task, resolve, reject, cleanup, setup });
-      this._exec();
+      this._exec(abortSignal);
     });
   }
 
-  _exec() {
+  _exec(abortSignal?: AbortSignal) {
     if (this.freeWorkers.length > 0) {
       const worker = this.freeWorkers.pop();
       const work = this.queue.shift();
       const { task, resolve, reject, cleanup, setup } = work as any;
 
       if (worker) {
+        abortSignal?.addEventListener("abort", () => {
+          worker.postMessage({ type: "abort" });
+        });
+
         worker[kTaskInfo] = new WorkerPoolTaskInfo({ cleanup, resolve, reject, worker, setup });
 
         worker[kWorkerCapturedStreamPromise] = new Promise<void>((onResolve) => {
           worker[kWorkerCapturedStreamEvents].once("end", onResolve);
         });
 
-        worker.postMessage(task);
+        worker.postMessage({ type: "start", task });
       }
     }
   }

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -1,6 +1,7 @@
 import { parentPort } from "worker_threads";
-import { AbortController, AbortSignal } from "abort-controller";
+import { AbortController } from "abort-controller";
 import { END_WORKER_STREAM_MARKER, START_WORKER_STREAM_MARKER } from "./stdioStreamMarkers";
+import type { AbortSignal } from "abort-controller";
 
 export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<void> | void) {
   parentPort?.on("message", async (message) => {
@@ -10,7 +11,7 @@ export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Pro
       case "start":
         abortController = new AbortController();
         return message.task && (await start(message.task, abortController.signal));
-      
+
       case "abort":
         return abortController?.abort();
     }
@@ -25,8 +26,6 @@ export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Pro
     } catch (err) {
       parentPort?.postMessage({ err, results: undefined });
     } finally {
-      
-
       process.stdout.write(`${END_WORKER_STREAM_MARKER}\n`);
       process.stderr.write(`${END_WORKER_STREAM_MARKER}\n`);
     }

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -1,18 +1,34 @@
 import { parentPort } from "worker_threads";
+import { AbortController, AbortSignal } from "abort-controller";
 import { END_WORKER_STREAM_MARKER, START_WORKER_STREAM_MARKER } from "./stdioStreamMarkers";
 
-export function registerWorker(fn: (data: any) => Promise<void> | void) {
-  parentPort?.on("message", async (task) => {
+export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<void> | void) {
+  parentPort?.on("message", async (message) => {
+    let abortController: AbortController | undefined;
+
+    switch (message.type) {
+      case "start":
+        abortController = new AbortController();
+        return message.task && (await start(message.task, abortController.signal));
+      
+      case "abort":
+        return abortController?.abort();
+    }
+  });
+
+  async function start(task: any, abortSignal?: AbortSignal) {
     try {
       process.stdout.write(`${START_WORKER_STREAM_MARKER}\n`);
       process.stderr.write(`${START_WORKER_STREAM_MARKER}\n`);
-      const results = await fn(task);
+      const results = await fn(task, abortSignal);
       parentPort?.postMessage({ err: undefined, results });
     } catch (err) {
       parentPort?.postMessage({ err, results: undefined });
     } finally {
+      
+
       process.stdout.write(`${END_WORKER_STREAM_MARKER}\n`);
       process.stderr.write(`${END_WORKER_STREAM_MARKER}\n`);
     }
-  });
+  }
 }

--- a/scripts/worker/lint.js
+++ b/scripts/worker/lint.js
@@ -2,7 +2,7 @@
 const { ESLint } = require("eslint");
 const PROJECT_ROOT = require("path").resolve(__dirname, "..", "..");
 
-const { registerWorker } = require("@lage-run/worker-threads-pool");
+const { registerWorker } = require("lage-npm");
 const { readFile } = require("fs/promises");
 
 const path = require("path");


### PR DESCRIPTION
1. updated to move the report init code to be inside reporters package
2. create a getMaxWorkersPerTask function (Unused yet in this PR)
3. update the registerWorker to not be needed (gives a warning)
4. Update WorkerRunner test to no output anything in console
5. update worker-threads-pool to understand abortSignals