### PR TITLE
fixing the max worker again - this time we need to account for general pool availability

### DIFF
--- a/change/@lage-run-cli-1697c967-ffe7-4c1c-93c4-a336f7172365.json
+++ b/change/@lage-run-cli-1697c967-ffe7-4c1c-93c4-a336f7172365.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing the max worker again - this time we need to account for general pool availability",
+  "packageName": "@lage-run/cli",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/tests/getMaxWorkersPerTask.test.ts
+++ b/packages/cli/tests/getMaxWorkersPerTask.test.ts
@@ -105,4 +105,33 @@ describe("getMaxWorkersPerTask", () => {
 
     expect(testAction).toThrow();
   });
+
+  it("reserves some workers for general pool", () => {
+    const maxWorkersPerTask = getMaxWorkersPerTask(
+      {
+        build: {},
+
+        lint: {
+          maxWorkers: 2,
+        },
+      },
+      2
+    );
+
+    expect(maxWorkersPerTask.get("build")).toBeUndefined();
+    expect(maxWorkersPerTask.get("lint")).toBe(1);
+  });
+
+  it("reserves no workers for general pool, when one task has taken over all the cores", () => {
+    const maxWorkersPerTask = getMaxWorkersPerTask(
+      {
+        lint: {
+          maxWorkers: 2,
+        },
+      },
+      2
+    );
+
+    expect(maxWorkersPerTask.get("lint")).toBe(2);
+  });
 });


### PR DESCRIPTION
In low core count environments, we still want to allow the "fallback" or "general" pool to take over work.