### PR TITLE
Adds an unstable watch mode (--unstable-watch)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Jest",

--- a/change/@lage-run-cli-89576ae4-f614-46a0-9b6a-4b5138899277.json
+++ b/change/@lage-run-cli-89576ae4-f614-46a0-9b6a-4b5138899277.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a watch mode action",
+  "packageName": "@lage-run/cli",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-lage-3c30f649-40ed-45aa-a27b-304b1489e0e7.json
+++ b/change/@lage-run-lage-3c30f649-40ed-45aa-a27b-304b1489e0e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adding a watch mode action",
+  "packageName": "@lage-run/lage",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-reporters-c50dc845-c473-4150-aafa-07d630169665.json
+++ b/change/@lage-run-reporters-c50dc845-c473-4150-aafa-07d630169665.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a watch mode action",
+  "packageName": "@lage-run/reporters",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-d241d746-05f7-4848-81c0-a2d2dac18d94.json
+++ b/change/@lage-run-scheduler-d241d746-05f7-4848-81c0-a2d2dac18d94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a watch mode action",
+  "packageName": "@lage-run/scheduler",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-types-fdf89b8a-b705-49db-a633-bfefe34b7b97.json
+++ b/change/@lage-run-scheduler-types-fdf89b8a-b705-49db-a633-bfefe34b7b97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a watch mode action",
+  "packageName": "@lage-run/scheduler-types",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "@lage-run/cache": "^0.1.19",
     "@lage-run/reporters": "^0.2.21",
     "commander": "^9.4.0",
-    "workspace-tools": "^0.28.0"
+    "workspace-tools": "^0.28.0",
+    "watchpack": "^2.4.0"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "@lage-run/reporters": "^0.2.21",
     "commander": "^9.4.0",
     "workspace-tools": "^0.28.0",
-    "chokidar": "^3.5.3"
+    "chokidar": "3.5.3"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "@lage-run/reporters": "^0.2.21",
     "commander": "^9.4.0",
     "workspace-tools": "^0.28.0",
