### PR TITLE
Target config changes: introducing shards, environmentGlob and moving maxWorkers

### DIFF
--- a/change/@lage-run-cache-01c92b52-b3bc-48c2-b5aa-c62d2d0b52fb.json
+++ b/change/@lage-run-cache-01c92b52-b3bc-48c2-b5aa-c62d2d0b52fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allows for target specific environmentGlob override",
+  "packageName": "@lage-run/cache",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-cli-d294901b-7ec8-4c9b-93c5-f0ef6a2ecfe1.json
+++ b/change/@lage-run-cli-d294901b-7ec8-4c9b-93c5-f0ef6a2ecfe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "promotes maxWorker to be a \"top level\" target config (options are for target runners)",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-09e135de-03a9-4cff-8671-5b8a5545eaeb.json
+++ b/change/@lage-run-target-graph-09e135de-03a9-4cff-8671-5b8a5545eaeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "introducing maxWorkers, shards, and environmentGlob as target configs (shards is a future feature)",
+  "packageName": "@lage-run/target-graph",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cache/src/TargetHasher.ts
+++ b/packages/cache/src/TargetHasher.ts
@@ -25,7 +25,7 @@ export class TargetHasher {
 
   async hash(target: Target): Promise<string> {
     const hashKey = await salt(
-      this.options.environmentGlob || ["lage.config.js"],
+      target.environmentGlob ?? this.options.environmentGlob ?? ["lage.config.js"],
       `${target.id}|${JSON.stringify(this.options.cliArgs)}`,
       this.options.root,
       this.options.cacheKey || ""

--- a/packages/cli/src/config/getMaxWorkersPerTask.ts
+++ b/packages/cli/src/config/getMaxWorkersPerTask.ts
@@ -6,7 +6,7 @@ export function getMaxWorkersPerTask(pipelineConfig: ConfigOptions["pipeline"]) 
 
   for (const [task, taskConfig] of Object.entries(pipelineConfig)) {
     if (!Array.isArray(taskConfig) && !task.includes("#")) {
-      const maxWorkerOptions: string | number = taskConfig.options?.maxWorkers ?? os.cpus().length - 1;
+      const maxWorkerOptions: string | number = taskConfig.maxWorkers ?? taskConfig.options?.maxWorkers ?? os.cpus().length - 1;
       let maxWorkers = 0;
       if (typeof maxWorkerOptions === "string") {
         if (maxWorkerOptions.endsWith("%")) {

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -50,7 +50,7 @@ export class TargetGraphBuilder {
    * @returns a generated global Target
    */
   private createGlobalTarget(id: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, inputs, outputs, priority, run } = config;
+    const { options, dependsOn, deps, inputs, outputs, priority } = config;
     const { task } = getPackageAndTask(id);
     const targetId = getTargetId(undefined, task);
     return {
@@ -68,7 +68,6 @@ export class TargetGraphBuilder {
       inputs,
       outputs,
       priority,
-      run,
       options,
     };
   }
@@ -81,7 +80,7 @@ export class TargetGraphBuilder {
    * @returns a package task `Target`
    */
   private createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, cache, inputs, outputs, priority, run } = config;
+    const { options, dependsOn, deps, cache, inputs, outputs, priority } = config;
     const info = this.packageInfos[packageName];
     return {
       id: getTargetId(packageName, task),
@@ -97,7 +96,6 @@ export class TargetGraphBuilder {
       inputs,
       outputs,
       priority,
-      run,
       options,
     };
   }

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -50,7 +50,7 @@ export class TargetGraphBuilder {
    * @returns a generated global Target
    */
   private createGlobalTarget(id: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, inputs, outputs, priority } = config;
+    const { options, dependsOn, deps, inputs, outputs, priority, maxWorkers, environmentGlob, shards } = config;
     const { task } = getPackageAndTask(id);
     const targetId = getTargetId(undefined, task);
     return {
@@ -68,6 +68,9 @@ export class TargetGraphBuilder {
       inputs,
       outputs,
       priority,
+      maxWorkers,
+      environmentGlob,
+      shards,
       options,
     };
   }
@@ -80,7 +83,7 @@ export class TargetGraphBuilder {
    * @returns a package task `Target`
    */
   private createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, cache, inputs, outputs, priority } = config;
+    const { options, dependsOn, deps, cache, inputs, outputs, priority, maxWorkers, environmentGlob, shards } = config;
     const info = this.packageInfos[packageName];
     return {
       id: getTargetId(packageName, task),
@@ -96,6 +99,9 @@ export class TargetGraphBuilder {
       inputs,
       outputs,
       priority,
+      maxWorkers,
+      environmentGlob,
+      shards,
       options,
     };
   }

--- a/packages/target-graph/src/types/Target.ts
+++ b/packages/target-graph/src/types/Target.ts
@@ -53,6 +53,21 @@ export interface Target {
   cache?: boolean;
 
   /**
+   * An optional override of environmentGlob for cases when targets that need different patterns
+   */
+  environmentGlob?: string[];
+
+  /**
+   * How many workers to dedicate to this task type
+   */
+  maxWorkers?: number;
+
+  /**
+   * How many shards to split tasks into
+   */
+  shards?: number;
+
+  /**
    * Run options for the Target
    */
   options?: Record<string, any>;
@@ -61,9 +76,4 @@ export interface Target {
    * Whether the target should be displayed by reporters
    */
   hidden?: boolean;
-
-  /**
-   * Custom run definition, if left blank, the scheduler will decide which runner to use to fulfill the work for the `Target`
-   */
-  run?: (target: Target) => Promise<void> | void;
 }

--- a/packages/target-graph/src/types/TargetConfig.ts
+++ b/packages/target-graph/src/types/TargetConfig.ts
@@ -51,6 +51,11 @@ export interface TargetConfig {
   cache?: boolean;
 
   /**
+   * An optional override of environmentGlob for cases when targets that need different patterns
+   */
+  environmentGlob?: string[];
+
+  /**
    * How many workers to dedicate to this task type
    */
   maxWorkers?: number;

--- a/packages/target-graph/src/types/TargetConfig.ts
+++ b/packages/target-graph/src/types/TargetConfig.ts
@@ -51,12 +51,17 @@ export interface TargetConfig {
   cache?: boolean;
 
   /**
-   * Run options for the Target. (e.g. `{ env: ...process.env, colors: true, ... }`)
+   * How many workers to dedicate to this task type
    */
-  options?: Record<string, any>;
+  maxWorkers?: number;
 
   /**
-   * Custom run definition, if left blank, the scheduler will decide which runner to use to fulfill the work for the `Target`
+   * How many shards to split tasks into
    */
-  run?: (target: Target) => Promise<void> | void;
+  shards?: number;
+
+  /**
+   * Run options for the Target Runner. (e.g. `{ env: ...process.env, colors: true, ... }`)
+   */
+  options?: Record<string, any>;
 }


### PR DESCRIPTION
This PR does three things:

1. introduces a (not enabled-yet) shards option
2. adds an environmentGlob override per target
3. promotes maxWorker to top level config - since everything depends on a worker pool now