### PR TITLE
Adds the Weighted Target option

### DIFF
--- a/change/@lage-run-lage-54eaaa44-9eb5-4f4d-94c2-54bd6a228a39.json
+++ b/change/@lage-run-lage-54eaaa44-9eb5-4f4d-94c2-54bd6a228a39.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adds the Weighted Target option",
+  "packageName": "@lage-run/lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-cc0ea770-4ce1-43ac-9f84-dcef49dbe234.json
+++ b/change/@lage-run-scheduler-cc0ea770-4ce1-43ac-9f84-dcef49dbe234.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds support for weighted targets",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-types-92b307c4-85f2-4cdd-b363-701f3a4fe4f8.json
+++ b/change/@lage-run-scheduler-types-92b307c4-85f2-4cdd-b363-701f3a4fe4f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds weight option",
+  "packageName": "@lage-run/scheduler-types",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-39577f6c-239c-4d63-b99f-af531dd16f02.json
+++ b/change/@lage-run-target-graph-39577f6c-239c-4d63-b99f-af531dd16f02.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds support for weighted targets",
+  "packageName": "@lage-run/target-graph",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-worker-threads-pool-8ad6d7d3-325e-46e6-b8f2-8d2d4888eb4b.json
+++ b/change/@lage-run-worker-threads-pool-8ad6d7d3-325e-46e6-b8f2-8d2d4888eb4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds support for weighted targets",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "lage build --scope=!docs --verbose",
-    "watch": "lage build --to cli --verbose --unstable-watch",
+    "watch": "lage build --scope=cli --no-dependents --verbose --unstable-watch",
     "change": "beachball change",
     "checkchange": "beachball check",
     "release": "beachball publish -y --tag latest",

