### PR TITLE
Fixed a race condition with calculating environment hash

### DIFF
--- a/change/@lage-run-cache-f0ee2776-0304-4b68-b2d6-f55657a62cfd.json
+++ b/change/@lage-run-cache-f0ee2776-0304-4b68-b2d6-f55657a62cfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed salt to not have race conditions with env hash calculations",
+  "packageName": "@lage-run/cache",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
During the calculation of environment glob hash, we were incrementally setting the environment glob with more and more hashes. This led to multiple targets to arrive at the hash separately and differently during the boot the build. We replaced this logic with one that is idempotent. 