-    "watchpack": "^2.4.0"
+    "chokidar": "^3.5.3"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*"

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -16,11 +16,11 @@ interface RunOptions extends ReporterInitOptions {
   resetCache: boolean;
   nodeArg: string;
   ignore: string[];
-  watch: boolean;
+  unstableWatch: boolean;
 }
 
 export async function action(options: RunOptions, command: Command) {
-  if (options.watch) {
+  if (options.unstableWatch) {
     return watchAction(options, command);
   } else {
     return runAction(options, command);

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -5,21 +5,19 @@ import { findNpmClient } from "@lage-run/find-npm-client";
 import { getConfig } from "../../config/getConfig";
 import { getFilteredPackages } from "../../filter/getFilteredPackages";
 import { getMaxWorkersPerTask } from "../../config/getMaxWorkersPerTask";
-import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import { getPackageInfos, getWorkspaceRoot, PackageInfos } from "workspace-tools";
 import { initializeReporters } from "@lage-run/reporters";
 import { isRunningFromCI } from "../isRunningFromCI";
 import { SimpleScheduler } from "@lage-run/scheduler";
-import { TargetGraphBuilder } from "@lage-run/target-graph";
-import createLogger from "@lage-run/logger";
+import { TargetGraph, TargetGraphBuilder } from "@lage-run/target-graph";
+import createLogger, { Logger, Reporter } from "@lage-run/logger";
 import type { ReporterInitOptions } from "@lage-run/reporters";
-
-function filterArgsForTasks(args: string[]) {
-  const optionsPosition = args.findIndex((arg) => arg.startsWith("-"));
-  return {
-    tasks: args.slice(0, optionsPosition === -1 ? undefined : optionsPosition),
-    taskArgs: optionsPosition === -1 ? [] : args.slice(optionsPosition),
-  };
-}
+import { filterArgsForTasks } from "./filterArgsForTasks";
+import { createTargetGraph } from "./createTargetGraph";
+import { createCache } from "./createCacheProvider";
+import { SchedulerRunSummary, TargetScheduler } from "@lage-run/scheduler-types";
+import Watchpack from "watchpack";
+import path from "path";
 
 interface RunOptions extends ReporterInitOptions {
   concurrency: number;
@@ -34,6 +32,7 @@ interface RunOptions extends ReporterInitOptions {
   resetCache: boolean;
   nodeArg: string;
   ignore: string[];
+  watch: boolean;
 }
 
 export async function runAction(options: RunOptions, command: Command) {
@@ -54,64 +53,28 @@ export async function runAction(options: RunOptions, command: Command) {
   const root = getWorkspaceRoot(process.cwd())!;
   const packageInfos = getPackageInfos(root);
 
-  const builder = new TargetGraphBuilder(root, packageInfos);
-
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 
-  const packages = getFilteredPackages({
-    root,
+  const targetGraph = createTargetGraph({
     logger,
-    packageInfos,
-    includeDependencies: options.dependencies,
-    includeDependents: options.dependents,
-    since: options.since,
-    scope: options.scope,
+    root,
+    dependencies: options.dependencies,
+    dependents: options.dependents,
+    ignore: options.ignore.concat(config.ignore),
+    pipeline: config.pipeline,
     repoWideChanges: config.repoWideChanges,
-    sinceIgnoreGlobs: options.ignore.concat(config.ignore),
+    scope: options.scope,
+    since: options.since,
+    outputs: config.cacheOptions.outputGlob,
+    tasks,
+    packageInfos,
   });
 
-  for (const [id, definition] of Object.entries(config.pipeline)) {
-    if (Array.isArray(definition)) {
-      builder.addTargetConfig(id, {
-        cache: true,
-        dependsOn: definition,
-        options: {},
-        outputs: config.cacheOptions.outputGlob,
-      });
-    } else {
-      builder.addTargetConfig(id, definition);
-    }
-  }
-
-  const targetGraph = builder.buildTargetGraph(tasks, packages);
-
-  const hasRemoteCacheConfig =
-    !!config.cacheOptions?.cacheStorageConfig || !!process.env.BACKFILL_CACHE_PROVIDER || !!process.env.BACKFILL_CACHE_PROVIDER_OPTIONS;
-
-  // Create Cache Provider
-  const cacheProvider = new RemoteFallbackCacheProvider({
+  const { cacheProvider, hasher } = createCache({
     root,
     logger,
-    localCacheProvider:
-      options.skipLocalCache === true
-        ? undefined
-        : new BackfillCacheProvider({
-            logger,
-            root,
-            cacheOptions: {
-              outputGlob: config.cacheOptions.outputGlob,
-              ...(config.cacheOptions.internalCacheFolder && { internalCacheFolder: config.cacheOptions.internalCacheFolder }),
-            },
-          }),
-    remoteCacheProvider: hasRemoteCacheConfig ? new BackfillCacheProvider({ logger, root, cacheOptions: config.cacheOptions }) : undefined,
-    writeRemoteCache:
-      config.cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI,
-  });
-
-  const hasher = new TargetHasher({
-    root,
-    environmentGlob: config.cacheOptions.environmentGlob,
-    cacheKey: config.cacheOptions.cacheKey,
+    cacheOptions: config.cacheOptions,
+    skipLocalCache: options.skipLocalCache,
   });
 
   const scheduler = new SimpleScheduler({
@@ -140,13 +103,77 @@ export async function runAction(options: RunOptions, command: Command) {
     },
   });
 
-  const summary = await scheduler.run(root, targetGraph);
+  if (options.watch) {
+    launchWatch({ logger, scheduler, root, targetGraph, packageInfos });
+  } else {
+    await launchRun({ logger, scheduler, root, targetGraph });
+  }
+}
 
+function launchWatch(options: {
+  logger: Logger;
+  scheduler: TargetScheduler;
+  root: string;
+  targetGraph: TargetGraph;
+  packageInfos: PackageInfos;
+}) {
+  const { logger, scheduler, root, targetGraph, packageInfos } = options;
+
+  logger.info("running scheduler in watch mode");
+
+  // scheduler.run(root, targetGraph);
+
+  var watchpack = new Watchpack({
+    // options:
+    aggregateTimeout: 1000,
+    // fire "aggregated" event when after a change for 1000ms no additional change occurred
+    // aggregated defaults to undefined, which doesn't fire an "aggregated" event
+
+    // poll: true,
+    // poll: true - use polling with the default interval
+    // poll: 10000 - use polling with an interval of 10s
+    // poll defaults to undefined, which prefer native watching methods
+    // Note: enable polling when watching on a network path
+    // When WATCHPACK_POLLING environment variable is set it will override this option
+
+    followSymlinks: true,
+    // true: follows symlinks and watches symlinks and real files
+    //   (This makes sense when symlinks has not been resolved yet, comes with a performance hit)
+    // false (default): watches only specified item they may be real files or symlinks
+    //   (This makes sense when symlinks has already been resolved)
+
+    ignored: ["**/.git", "**/node_modules"],
+    // ignored: "string" - a glob pattern for files or folders that should not be watched
+    // ignored: ["string", "string"] - multiple glob patterns that should be ignored
+    // ignored: /regexp/ - a regular expression for files or folders that should not be watched
+    // ignored: (entry) => boolean - an arbitrary function which must return truthy to ignore an entry
+    // For all cases expect the arbitrary function the path will have path separator normalized to '/'.
+    // All subdirectories are ignored too
+  });
+
+  const directories = Object.values(packageInfos).map((info) => path.join(root, path.dirname(info.packageJsonPath)));
+  watchpack.watch({
+    startTime: Date.now() - 10000,
+    files: directories.map((d) => path.join(d, "src/**/*")),
+  });
+
+  watchpack.on("aggregated", (changes, details) => {
+    logger.info("change detected " + JSON.stringify(changes) + " " + JSON.stringify(details));
+  });
+}
+
+async function launchRun(options: { logger: Logger; scheduler: TargetScheduler; root: string; targetGraph: TargetGraph }) {
+  const { logger, scheduler, root, targetGraph } = options;
+  const summary = await scheduler.run(root, targetGraph);
+  displaySummaryAndExit(summary, logger.reporters);
+}
+
+function displaySummaryAndExit(summary: SchedulerRunSummary, reporters: Reporter[]) {
   if (summary.results !== "success") {
     process.exitCode = 1;
   }
 
-  for (const reporter of logger.reporters) {
+  for (const reporter of reporters) {
     reporter.summarize(summary);
   }
 }

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -1,19 +1,7 @@
 import { Command } from "commander";
-import { createProfileReporter } from "./createProfileReporter";
-import { findNpmClient } from "@lage-run/find-npm-client";
-import { getConfig } from "../../config/getConfig";
-import { getMaxWorkersPerTask } from "../../config/getMaxWorkersPerTask";
-import { getPackageInfos, getWorkspaceRoot, PackageInfos } from "workspace-tools";
-import { initializeReporters } from "@lage-run/reporters";
-import { SimpleScheduler } from "@lage-run/scheduler";
-import { TargetGraph } from "@lage-run/target-graph";
-import createLogger, { Logger, Reporter } from "@lage-run/logger";
+import { runAction } from "./runAction";
+import { watchAction } from "./watchAction";
 import type { ReporterInitOptions } from "@lage-run/reporters";
-import { filterArgsForTasks } from "./filterArgsForTasks";
-import { createTargetGraph } from "./createTargetGraph";
-import { createCache } from "./createCacheProvider";
-import { SchedulerRunSummary, TargetScheduler } from "@lage-run/scheduler-types";
-import { watch } from "./watcher";
 
 interface RunOptions extends ReporterInitOptions {
   concurrency: number;
@@ -31,143 +19,10 @@ interface RunOptions extends ReporterInitOptions {
   watch: boolean;
 }
 
-export async function runAction(options: RunOptions, command: Command) {
-  const cwd = process.cwd();
-  const config = await getConfig(cwd);
-
-  // Configure logger
-  const logger = createLogger();
-
-  initializeReporters(logger, options);
-
-  if (options.profile !== undefined) {
-    const reporter = createProfileReporter(options);
-    logger.addReporter(reporter);
-  }
-
-  // Build Target Graph
-  const root = getWorkspaceRoot(process.cwd())!;
-  const packageInfos = getPackageInfos(root);
-
-  const { tasks, taskArgs } = filterArgsForTasks(command.args);
-
-  const targetGraph = createTargetGraph({
-    logger,
-    root,
-    dependencies: options.dependencies,
-    dependents: options.dependents,
-    ignore: options.ignore.concat(config.ignore),
-    pipeline: config.pipeline,
-    repoWideChanges: config.repoWideChanges,
-    scope: options.scope,
-    since: options.since,
-    outputs: config.cacheOptions.outputGlob,
-    tasks,
-    packageInfos,
-  });
-
+export async function action(options: RunOptions, command: Command) {
   if (options.watch) {
-    const scheduler = new SimpleScheduler({
-      logger,
-      concurrency: options.concurrency,
-      cacheProvider: undefined,
-      hasher: undefined,
-      continueOnError: options.continue,
-      shouldCache: options.cache,
-      shouldResetCache: options.resetCache,
-      maxWorkersPerTask: getMaxWorkersPerTask(config.pipeline ?? {}),
-      runners: {
-        npmScript: {
-          script: require.resolve("./runners/NpmScriptRunner"),
-          options: {
-            nodeArg: options.nodeArg,
-            taskArgs,
-            npmCmd: findNpmClient(config.npmClient),
-          },
-        },
-        worker: {
-          script: require.resolve("./runners/WorkerRunner"),
-          options: {},
-        },
-        ...config.runners,
-      },
-    });
-    launchWatch({ logger, scheduler, root, targetGraph, packageInfos });
+    return watchAction(options, command);
   } else {
-    const { cacheProvider, hasher } = createCache({
-      root,
-      logger,
-      cacheOptions: config.cacheOptions,
-      skipLocalCache: options.skipLocalCache,
-    });
-
-    const scheduler = new SimpleScheduler({
-      logger,
-      concurrency: options.concurrency,
-      cacheProvider,
-      hasher,
-      continueOnError: options.continue,
-      shouldCache: options.cache,
-      shouldResetCache: options.resetCache,
-      maxWorkersPerTask: getMaxWorkersPerTask(config.pipeline ?? {}),
-      runners: {
-        npmScript: {
-          script: require.resolve("./runners/NpmScriptRunner"),
-          options: {
-            nodeArg: options.nodeArg,
-            taskArgs,
-            npmCmd: findNpmClient(config.npmClient),
-          },
-        },
-        worker: {
-          script: require.resolve("./runners/WorkerRunner"),
-          options: {},
-        },
-        ...config.runners,
-      },
-    });
-    await launchRun({ logger, scheduler, root, targetGraph });
-  }
-}
-
-function launchWatch(options: {
-  logger: Logger;
-  scheduler: TargetScheduler;
-  root: string;
-  targetGraph: TargetGraph;
-  packageInfos: PackageInfos;
-}) {
-  const { logger, scheduler, root, targetGraph, packageInfos } = options;
-
-  logger.info("running scheduler in watch mode");
-
-  scheduler.run(root, targetGraph);
-
-  const watcher = watch(root);
-  watcher.on("change", (packageName) => {
-    logger.info(`change detected in ${packageName}`);
-
-    for (const target of targetGraph.targets.values()) {
-      if (target.packageName === packageName && scheduler.onTargetChange) {
-        console.log("target changed", target.id);
-        scheduler.onTargetChange(target.id);
-      }
-    }
-  });
-}
-
-async function launchRun(options: { logger: Logger; scheduler: TargetScheduler; root: string; targetGraph: TargetGraph }) {
-  const { logger, scheduler, root, targetGraph } = options;
-  const summary = await scheduler.run(root, targetGraph);
-  displaySummaryAndExit(summary, logger.reporters);
-}
-
-function displaySummaryAndExit(summary: SchedulerRunSummary, reporters: Reporter[]) {
-  if (summary.results !== "success") {
-    process.exitCode = 1;
-  }
-
-  for (const reporter of reporters) {
-    reporter.summarize(summary);
+    return runAction(options, command);
   }
 }

--- a/packages/cli/src/commands/run/createCacheProvider.ts
+++ b/packages/cli/src/commands/run/createCacheProvider.ts
@@ -1,0 +1,45 @@
+import { BackfillCacheProvider, CacheOptions, RemoteFallbackCacheProvider, TargetHasher } from "@lage-run/cache";
+import { Logger } from "@lage-run/logger";
+import { isRunningFromCI } from "../isRunningFromCI";
+
+interface CreateCacheOptions {
+  cacheOptions?: CacheOptions;
+  logger: Logger;
+  root: string;
+  skipLocalCache: boolean;
+}
+
+export function createCache(options: CreateCacheOptions) {
+  const { cacheOptions, logger, root, skipLocalCache } = options;
+
+  const hasRemoteCacheConfig =
+    !!cacheOptions?.cacheStorageConfig || !!process.env.BACKFILL_CACHE_PROVIDER || !!process.env.BACKFILL_CACHE_PROVIDER_OPTIONS;
+
+  // Create Cache Provider
+  const cacheProvider = new RemoteFallbackCacheProvider({
+    root,
+    logger,
+    localCacheProvider:
+      skipLocalCache === true
+        ? undefined
+        : new BackfillCacheProvider({
+            logger,
+            root,
+            cacheOptions: {
+              outputGlob: cacheOptions?.outputGlob,
+              ...(cacheOptions?.internalCacheFolder && { internalCacheFolder: cacheOptions.internalCacheFolder }),
+            },
+          }),
+    remoteCacheProvider: hasRemoteCacheConfig ? new BackfillCacheProvider({ logger, root, cacheOptions: cacheOptions ?? {} }) : undefined,
+    writeRemoteCache:
+      cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI,
+  });
+
+  const hasher = new TargetHasher({
+    root,
+    environmentGlob: cacheOptions?.environmentGlob ?? [],
+    cacheKey: cacheOptions?.cacheKey,
+  });
+
+  return { cacheProvider, hasher };
+}

--- a/packages/cli/src/commands/run/createCacheProvider.ts
+++ b/packages/cli/src/commands/run/createCacheProvider.ts
@@ -28,6 +28,7 @@ export function createCache(options: CreateCacheOptions) {
             cacheOptions: {
               outputGlob: cacheOptions?.outputGlob,
               ...(cacheOptions?.internalCacheFolder && { internalCacheFolder: cacheOptions.internalCacheFolder }),
+              ...(cacheOptions?.incrementalCaching && { incrementalCaching: cacheOptions.incrementalCaching }),
             },
           }),
     remoteCacheProvider: hasRemoteCacheConfig ? new BackfillCacheProvider({ logger, root, cacheOptions: cacheOptions ?? {} }) : undefined,

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -1,0 +1,54 @@
+import { Logger } from "@lage-run/logger";
+import { TargetGraphBuilder } from "@lage-run/target-graph";
+import { getPackageInfos, PackageInfos } from "workspace-tools";
+import { getFilteredPackages } from "../../filter/getFilteredPackages";
+import type { PipelineDefinition } from "../../types/PipelineDefinition";
+import { filterArgsForTasks } from "./filterArgsForTasks";
+
+interface CreateTargetGraphOptions {
+  logger: Logger;
+  root: string;
+  dependencies: boolean;
+  dependents: boolean;
+  since: string;
+  scope: string[];
+  ignore: string[];
+  repoWideChanges: string[];
+  pipeline: PipelineDefinition;
+  outputs: string[];
+  tasks: string[];
+  packageInfos: PackageInfos;
+}
+
+export function createTargetGraph(options: CreateTargetGraphOptions) {
+  const { logger, root, dependencies, dependents, since, scope, repoWideChanges, ignore, pipeline, outputs, tasks, packageInfos } = options;
+
+  const builder = new TargetGraphBuilder(root, packageInfos);
+
+  const packages = getFilteredPackages({
+    root,
+    logger,
+    packageInfos,
+    includeDependencies: dependencies,
+    includeDependents: dependents,
+    since,
+    scope,
+    repoWideChanges,
+    sinceIgnoreGlobs: ignore,
+  });
+
+  for (const [id, definition] of Object.entries(pipeline)) {
+    if (Array.isArray(definition)) {
+      builder.addTargetConfig(id, {
+        cache: true,
+        dependsOn: definition,
+        options: {},
+        outputs,
+      });
+    } else {
+      builder.addTargetConfig(id, definition);
+    }
+  }
+
+  return builder.buildTargetGraph(tasks, packages);
+}

--- a/packages/cli/src/commands/run/filterArgsForTasks.ts
+++ b/packages/cli/src/commands/run/filterArgsForTasks.ts
@@ -1,0 +1,7 @@
+export function filterArgsForTasks(args: string[]) {
+  const optionsPosition = args.findIndex((arg) => arg.startsWith("-"));
+  return {
+    tasks: args.slice(0, optionsPosition === -1 ? undefined : optionsPosition),
+    taskArgs: optionsPosition === -1 ? [] : args.slice(optionsPosition),
+  };
+}

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -1,13 +1,13 @@
 import { Command, Option } from "commander";
 import os from "os";
-import { runAction } from "./action";
+import { action } from "./action";
 import { addLoggerOptions } from "../addLoggerOptions";
 import { isRunningFromCI } from "../isRunningFromCI";
 
 const runCommand = new Command("run");
 
 addLoggerOptions(runCommand)
-  .action(runAction)
+  .action(action)
   .option(
     "-c, --concurrency <n>",
     "concurrency",

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -43,7 +43,7 @@ addLoggerOptions(runCommand)
     'arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable'
   )
   .option("--continue", "continues the run even on error")
-
+  .option("--watch", "runs in watch mode")
   .allowUnknownOption(true)
   .addHelpCommand("[run] command1 [command2...commandN] [options]", "run commands")
   .addHelpText(

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -43,7 +43,7 @@ addLoggerOptions(runCommand)
     'arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable'
   )
   .option("--continue", "continues the run even on error")
-  .option("--watch", "runs in watch mode")
+  .option("--unstable-watch", "runs in watch mode")
   .allowUnknownOption(true)
   .addHelpCommand("[run] command1 [command2...commandN] [options]", "run commands")
   .addHelpText(

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -26,7 +26,6 @@ interface RunOptions extends ReporterInitOptions {
   resetCache: boolean;
   nodeArg: string;
   ignore: string[];
-  watch: boolean;
 }
 
 export async function runAction(options: RunOptions, command: Command) {

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -1,0 +1,114 @@
+import { Command } from "commander";
+import { createProfileReporter } from "./createProfileReporter";
+import { findNpmClient } from "@lage-run/find-npm-client";
+import { getConfig } from "../../config/getConfig";
+import { getMaxWorkersPerTask } from "../../config/getMaxWorkersPerTask";
+import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import { initializeReporters } from "@lage-run/reporters";
+import { SimpleScheduler } from "@lage-run/scheduler";
+import createLogger, { Reporter } from "@lage-run/logger";
+import type { ReporterInitOptions } from "@lage-run/reporters";
+import { filterArgsForTasks } from "./filterArgsForTasks";
+import { createTargetGraph } from "./createTargetGraph";
+import { createCache } from "./createCacheProvider";
+import { SchedulerRunSummary } from "@lage-run/scheduler-types";
+
+interface RunOptions extends ReporterInitOptions {
+  concurrency: number;
+  profile: string | boolean | undefined;
+  dependencies: boolean;
+  dependents: boolean;
+  since: string;
+  scope: string[];
+  skipLocalCache: boolean;
+  continue: boolean;
+  cache: boolean;
+  resetCache: boolean;
+  nodeArg: string;
+  ignore: string[];
+  watch: boolean;
+}
+
+export async function runAction(options: RunOptions, command: Command) {
+  const cwd = process.cwd();
+  const config = await getConfig(cwd);
+
+  // Configure logger
+  const logger = createLogger();
+
+  initializeReporters(logger, options);
+
+  if (options.profile !== undefined) {
+    const reporter = createProfileReporter(options);
+    logger.addReporter(reporter);
+  }
+
+  // Build Target Graph
+  const root = getWorkspaceRoot(process.cwd())!;
+  const packageInfos = getPackageInfos(root);
+
+  const { tasks, taskArgs } = filterArgsForTasks(command.args);
+
+  const targetGraph = createTargetGraph({
+    logger,
+    root,
+    dependencies: options.dependencies,
+    dependents: options.dependents,
+    ignore: options.ignore.concat(config.ignore),
+    pipeline: config.pipeline,
+    repoWideChanges: config.repoWideChanges,
+    scope: options.scope,
+    since: options.since,
+    outputs: config.cacheOptions.outputGlob,
+    tasks,
+    packageInfos,
+  });
+
+  const { cacheProvider, hasher } = createCache({
+    root,
+    logger,
+    cacheOptions: config.cacheOptions,
+    skipLocalCache: options.skipLocalCache,
+  });
+
+  const scheduler = new SimpleScheduler({
+    logger,
+    concurrency: options.concurrency,
+    cacheProvider,
+    hasher,
+    continueOnError: options.continue,
+    shouldCache: options.cache,
+    shouldResetCache: options.resetCache,
+    maxWorkersPerTask: getMaxWorkersPerTask(config.pipeline ?? {}),
+    runners: {
+      npmScript: {
+        script: require.resolve("./runners/NpmScriptRunner"),
+        options: {
+          nodeArg: options.nodeArg,
+          taskArgs,
+          npmCmd: findNpmClient(config.npmClient),
+        },
+      },
+      worker: {
+        script: require.resolve("./runners/WorkerRunner"),
+        options: {},
+      },
+      ...config.runners,
+    },
+  });
+
+  const summary = await scheduler.run(root, targetGraph);
+  await scheduler.cleanup();
+
+  displaySummaryAndExit(summary, logger.reporters);
+}
+
+function displaySummaryAndExit(summary: SchedulerRunSummary, reporters: Reporter[]) {
+  if (summary.results !== "success") {
+    process.exitCode = 1;
+  }
+
+  for (const reporter of reporters) {
+    reporter.summarize(summary);
+  }
+}

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -1,0 +1,133 @@
+import { Command } from "commander";
+import { createProfileReporter } from "./createProfileReporter";
+import { findNpmClient } from "@lage-run/find-npm-client";
+import { getConfig } from "../../config/getConfig";
+import { getMaxWorkersPerTask } from "../../config/getMaxWorkersPerTask";
+import { getPackageInfos, getWorkspaceRoot, PackageInfos } from "workspace-tools";
+import { initializeReporters, LogReporter } from "@lage-run/reporters";
+import { SimpleScheduler } from "@lage-run/scheduler";
+import { TargetGraph } from "@lage-run/target-graph";
+import createLogger, { Logger, LogLevel, Reporter } from "@lage-run/logger";
+import type { ReporterInitOptions } from "@lage-run/reporters";
+import { filterArgsForTasks } from "./filterArgsForTasks";
+import { createTargetGraph } from "./createTargetGraph";
+import { createCache } from "./createCacheProvider";
+import { SchedulerRunSummary, TargetScheduler } from "@lage-run/scheduler-types";
+import { watch } from "./watcher";
+
+interface RunOptions extends ReporterInitOptions {
+  concurrency: number;
+  profile: string | boolean | undefined;
+  dependencies: boolean;
+  dependents: boolean;
+  since: string;
+  scope: string[];
+  skipLocalCache: boolean;
+  continue: boolean;
+  cache: boolean;
+  resetCache: boolean;
+  nodeArg: string;
+  ignore: string[];
+  watch: boolean;
+}
+
+export async function watchAction(options: RunOptions, command: Command) {
+  const cwd = process.cwd();
+  const config = await getConfig(cwd);
+
+  // Configure logger
+  const logger = createLogger();
+  const reporter = new LogReporter({
+    grouped: true,
+    logLevel: LogLevel[options.logLevel],
+  });
+  logger.addReporter(reporter);
+
+  // Build Target Graph
+  const root = getWorkspaceRoot(process.cwd())!;
+  const packageInfos = getPackageInfos(root);
+
+  const { tasks, taskArgs } = filterArgsForTasks(command.args);
+
+  const targetGraph = createTargetGraph({
+    logger,
+    root,
+    dependencies: options.dependencies,
+    dependents: options.dependents,
+    ignore: options.ignore.concat(config.ignore),
+    pipeline: config.pipeline,
+    repoWideChanges: config.repoWideChanges,
+    scope: options.scope,
+    since: options.since,
+    outputs: config.cacheOptions.outputGlob,
+    tasks,
+    packageInfos,
+  });
+
+  // Make sure we do not attempt writeRemoteCache in watch mode
+  config.cacheOptions.writeRemoteCache = false;
+
+  const { cacheProvider, hasher } = createCache({
+    root,
+    logger,
+    cacheOptions: config.cacheOptions,
+    skipLocalCache: false,
+  });
+
+  const scheduler = new SimpleScheduler({
+    logger,
+    concurrency: options.concurrency,
+    cacheProvider,
+    hasher,
+    continueOnError: true,
+    shouldCache: options.cache,
+    shouldResetCache: options.resetCache,
+    maxWorkersPerTask: getMaxWorkersPerTask(config.pipeline ?? {}),
+    runners: {
+      npmScript: {
+        script: require.resolve("./runners/NpmScriptRunner"),
+        options: {
+          nodeArg: options.nodeArg,
+          taskArgs,
+          npmCmd: findNpmClient(config.npmClient),
+        },
+      },
+      worker: {
+        script: require.resolve("./runners/WorkerRunner"),
+        options: {},
+      },
+      ...config.runners,
+    },
+  });
+
+  // Initial run
+  const summary = await scheduler.run(root, targetGraph);
+  displaySummary(summary, logger.reporters);
+
+  logger.info("Running scheduler in watch mode");
+
+  // Disables cache for subsequent runs
+  // TODO: support updating hasher + write-only local cacheProvider for subsequent runs
+  for (const targetRun of scheduler.targetRuns.values()) {
+    targetRun.options.cacheProvider = undefined;
+    targetRun.options.hasher = undefined;
+    targetRun.options.shouldCache = false;
+  }
+
+  // When initial run is done, disable fetching of caches on all targets, keep writing to the cache
+  const watcher = watch(root);
+  watcher.on("change", (packageName) => {
+    reporter.resetLogEntries();
+    for (const target of targetGraph.targets.values()) {
+      if (target.packageName === packageName && scheduler.onTargetChange) {
+        scheduler.onTargetChange(target.id);
+      }
+    }
+  });
+}
+
+function displaySummary(summary: SchedulerRunSummary, reporters: Reporter[]) {
+  for (const reporter of reporters) {
+    reporter.summarize(summary);
+  }
+}

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -28,7 +28,6 @@ interface RunOptions extends ReporterInitOptions {
   resetCache: boolean;
   nodeArg: string;
   ignore: string[];
-  watch: boolean;
 }
 
 export async function watchAction(options: RunOptions, command: Command) {

--- a/packages/cli/src/commands/run/watcher.ts
+++ b/packages/cli/src/commands/run/watcher.ts
@@ -1,0 +1,85 @@
+import chokidar from "chokidar";
+
+import path from "path";
+import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import type { PackageInfo, PackageInfos } from "workspace-tools";
+import EventEmitter from "events";
+
+interface PathIndexItem {
+  packageName?: string;
+}
+
+interface PathIndex {
+  [pathPart: string]: PathIndexItem;
+}
+
+export function watch(cwd: string): EventEmitter {
+  const events = new EventEmitter();
+  const root = getWorkspaceRoot(cwd);
+  const packageInfos = getPackageInfos(cwd);
+
+  // generate a tree index of all the packages
+  const packageIndex = createPackageIndex(root!, packageInfos);
+
+  const packagePaths = Object.values(packageInfos).map((pkg) => path.dirname(pkg.packageJsonPath));
+
+  // watch for changes in the packages
+  const watcher = chokidar.watch(packagePaths, {
+    cwd: root,
+    ignored: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/lib/**"],
+  });
+
+  // when a change happens, find the package that changed
+  watcher.on("change", (filePath) => {
+    console.log("changed, filePath", filePath);
+    const packageName = findPackageByPath(filePath, packageIndex);
+    events.emit("change", packageName);
+  });
+
+  return events;
+}
+
+function createPackageIndex(root: string, packageInfos: PackageInfos) {
+  const pathIndex: PathIndex = {};
+
+  // generate a tree index of all the packages
+  for (const [packageName, info] of Object.entries(packageInfos)) {
+    const packagePath = path.relative(root, path.dirname(info.packageJsonPath));
+    const pathParts = packagePath.split(/[/\\]/);
+
+    let pointer: PathIndexItem = pathIndex;
+
+    for (const pathPart of pathParts) {
+      if (!pointer[pathPart]) {
+        pointer[pathPart] = {};
+      }
+
+      pointer = pointer[pathPart];
+    }
+
+    pointer.packageName = packageName;
+  }
+
+  return pathIndex;
+}
+
+function findPackageByPath(filePath: string, index: PathIndex) {
+  const pathParts = filePath.split(/[/\\]/);
+
+  let pointer: PathIndexItem = index;
+
+  for (const pathPart of pathParts) {
+    if (!pointer[pathPart]) {
+      console.log(pathPart, filePath);
+      break;
+    }
+
+    if (pointer[pathPart].packageName) {
+      return pointer[pathPart].packageName;
+    }
+
+    pointer = pointer[pathPart];
+  }
+
+  return undefined;
+}

--- a/packages/cli/src/commands/run/watcher.ts
+++ b/packages/cli/src/commands/run/watcher.ts
@@ -29,11 +29,18 @@ export function watch(cwd: string): EventEmitter {
     ignored: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/lib/**"],
   });
 
+  let timeoutHandle: NodeJS.Timeout;
+
   // when a change happens, find the package that changed
   watcher.on("change", (filePath) => {
-    console.log("changed, filePath", filePath);
-    const packageName = findPackageByPath(filePath, packageIndex);
-    events.emit("change", packageName);
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+
+    timeoutHandle = setTimeout(() => {
+      const packageName = findPackageByPath(filePath, packageIndex);
+      events.emit("change", packageName);
+    }, 200);
   });
 
   return events;

--- a/packages/lage2/package.json
+++ b/packages/lage2/package.json
@@ -9,8 +9,8 @@
     "prebuild": "node scripts/prebuild.js",
     "build": "rollup --config ./rollup.config.js"
   },
-  "dependencies": {
-    "fsevents": "^2.0.0"
+  "optionalDependencies": {
+    "fsevents": "~2.3.2"
   },
   "devDependencies": {
     "@lage-run/cli": "*",

--- a/packages/lage2/package.json
+++ b/packages/lage2/package.json
@@ -9,6 +9,9 @@
     "prebuild": "node scripts/prebuild.js",
     "build": "rollup --config ./rollup.config.js"
   },
+  "dependencies": {
+    "fsevents": "^2.0.0"
+  },
   "devDependencies": {
     "@lage-run/cli": "*",
     "@lage-run/scheduler": "*",

--- a/packages/lage2/rollup.config.js
+++ b/packages/lage2/rollup.config.js
@@ -32,6 +32,7 @@ export default [
       json(),
       terser(),
     ],
+    external: ["fsevents"]
   },
   {
     input: "./index.js",

--- a/packages/reporters/src/LogReporter.ts
+++ b/packages/reporters/src/LogReporter.ts
@@ -257,4 +257,8 @@ export class LogReporter implements Reporter {
 
     this.print(`Took a total of ${formatDuration(hrToSeconds(duration))} to complete. ${allCacheHitText}`);
   }
+
+  resetLogEntries() {
+    this.logEntries.clear();
+  }
 }

--- a/packages/scheduler-types/src/types/TargetScheduler.ts
+++ b/packages/scheduler-types/src/types/TargetScheduler.ts
@@ -4,4 +4,5 @@ import type { SchedulerRunSummary } from "./SchedulerRunSummary";
 export interface TargetScheduler {
   abort(): void;
   run(root: string, targetGraph: TargetGraph): Promise<SchedulerRunSummary>;
+  onTargetChange?(targetId: string): void;
 }

--- a/packages/scheduler-types/src/types/TargetScheduler.ts
+++ b/packages/scheduler-types/src/types/TargetScheduler.ts
@@ -5,4 +5,5 @@ export interface TargetScheduler {
   abort(): void;
   run(root: string, targetGraph: TargetGraph): Promise<SchedulerRunSummary>;
   onTargetChange?(targetId: string): void;
+  cleanup(): void;
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -22,9 +22,11 @@
     "p-graph": "^1.1.1",
     "p-profiler": "^0.2.1",
     "abort-controller": "^3.0.0",
-    "workspace-tools": "^0.28.0"
+    "workspace-tools": "^0.28.0",
+    "watchpack": "^2.4.0"
   },
   "devDependencies": {
+    "@types/watchpack": "^2.4.0",
     "@lage-run/scheduler-types": "^0.1.8",
     "@lage-run/monorepo-fixture": "*",
     "@types/workerpool": "6.1.0",

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -44,6 +44,7 @@ export class SimpleScheduler implements TargetScheduler {
   abortSignal: AbortSignal = this.abortController.signal;
   dependencies: [string, string][] = [];
   pool: Pool;
+  runPromise = Promise.resolve() as Promise<any>;
 
   constructor(private options: SimpleSchedulerOptions) {
     this.pool =
@@ -79,6 +80,7 @@ export class SimpleScheduler implements TargetScheduler {
 
     const { dependencies, targets } = targetGraph;
     this.dependencies = dependencies;
+
     this.targetsByPriority = sortTargetsByPriority([...targets.values()]);
     for (const target of targets.values()) {
       const targetRun = new WrappedTarget({
@@ -125,8 +127,6 @@ export class SimpleScheduler implements TargetScheduler {
       }
     }
 
-    await this.pool.close();
-
     return {
       targetRunByStatus,
       targetRuns: this.targetRuns,
@@ -141,7 +141,11 @@ export class SimpleScheduler implements TargetScheduler {
    * Used by consumers of the scheduler to notify that the inputs to the target has changed
    * @param targetId
    */
-  onTargetChange(targetId: string) {
+  async onTargetChange(targetId: string) {
+    this.abortController.abort();
+
+    await this.runPromise;
+
     const queue = [targetId];
     while (queue.length > 0) {
       const current = queue.shift()!;
@@ -150,9 +154,6 @@ export class SimpleScheduler implements TargetScheduler {
       if (targetRun.status !== "pending") {
         targetRun.status = "pending";
         const dependents = targetRun.target.dependents;
-
-        console.log(targetRun.target.dependents);
-
         for (const dependent of dependents) {
           queue.push(dependent);
         }
@@ -165,7 +166,7 @@ export class SimpleScheduler implements TargetScheduler {
       targetRun.abortController = this.abortController;
     }
 
-    this.scheduleReadyTargets();
+    this.runPromise = this.scheduleReadyTargets();
   }
 
   getReadyTargets() {
@@ -218,7 +219,7 @@ export class SimpleScheduler implements TargetScheduler {
 
   async scheduleReadyTargets() {
     if (this.isAllDone() || this.abortSignal.aborted) {
-      return;
+      return Promise.resolve();
     }
 
     const promises: Promise<any>[] = [];
@@ -243,7 +244,12 @@ export class SimpleScheduler implements TargetScheduler {
       );
     }
 
-    return await Promise.all(promises);
+    this.runPromise = Promise.all(promises);
+    return this.runPromise;
+  }
+
+  async cleanup() {
+    await this.pool.close();
   }
 
   /**

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -16,8 +16,8 @@ export interface SimpleSchedulerOptions {
   logger: Logger;
   concurrency: number;
   continueOnError: boolean;
-  cacheProvider: CacheProvider;
-  hasher: TargetHasher;
+  cacheProvider?: CacheProvider;
+  hasher?: TargetHasher;
   shouldCache: boolean;
   shouldResetCache: boolean;
   runners: TargetRunnerPickerOptions;
@@ -150,10 +150,19 @@ export class SimpleScheduler implements TargetScheduler {
       if (targetRun.status !== "pending") {
         targetRun.status = "pending";
         const dependents = targetRun.target.dependents;
+
+        console.log(targetRun.target.dependents);
+
         for (const dependent of dependents) {
           queue.push(dependent);
         }
       }
+    }
+
+    this.abortController = new AbortController();
+    this.abortSignal = this.abortController.signal;
+    for (const targetRun of this.targetRuns.values()) {
+      targetRun.abortController = this.abortController;
     }
 
     this.scheduleReadyTargets();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4239,7 +4239,7 @@ cheerio@^1.0.0-rc.12, cheerio@^1.0.0-rc.9:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
-chokidar@^3.2.1, chokidar@^3.4.2, chokidar@^3.5.3:
+chokidar@3.5.3, chokidar@^3.2.1, chokidar@^3.4.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -6346,7 +6346,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.0.0, fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,7 +2876,7 @@
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
   integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
 
-"@types/graceful-fs@^4.1.3":
+"@types/graceful-fs@*", "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
@@ -3144,6 +3144,14 @@
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
+"@types/watchpack@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/watchpack/-/watchpack-2.4.0.tgz#35c6f8cdb3e82f443a93207856a54c2bfa7e6041"
+  integrity sha512-PSAD+o9hezvfUFFzrYB/PO6Je7kwiZ2BSnB3/EZ9le+jTDKB6x5NJ96WWzQz1h/AyGJ/de3/1KpuBTkUFZm77A==
+  dependencies:
+    "@types/graceful-fs" "*"
+    "@types/node" "*"
 
 "@types/workerpool@6.1.0":
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,7 +6346,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.0.0, fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==


### PR DESCRIPTION
This adds a watch mode that is mostly unstable - really need real world study of the feature to fine tune the defaults, configs, etc.

1. Splits the "runAction" into "watchAction" vs "runAction"
2. watch mode auto disables the cache after an initial run (but won't write new caches)
3. adds fsevents as a dependency to `@lage-run/lage` - this is an optional dep like chokidar itself
4. fixed rollup.config.js to consider fsevents as external
5. refactored various setup `create*` functions in the actions to DRY on the `watchAction` & `runAction`