### PR TITLE
Fix workers 

### DIFF
--- a/change/@lage-run-lage-243f3f81-fa92-479d-9d3f-37cecbcee1d9.json
+++ b/change/@lage-run-lage-243f3f81-fa92-479d-9d3f-37cecbcee1d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing the targetWorker",
+  "packageName": "@lage-run/lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage2/index.js
+++ b/packages/lage2/index.js
@@ -2,7 +2,7 @@
  * @deprecated 
  * The use of registerWorker is no longer necessary! Simply use the default export or module.exports from a script file.
  **/
-function registerWorker() {
+function registerWorker(_fn) {
   console.warn("registerWorker is deprecated, it is no longer necessary!");
 };
 

--- a/packages/lage2/rollup.config.js
+++ b/packages/lage2/rollup.config.js
@@ -4,50 +4,74 @@ import json from "@rollup/plugin-json";
 import { terser } from "rollup-plugin-terser";
 import alias from "@rollup/plugin-alias";
 
-export default [{
-  input: "@lage-run/cli/lib/cli.js",
-  output: {
-    banner: "#!/usr/bin/env node",
-    sourcemap: "inline",
-    file: "dist/lage.js",
-    format: "cjs",
-    exports: "auto",
-    sourcemap: true,
+export default [
+  {
+    input: "@lage-run/cli/lib/cli.js",
+    output: {
+      banner: "#!/usr/bin/env node",
+      sourcemap: "inline",
+      file: "dist/lage.js",
+      format: "cjs",
+      exports: "auto",
+      sourcemap: true,
+    },
+    plugins: [
+      alias({
+        // Added this entry to guard against readable-stream's WEIRD import of "string_decoder/" (present in v3.x)
+        entries: [{ find: "string_decoder/", replacement: "string_decoder" }],
+      }),
+      nodeResolve({
+        // Since we are produce CJS, let's resolve main first!
+        mainFields: ["main", "module"],
+        preferBuiltins: true,
+      }),
+      commonjs({
+        ignoreDynamicRequires: true,
+      }),
+      json(),
+      terser(),
+    ],
   },
-  plugins: [
-    alias({
-      // Added this entry to guard against readable-stream's WEIRD import of "string_decoder/" (present in v3.x)
-      entries: [{ find: "string_decoder/", replacement: "string_decoder" }],
-    }),
-    nodeResolve({
-      // Since we are produce CJS, let's resolve main first!
-      mainFields: ["main", "module"],
-      preferBuiltins: true,
-    }),
-    commonjs({
-      ignoreDynamicRequires: true,
-    }),
-    json(),
-    terser(),
-  ],
-}, {
-  input: "./index.js",
-  output: {
-    file: "dist/main.js",
-    format: "cjs",
-    exports: "auto",
-    sourcemap: true,
+  {
+    input: "./index.js",
+    output: {
+      file: "dist/main.js",
+      format: "cjs",
+      exports: "auto",
+      sourcemap: true,
+    },
+    plugins: [
+      nodeResolve({
+        // Since we are produce CJS, let's resolve main first!
+        mainFields: ["main", "module"],
+        preferBuiltins: true,
+      }),
+      commonjs({
+        ignoreDynamicRequires: true,
+      }),
+      json(),
+      terser(),
+    ],
   },
-  plugins: [
-    nodeResolve({
-      // Since we are produce CJS, let's resolve main first!
-      mainFields: ["main", "module"],
-      preferBuiltins: true,
-    }),
-    commonjs({
-      ignoreDynamicRequires: true,
-    }),
-    json(),
-    terser(),
-  ]
-}];
+  {
+    input: "@lage-run/scheduler/lib/workers/targetWorker.js",
+    output: {
+      file: "dist/workers/targetWorker.js",
+      format: "cjs",
+      exports: "auto",
+      sourcemap: true,
+    },
+    plugins: [
+      nodeResolve({
+        // Since we are produce CJS, let's resolve main first!
+        mainFields: ["main", "module"],
+        preferBuiltins: true,
+      }),
+      commonjs({
+        ignoreDynamicRequires: true,
+      }),
+      json(),
+      terser(),
+    ],
+  },
+];

--- a/packages/lage2/scripts/prebuild.js
+++ b/packages/lage2/scripts/prebuild.js
@@ -5,7 +5,6 @@ const cwd = process.cwd();
 const schedulerPath = path.dirname(require.resolve("@lage-run/scheduler/package.json"));
 
 const runners = fs.readdirSync(path.join(schedulerPath, "lib", "runners"));
-const workers = fs.readdirSync(path.join(schedulerPath, "lib", "workers"));
 
 function prebuild() {
   fs.mkdirSync(path.join(schedulerPath, "runners"), { recursive: true });
@@ -16,14 +15,6 @@ function prebuild() {
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.copyFileSync(src, dest);
     }
-  }
-
-  fs.mkdirSync(path.join(schedulerPath, "workers"), { recursive: true });
-  for (const worker of workers) {
-    const src = path.join(schedulerPath, "lib", "workers", worker);
-    const dest = path.join(cwd, "dist", "workers", worker);
-    fs.mkdirSync(path.dirname(dest), { recursive: true });
-    fs.copyFileSync(src, dest);
   }
 }
 


### PR DESCRIPTION
The rollup config now needs to bundle the targetWorkers as well because it contains an internal package import to the threadspool "registerWorker"
