### PR TITLE
Recover cache check: enforce only one actor to generate envhash at a time

### DIFF
--- a/change/@lage-run-cache-ffa9578d-30a6-457d-a076-3ffc3a4934fb.json
+++ b/change/@lage-run-cache-ffa9578d-30a6-457d-a076-3ffc3a4934fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "recover the cache check to not bombard with file reads",
+  "packageName": "@lage-run/cache",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cache/src/salt.ts
+++ b/packages/cache/src/salt.ts
@@ -8,7 +8,8 @@ interface MemoizedEnvHashes {
 }
 
 let envHashes: MemoizedEnvHashes = {};
-// A promise to guarantee the getRepoInfo is done one at a time
+
+// A promise to guarantee the getEnvHashes is done one at a time
 let oneAtATime: Promise<any> = Promise.resolve();
 
 export function _testResetEnvHash() {


### PR DESCRIPTION
Having too many concurrent calls to getEnvHash would crash it because we do not block the hash generation to one at a time. We do so now with a cache lookup for the case that we already have calculated it.