--- a/packages/scheduler-types/src/types/TargetRunner.ts
+++ b/packages/scheduler-types/src/types/TargetRunner.ts
@@ -3,6 +3,7 @@ import type { AbortSignal } from "abort-controller";
 
 export interface TargetRunnerOptions {
   target: Target;
+  weight: number;
   abortSignal?: AbortSignal;
 }
 

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -223,6 +223,7 @@ export class WrappedTarget implements TargetRun {
 
     await pool.exec(
       { target },
+      target.weight ?? 1,
       (_worker, stdout, stderr) => {
         this.onStart();
 

--- a/packages/scheduler/src/runners/NpmScriptRunner.ts
+++ b/packages/scheduler/src/runners/NpmScriptRunner.ts
@@ -56,7 +56,7 @@ export class NpmScriptRunner implements TargetRunner {
   }
 
   async run(runOptions: TargetRunnerOptions) {
-    const { target, abortSignal } = runOptions;
+    const { target, weight, abortSignal } = runOptions;
     const { nodeOptions, npmCmd, taskArgs } = this.options;
 
     let childProcess: ChildProcess | undefined;
@@ -117,6 +117,7 @@ export class NpmScriptRunner implements TargetRunner {
           ...(npmRunNodeOptions && { NODE_OPTIONS: npmRunNodeOptions }),
           LAGE_PACKAGE_NAME: target.packageName,
           LAGE_TASK: target.task,
+          LAGE_WEIGHT: String(weight),
         },
       });
 

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -39,7 +39,7 @@ export class WorkerRunner implements TargetRunner {
   static gracefulKillTimeout = 2500;
 
   async run(runOptions: TargetRunnerOptions) {
-    const { target, abortSignal } = runOptions;
+    const { target, weight, abortSignal } = runOptions;
     const scriptFile = target.options?.worker ?? target.options?.script;
 
     if (!scriptFile) {
@@ -54,6 +54,6 @@ export class WorkerRunner implements TargetRunner {
       throw new Error("WorkerRunner: worker script must export a function; you likely need to use `module.exports = function() {...}`");
     }
 
-    await runFn({ target, abortSignal });
+    await runFn({ target, weight, abortSignal });
   }
 }

--- a/packages/scheduler/tests/NpmScriptRunner.test.ts
+++ b/packages/scheduler/tests/NpmScriptRunner.test.ts
@@ -63,6 +63,7 @@ describe("NpmScriptRunner", () => {
     const runPromise = runner
       .run({
         target,
+        weight: 1,
         abortSignal: abortController.signal,
       })
       .catch(() => exceptionSpy());
@@ -89,6 +90,7 @@ describe("NpmScriptRunner", () => {
     const runPromise = runner
       .run({
         target,
+        weight: 1,
         abortSignal: abortController.signal,
       })
       .catch(() => exceptionSpy());
@@ -125,6 +127,7 @@ describe("NpmScriptRunner", () => {
       runner
         .run({
           target: createTarget(packageName),
+          weight: 1,
           abortSignal: abortController.signal,
         })
         .catch(() => {

--- a/packages/scheduler/tests/SimpleScheduler.test.ts
+++ b/packages/scheduler/tests/SimpleScheduler.test.ts
@@ -8,7 +8,7 @@ import { TargetRunner } from "@lage-run/scheduler-types";
 class InProcPool implements Pool {
   constructor(private runner: TargetRunner) {}
   exec({ target }: { target: Target }) {
-    return this.runner.run({ target });
+    return this.runner.run({ target, weight: 1 });
   }
   close() {
     return Promise.resolve();
@@ -21,7 +21,7 @@ class SingleSchedulePool implements Pool {
   exec({ target }: { target: Target }) {
     if (this.concurrency > this.count) {
       this.count++;
-      return this.runner.run({ target });
+      return this.runner.run({ target, weight: 1 });
     }
 
     return Promise.reject(new Error("Pool is full"));

--- a/packages/scheduler/tests/WorkerRunner.test.ts
+++ b/packages/scheduler/tests/WorkerRunner.test.ts
@@ -38,6 +38,6 @@ describe("WorkerRunner", () => {
       },
     } as Target;
 
-    await Promise.all([runner.run({ target: target1 }), runner.run({ target: target2 })]);
+    await Promise.all([runner.run({ target: target1, weight: 1 }), runner.run({ target: target2, weight: 1 })]);
   });
 });

--- a/packages/scheduler/tests/WrappedTarget.test.ts
+++ b/packages/scheduler/tests/WrappedTarget.test.ts
@@ -23,8 +23,8 @@ function createTarget(packageName: string): Target {
 
 class InProcPool implements Pool {
   constructor(private runner: TargetRunner) {}
-  exec({ target }: { target: Target }, _setup, _teardown, abortSignal?: AbortSignal) {
-    return this.runner.run({ target, abortSignal });
+  exec({ target }: { target: Target; weight: number }, weight, _setup, _teardown, abortSignal?: AbortSignal) {
+    return this.runner.run({ target, weight, abortSignal });
   }
   close() {
     return Promise.resolve();

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -10,6 +10,7 @@ import type { PackageInfos } from "workspace-tools";
 import type { Target } from "./types/Target";
 import type { TargetConfig } from "./types/TargetConfig";
 import { detectCycles } from "./detectCycles";
+import { getWeight } from "./getWeight";
 
 /**
  * TargetGraphBuilder class provides a builder API for registering target configs. It exposes a method called `generateTargetGraph` to
@@ -70,8 +71,11 @@ export class TargetGraphBuilder {
       priority,
       maxWorkers,
       environmentGlob,
+      weight: 1,
       options,
     };
+
+    target.weight = getWeight(target, config.weight, maxWorkers);
 
     return target;
   }
@@ -102,8 +106,11 @@ export class TargetGraphBuilder {
       priority,
       maxWorkers,
       environmentGlob,
+      weight: 1,
       options,
     };
+
+    target.weight = getWeight(target, config.weight, maxWorkers);
 
     return target;
   }
@@ -233,6 +240,7 @@ export class TargetGraphBuilder {
       dependencies: [],
       dependents: [],
       depSpecs: [],
+      weight: 1,
     } as Target);
 
     const subGraphEdges = this.createSubGraph(tasks, scope);

--- a/packages/target-graph/src/getWeight.ts
+++ b/packages/target-graph/src/getWeight.ts
@@ -1,0 +1,15 @@
+import type { Target } from "./types/Target";
+
+export function getWeight(
+  target: Target,
+  weight: number | ((target: Target, maxWorkers?: number) => number) | undefined,
+  maxWorkers?: number
+): number {
+  if (typeof weight === "number") {
+    return weight;
+  } else if (typeof weight === "function") {
+    return weight(target, maxWorkers);
+  }
+
+  return 1;
+}

--- a/packages/target-graph/src/types/Target.ts
+++ b/packages/target-graph/src/types/Target.ts
@@ -63,6 +63,15 @@ export interface Target {
   maxWorkers?: number;
 
   /**
+   * Weight of a target - used to determine the number of "worker slots" to dedicate to a target
+   *
+   * Even if we have workers "free", we might not want to dedicate them to a target that is very heavy (i.e. takes multiple CPU cores).
+   * An example is jest targets that can take up multiple cores with its own worker pool.
+   *
+   */
+  weight?: number;
+
+  /**
    * Run options for the Target
    */
   options?: Record<string, any>;

--- a/packages/target-graph/src/types/TargetConfig.ts
+++ b/packages/target-graph/src/types/TargetConfig.ts
@@ -61,6 +61,16 @@ export interface TargetConfig {
   maxWorkers?: number;
 
   /**
+   * Weight of a target - used to determine the number of "worker slots" to dedicate to a target
+   *
+   * Even if we have workers "free", we might not want to dedicate them to a target that is very heavy (i.e. takes multiple CPU cores).
+   * An example is jest targets that can take up multiple cores with its own worker pool.
+   *
+   * This weight will be "culled" to the max number of workers (concurrency) for the target type. (i.e. maxWorkers above)
+   */
+  weight?: number | ((target: Target, maxWorkers?: number) => number);
+
+  /**
    * Run options for the Target Runner. (e.g. `{ env: ...process.env, colors: true, ... }`)
    */
   options?: Record<string, any>;

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -49,7 +49,7 @@ export class AggregatedPool implements Pool {
   }
 
   async exec(
-    data: Object,
+    data: Record<string, unknown>,
     weight: number,
     setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (args: any) => void,

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -42,14 +42,15 @@ export class AggregatedPool implements Pool {
     }
 
     this.options.logger.verbose(
-      `Workers pools created:  ${[...maxWorkersByGroup.entries()]
+      `Workers pools created:  ${[...maxWorkersByGroup.entries(), ["default", defaultPoolWorkersCount]]
         .map(([group, count]) => `${group} (${count})`)
-        .join(", ")}, default (${defaultPoolWorkersCount})`
+        .join(", ")}`
     );
   }
 
   async exec(
-    data: unknown,
+    data: Object,
+    weight: number,
     setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (args: any) => void,
     abortSignal?: AbortSignal
@@ -61,7 +62,7 @@ export class AggregatedPool implements Pool {
       throw new Error(`No pool found to be able to run ${group} tasks, try adjusting the maxWorkers & concurrency values`);
     }
 
-    return pool.exec(data, setup, cleanup, abortSignal);
+    return pool.exec(data, weight, setup, cleanup, abortSignal);
   }
 
   async close(): Promise<unknown> {

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -73,7 +73,7 @@ class WorkerPoolTaskInfo extends AsyncResource {
 interface QueueItem {
   setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void;
   cleanup?: (worker: Worker) => void;
-  task: Object;
+  task: Record<string, unknown>;
   weight: number;
   resolve: (value?: unknown) => void;
   reject: (reason: unknown) => void;
@@ -83,8 +83,8 @@ export class WorkerPool extends EventEmitter implements Pool {
   workers: Worker[] = [];
   freeWorkers: Worker[] = [];
   queue: QueueItem[] = [];
-  maxWorkers: number = 0;
-  availability: number = 0;
+  maxWorkers = 0;
+  availability = 0;
 
   constructor(private options: WorkerPoolOptions) {
     super();
@@ -212,7 +212,7 @@ export class WorkerPool extends EventEmitter implements Pool {
   }
 
   exec(
-    task: Object,
+    task: Record<string, unknown>,
     weight: number,
     setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (worker: Worker) => void,

--- a/packages/worker-threads-pool/src/types/Pool.ts
+++ b/packages/worker-threads-pool/src/types/Pool.ts
@@ -5,6 +5,7 @@ import type { AbortSignal } from "abort-controller";
 export interface Pool {
   exec(
     data: unknown,
+    weight: number,
     setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (args: any) => void,
     abortSignal?: AbortSignal

--- a/packages/worker-threads-pool/tests/WorkerPool.test.ts
+++ b/packages/worker-threads-pool/tests/WorkerPool.test.ts
@@ -20,7 +20,7 @@ describe("WorkerPool", () => {
     const range = Array(numTasks)
       .fill(0)
       .map((_, i) => i);
-    const results = await Promise.all(range.map((i) => pool.exec({ id: i }, setup)));
+    const results = await Promise.all(range.map((i) => pool.exec({ id: i }, 1, setup)));
 
     expect(pool.workers.length).toBe(5);
 
@@ -51,7 +51,7 @@ describe("WorkerPool", () => {
     let results: any[] = [];
 
     try {
-      results = await Promise.all(range.map((i) => pool.exec({ id: i }, setup).catch(() => {})));
+      results = await Promise.all(range.map((i) => pool.exec({ id: i }, 1, setup).catch(() => {})));
     } finally {
       pool.close();
     }
@@ -69,7 +69,7 @@ describe("WorkerPool", () => {
 
     const setup = jest.fn();
 
-    await pool.exec({ id: 1 }, setup);
+    await pool.exec({ id: 1 }, 1, setup);
 
     expect(setup).toHaveBeenCalledTimes(1);
     expect(setup).toHaveBeenCalledWith(expect.anything(), expect.any(Readable), expect.any(Readable));

--- a/packages/worker-threads-pool/tests/WorkerPool.test.ts
+++ b/packages/worker-threads-pool/tests/WorkerPool.test.ts
@@ -24,7 +24,7 @@ describe("WorkerPool", () => {
 
     expect(pool.workers.length).toBe(5);
 
-    pool.close();
+    await pool.close();
 
     expect(running.length).toBe(numTasks);
     expect(results.length).toBe(numTasks);
@@ -74,6 +74,22 @@ describe("WorkerPool", () => {
     expect(setup).toHaveBeenCalledTimes(1);
     expect(setup).toHaveBeenCalledWith(expect.anything(), expect.any(Readable), expect.any(Readable));
 
-    pool.close();
+    await pool.close();
+  });
+
+  it("take up the availability of a pool with a fully weighted worker", async () => {
+    expect.hasAssertions();
+
+    const pool = new WorkerPool({
+      maxWorkers: 5,
+      script: path.resolve(__dirname, "fixtures", "my-worker.js"),
+    });
+
+    const setup = () => {
+      expect(pool.availability).toBe(0);
+    };
+
+    await pool.exec({ id: 1 }, 5, setup);
+    await pool.close();
   });
 });


### PR DESCRIPTION
With a custom worker script like this: 

```ts
// @filename: jest-worker.js

const { runCLI } = require("jest");

module.exports = async function jest(data) {
  const { target, weight } = data;
  console.log(`Running ${target.id} on with weight of ${weight}`);

  const { results } = await runCLI({ maxWorkers: weight, rootDir: target.cwd, passWithNoTests: true, verbose: true }, [target.cwd]);

  if (results.success) {
    console.log("Tests passed");
  } else {
    throw new Error("FAILED");
  }
};
```

You can supply something like "maxWorkers" to the jest.runCLI() with the weight. This will coordinate the jest and the lage worker pools so resources are respected. The weight can be adjusted per target as well:

```js
// @filename: lage.config.js

module.exports = {
  pipeline: {
     test: {
      type: "worker", 
      weight: (target) => {
        // glob for the target.cwd and return the number of test files
        return glob.sync('**/*.test.js', { cwd: target.cwd }).length;
      },
      maxWorkers: 8,
      options: {
        worker: path.join(__dirname, "scripts/worker/jest-worker.js"),
      }
    },
  }
}
```

If you don't feel like specifying `maxWorkers` inside `lage.config.js`, you can do so in the CLI instead:

```
$ lage test --max-workers-per-task test=8
```