### PR TITLE
The workerpool wasn't awaiting on the stderr before moving onto the next target

### DIFF
--- a/change/@lage-run-worker-threads-pool-ba08f50c-17dc-49cb-913a-87a8f206c5cc.json
+++ b/change/@lage-run-worker-threads-pool-ba08f50c-17dc-49cb-913a-87a8f206c5cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes stdio streams capturing so the logs belong to the right worker and task",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -6,9 +6,10 @@
 import { AsyncResource } from "async_hooks";
 import { createFilteredStreamTransform } from "./createFilteredStreamTransform";
 import { createInterface } from "readline";
-import { END_WORKER_STREAM_MARKER, START_WORKER_STREAM_MARKER } from "./stdioStreamMarkers";
+import { endMarker, startMarker } from "./stdioStreamMarkers";
 import { EventEmitter } from "events";
 import { Worker } from "worker_threads";
+import crypto from "crypto";
 import os from "os";
 import type { Pool } from "./Pool";
 import type { Readable } from "stream";
@@ -17,12 +18,17 @@ import type { AbortSignal } from "abort-controller";
 
 const kTaskInfo = Symbol("kTaskInfo");
 const kWorkerFreedEvent = Symbol("kWorkerFreedEvent");
-const kWorkerCapturedStreamEvents = Symbol("kWorkerCapturedStreamEvents");
-const kWorkerCapturedStreamPromise = Symbol("kWorkerCapturedStreamPromise");
+
+const kWorkerCapturedStdoutResolve = Symbol("kWorkerCapturedStdoutResolve");
+const kWorkerCapturedStderrResolve = Symbol("kWorkerCapturedStderrResolve");
+
+const kWorkerCapturedStdoutPromise = Symbol("kWorkerCapturedStdoutPromise");
+const kWorkerCapturedStderrPromise = Symbol("kWorkerCapturedStderrPromise");
 
 class WorkerPoolTaskInfo extends AsyncResource {
   constructor(
     private options: {
+      id: string;
       setup: (worker: Worker, stdout: Readable, stderr: Readable) => void;
       cleanup: (worker: Worker) => void;
       resolve: (value: unknown) => void;
@@ -35,6 +41,10 @@ class WorkerPoolTaskInfo extends AsyncResource {
     if (options.setup) {
       this.runInAsyncScope(options.setup, null, options.worker, options.worker["filteredStdout"], options.worker["filteredStderr"]);
     }
+  }
+
+  get id() {
+    return this.options.id;
   }
 
   done(err: Error, results: unknown) {
@@ -102,9 +112,6 @@ export class WorkerPool extends EventEmitter implements Pool {
   }
 
   captureWorkerStdioStreams(worker: Worker) {
-    const capturedStreamEvent = new EventEmitter();
-    worker[kWorkerCapturedStreamEvents] = capturedStreamEvent;
-
     const stdout = worker.stdout;
     const stdoutInterface = createInterface({
       input: stdout,
@@ -117,22 +124,28 @@ export class WorkerPool extends EventEmitter implements Pool {
       crlfDelay: Infinity,
     });
 
-    const lineHandlerFactory = () => {
+    const lineHandlerFactory = (outputType: string) => {
       let lines: string[] = [];
+      let resolve: () => void = () => {};
 
       return (line: string) => {
-        if (line.includes(START_WORKER_STREAM_MARKER)) {
+        if (line.includes(startMarker(worker[kTaskInfo].id))) {
           lines = [];
-        } else if (line.includes(END_WORKER_STREAM_MARKER)) {
-          worker[kWorkerCapturedStreamEvents].emit("end", lines);
+          if (outputType === "stdout") {
+            resolve = worker[kWorkerCapturedStdoutResolve];
+          } else {
+            resolve = worker[kWorkerCapturedStderrResolve];
+          }
+        } else if (line.includes(endMarker(worker[kTaskInfo].id))) {
+          resolve();
         } else {
           lines.push(line);
         }
       };
     };
 
-    const stdoutLineHandler = lineHandlerFactory();
-    const stderrLineHandler = lineHandlerFactory();
+    const stdoutLineHandler = lineHandlerFactory("stdout");
+    const stderrLineHandler = lineHandlerFactory("stderr");
 
     stdoutInterface.on("line", stdoutLineHandler);
     stderrInterface.on("line", stderrLineHandler);
@@ -142,10 +155,11 @@ export class WorkerPool extends EventEmitter implements Pool {
     const { script, workerOptions } = this.options;
     const worker = new Worker(script, { ...workerOptions, stdout: true, stderr: true });
 
-    const capturedStreamEvent = new EventEmitter();
-    worker[kWorkerCapturedStreamEvents] = capturedStreamEvent;
-    worker[kWorkerCapturedStreamPromise] = Promise.resolve();
+    worker[kWorkerCapturedStderrPromise] = Promise.resolve();
+    worker[kWorkerCapturedStdoutPromise] = Promise.resolve();
+
     this.captureWorkerStdioStreams(worker);
+
     worker["filteredStdout"] = worker.stdout.pipe(createFilteredStreamTransform());
     worker["filteredStderr"] = worker.stderr.pipe(createFilteredStreamTransform());
 
@@ -153,9 +167,8 @@ export class WorkerPool extends EventEmitter implements Pool {
       // In case of success: Call the callback that was passed to `runTask`,
       // remove the `TaskInfo` associated with the Worker, and mark it as free
       // again.
-      worker[kWorkerCapturedStreamPromise].then(() => {
+      Promise.all([worker[kWorkerCapturedStdoutPromise], worker[kWorkerCapturedStderrPromise]]).then(() => {
         const { err, results } = data;
-
         worker[kTaskInfo].done(err, results);
         worker[kTaskInfo] = null;
         this.freeWorkers.push(worker);
@@ -166,7 +179,7 @@ export class WorkerPool extends EventEmitter implements Pool {
     worker.on("message", msgHandler);
 
     const errHandler = (err) => {
-      worker[kWorkerCapturedStreamPromise].then(() => {
+      Promise.all([worker[kWorkerCapturedStdoutPromise], worker[kWorkerCapturedStderrPromise]]).then(() => {
         // In case of an uncaught exception: Call the callback that was passed to
         // `runTask` with the error.
         if (worker[kTaskInfo]) {
@@ -212,13 +225,21 @@ export class WorkerPool extends EventEmitter implements Pool {
           worker.postMessage({ type: "abort" });
         });
 
-        worker[kTaskInfo] = new WorkerPoolTaskInfo({ cleanup, resolve, reject, worker, setup });
+        const id = crypto.randomBytes(32).toString("hex");
 
-        worker[kWorkerCapturedStreamPromise] = new Promise<void>((onResolve) => {
-          worker[kWorkerCapturedStreamEvents].once("end", onResolve);
+        worker[kTaskInfo] = new WorkerPoolTaskInfo({ id, cleanup, resolve, reject, worker, setup });
+
+        // Create a pair of promises that are only resolved when a specific task end marker is detected
+        // in the worker's stdout/stderr streams.
+        worker[kWorkerCapturedStdoutPromise] = new Promise<void>((onResolve) => {
+          worker[kWorkerCapturedStdoutResolve] = onResolve;
         });
 
-        worker.postMessage({ type: "start", task });
+        worker[kWorkerCapturedStderrPromise] = new Promise<void>((onResolve) => {
+          worker[kWorkerCapturedStderrResolve] = onResolve;
+        });
+
+        worker.postMessage({ type: "start", task, id });
       }
     }
   }

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -126,7 +126,7 @@ export class WorkerPool extends EventEmitter implements Pool {
 
     const lineHandlerFactory = (outputType: string) => {
       let lines: string[] = [];
-      let resolve: () => void = () => {};
+      let resolve: () => void;
 
       return (line: string) => {
         if (line.includes(startMarker(worker[kTaskInfo].id))) {

--- a/packages/worker-threads-pool/src/createFilteredStreamTransform.ts
+++ b/packages/worker-threads-pool/src/createFilteredStreamTransform.ts
@@ -1,17 +1,17 @@
 import { Transform } from "stream";
-import { END_WORKER_STREAM_MARKER, START_WORKER_STREAM_MARKER } from "./stdioStreamMarkers";
+import { END_MARKER_PREFIX, START_MARKER_PREFIX } from "./stdioStreamMarkers";
 
 export function createFilteredStreamTransform(): Transform {
   const transform = new Transform({
     transform(chunk, _encoding, callback) {
       let str = chunk.toString();
 
-      if (str.includes(START_WORKER_STREAM_MARKER)) {
-        str = str.replace(START_WORKER_STREAM_MARKER + "\n", "");
+      if (str.includes(START_MARKER_PREFIX)) {
+        str = str.replace(new RegExp(START_MARKER_PREFIX + "[0-9a-z]{64}\n"), "");
       }
 
-      if (str.includes(END_WORKER_STREAM_MARKER)) {
-        str = str.replace(END_WORKER_STREAM_MARKER + "\n", "");
+      if (str.includes(END_MARKER_PREFIX)) {
+        str = str.replace(new RegExp(END_MARKER_PREFIX + "[0-9a-z]{64}\n"), "");
       }
 
       callback(null, str);

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -1,6 +1,6 @@
 import { parentPort } from "worker_threads";
 import { AbortController } from "abort-controller";
-import { END_WORKER_STREAM_MARKER, START_WORKER_STREAM_MARKER } from "./stdioStreamMarkers";
+import { endMarker, END_MARKER_PREFIX, startMarker, START_MARKER_PREFIX } from "./stdioStreamMarkers";
 import type { AbortSignal } from "abort-controller";
 
 export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<void> | void) {
@@ -10,24 +10,24 @@ export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Pro
     switch (message.type) {
       case "start":
         abortController = new AbortController();
-        return message.task && (await start(message.task, abortController.signal));
+        return message.task && (await start(message.id, message.task, abortController.signal));
 
       case "abort":
         return abortController?.abort();
     }
   });
 
-  async function start(task: any, abortSignal?: AbortSignal) {
+  async function start(workerTaskId: string, task: any, abortSignal?: AbortSignal) {
     try {
-      process.stdout.write(`${START_WORKER_STREAM_MARKER}\n`);
-      process.stderr.write(`${START_WORKER_STREAM_MARKER}\n`);
+      process.stdout.write(`${startMarker(workerTaskId)}\n`);
+      process.stderr.write(`${startMarker(workerTaskId)}\n`);
       const results = await fn(task, abortSignal);
       parentPort?.postMessage({ err: undefined, results });
     } catch (err) {
       parentPort?.postMessage({ err, results: undefined });
     } finally {
-      process.stdout.write(`${END_WORKER_STREAM_MARKER}\n`);
-      process.stderr.write(`${END_WORKER_STREAM_MARKER}\n`);
+      process.stdout.write(`${endMarker(workerTaskId)}\n`);
+      process.stderr.write(`${endMarker(workerTaskId)}\n`);
     }
   }
 }

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -1,6 +1,6 @@
 import { parentPort } from "worker_threads";
 import { AbortController } from "abort-controller";
-import { endMarker, END_MARKER_PREFIX, startMarker, START_MARKER_PREFIX } from "./stdioStreamMarkers";
+import { endMarker, startMarker } from "./stdioStreamMarkers";
 import type { AbortSignal } from "abort-controller";
 
 export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<void> | void) {

--- a/packages/worker-threads-pool/src/stdioStreamMarkers.ts
+++ b/packages/worker-threads-pool/src/stdioStreamMarkers.ts
@@ -5,6 +5,6 @@ export function startMarker(id: string) {
   return `${START_MARKER_PREFIX}${id}`;
 }
 
-export function endMarker(id:string) {
+export function endMarker(id: string) {
   return `${END_MARKER_PREFIX}${id}`;
 }

--- a/packages/worker-threads-pool/src/stdioStreamMarkers.ts
+++ b/packages/worker-threads-pool/src/stdioStreamMarkers.ts
@@ -1,2 +1,10 @@
-export const START_WORKER_STREAM_MARKER = "## WORKER:START:";
-export const END_WORKER_STREAM_MARKER = "## WORKER:END:";
+export const START_MARKER_PREFIX = "## WORKER:START:";
+export const END_MARKER_PREFIX = "## WORKER:END:";
+
+export function startMarker(id: string) {
+  return `${START_MARKER_PREFIX}${id}`;
+}
+
+export function endMarker(id:string) {
+  return `${END_MARKER_PREFIX}${id}`;
+}

--- a/packages/worker-threads-pool/tests/fixtures/my-bad-worker.js
+++ b/packages/worker-threads-pool/tests/fixtures/my-bad-worker.js
@@ -4,10 +4,34 @@ const { parentPort } = require("worker_threads");
 const START_WORKER_STREAM_MARKER = "## WORKER:START:";
 const END_WORKER_STREAM_MARKER = "## WORKER:END:";
 
-parentPort?.on("message", async () => {
-  process.stdout.write(`${START_WORKER_STREAM_MARKER}\n`);
-  process.stderr.write(`${START_WORKER_STREAM_MARKER}\n`);
-  parentPort?.postMessage({ err: "BAD", results: undefined });
-  process.stdout.write(`${END_WORKER_STREAM_MARKER}\n`);
-  process.stderr.write(`${END_WORKER_STREAM_MARKER}\n`);
+
+parentPort?.on("message", async (message) => {
+  let abortController;
+
+  switch (message.type) {
+    case "start":
+      abortController = new AbortController();
+      return message.task && (await start(message.task, abortController.signal, message.id));
+
+    case "abort":
+      return abortController?.abort();
+  }
 });
+
+function fn() {
+  return Promise.reject();
+}
+
+async function start(task, abortSignal, id) {
+  try {
+    process.stdout.write(`${START_WORKER_STREAM_MARKER}${id}\n`);
+    process.stderr.write(`${START_WORKER_STREAM_MARKER}${id}\n`);
+    const results = await fn(task, abortSignal);
+    parentPort?.postMessage({ err: undefined, results });
+  } catch (err) {
+    parentPort?.postMessage({ err, results: undefined });
+  } finally {
+    process.stdout.write(`${END_WORKER_STREAM_MARKER}${id}\n`);
+    process.stderr.write(`${END_WORKER_STREAM_MARKER}${id}\n`);
+  }
+}

--- a/packages/worker-threads-pool/tests/fixtures/my-worker.js
+++ b/packages/worker-threads-pool/tests/fixtures/my-worker.js
@@ -10,7 +10,7 @@ parentPort?.on("message", async (message) => {
   switch (message.type) {
     case "start":
       abortController = new AbortController();
-      return message.task && (await start(message.task, abortController.signal));
+      return message.task && (await start(message.task, abortController.signal, message.id));
 
     case "abort":
       return abortController?.abort();
@@ -21,16 +21,16 @@ function fn() {
   return Promise.resolve();
 }
 
-async function start(task, abortSignal) {
+async function start(task, abortSignal, id) {
   try {
-    process.stdout.write(`${START_WORKER_STREAM_MARKER}\n`);
-    process.stderr.write(`${START_WORKER_STREAM_MARKER}\n`);
+    process.stdout.write(`${START_WORKER_STREAM_MARKER}${id}\n`);
+    process.stderr.write(`${START_WORKER_STREAM_MARKER}${id}\n`);
     const results = await fn(task, abortSignal);
     parentPort?.postMessage({ err: undefined, results });
   } catch (err) {
     parentPort?.postMessage({ err, results: undefined });
   } finally {
-    process.stdout.write(`${END_WORKER_STREAM_MARKER}\n`);
-    process.stderr.write(`${END_WORKER_STREAM_MARKER}\n`);
+    process.stdout.write(`${END_WORKER_STREAM_MARKER}${id}\n`);
+    process.stderr.write(`${END_WORKER_STREAM_MARKER}${id}\n`);
   }
 }


### PR DESCRIPTION
This PR corrects the issue where the workerpool is declaring a task done when only ONE of the stdio streams has an end marker. The fix is to replace eventemitters with keeping a pair of instances of `Promise`. We then let the message interface detect whether we need to resolve these promises. We only fulfill the task promise when these three promises are fulfilled:

1. the task function itself
2. the stdout capture promise
3. the stderr capture promise

In this way, we ensure the worker does not take on additional work until the logs are flushed!