### PR TITLE
Fix remote cache: when backfill env variables are used, enable remote cache provider

### DIFF
--- a/change/@lage-run-cli-7edad6a1-2a4c-4c05-afa1-26ed9d762ec3.json
+++ b/change/@lage-run-cli-7edad6a1-2a4c-4c05-afa1-26ed9d762ec3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes remote cache configuration for when environment variables are used instead of the config file",
+  "packageName": "@lage-run/cli",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -84,6 +84,9 @@ export async function runAction(options: RunOptions, command: Command) {
 
   const targetGraph = builder.buildTargetGraph(tasks, packages);
 
+  const hasRemoteCacheConfig =
+    !!config.cacheOptions?.cacheStorageConfig || !!process.env.BACKFILL_CACHE_PROVIDER || !!process.env.BACKFILL_CACHE_PROVIDER_OPTIONS;
+
   // Create Cache Provider
   const cacheProvider = new RemoteFallbackCacheProvider({
     root,
@@ -98,9 +101,7 @@ export async function runAction(options: RunOptions, command: Command) {
               ...(config.cacheOptions.internalCacheFolder && { internalCacheFolder: config.cacheOptions.internalCacheFolder }),
             },
           }),
-    remoteCacheProvider: config.cacheOptions?.cacheStorageConfig
-      ? new BackfillCacheProvider({ root, cacheOptions: config.cacheOptions })
-      : undefined,
+    remoteCacheProvider: hasRemoteCacheConfig ? new BackfillCacheProvider({ root, cacheOptions: config.cacheOptions }) : undefined,
     writeRemoteCache:
       config.cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI,
   });


### PR DESCRIPTION
We need to also consider the case where people are configuring the cache provider via the config file