### PR TITLE
Memory limits: adding a mechanism for worker pool to restart workers + do memory checks

### DIFF
--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -11,6 +11,7 @@ import type { TargetScheduler, SchedulerRunResults, SchedulerRunSummary, TargetR
 import type { Pool } from "@lage-run/worker-threads-pool";
 import type { TargetRunnerPickerOptions } from "./runners/TargetRunnerPicker";
 import { AggregatedPool } from "@lage-run/worker-threads-pool";
+import { formatBytes } from "./formatBytes";
 
 export interface SimpleSchedulerOptions {
   logger: Logger;
@@ -221,6 +222,8 @@ export class SimpleScheduler implements TargetScheduler {
       return Promise.resolve();
     }
 
+    this.options.logger.silly(`Max Worker Memory Usage: ${formatBytes(this.pool.stats().maxWorkerMemoryUsage)}`);
+
     const promises: Promise<any>[] = [];
 
     for (const nextTarget of this.getReadyTargets()) {
@@ -248,6 +251,7 @@ export class SimpleScheduler implements TargetScheduler {
   }
 
   async cleanup() {
+    this.options.logger.silly(`Max Worker Memory Usage: ${formatBytes(this.pool.stats().maxWorkerMemoryUsage)}`);
     await this.pool.close();
   }
 

--- a/packages/scheduler/src/formatBytes.ts
+++ b/packages/scheduler/src/formatBytes.ts
@@ -1,0 +1,3 @@
+export function formatBytes(bytes: number) {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -81,8 +81,6 @@ export class AggregatedPool implements Pool {
   }
 
   async close(): Promise<unknown> {
-    this.options.logger.verbose("Max worker memory usage: " + this.stats().maxWorkerMemoryUsage);
-
     const promises = [...this.groupedPools.values(), this.defaultPool].map((pool) => pool?.close());
     return Promise.all(promises);
   }

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -85,6 +85,7 @@ export class WorkerPool extends EventEmitter implements Pool {
   queue: QueueItem[] = [];
   maxWorkers = 0;
   availability = 0;
+  maxWorkerMemoryUsage = 0;
 
   constructor(private options: WorkerPoolOptions) {
     super();
@@ -105,6 +106,12 @@ export class WorkerPool extends EventEmitter implements Pool {
         this._exec();
       }
     });
+  }
+
+  stats() {
+    return {
+      maxWorkerMemoryUsage: this.maxWorkerMemoryUsage,
+    };
   }
 
   ensureWorkers() {
@@ -168,19 +175,30 @@ export class WorkerPool extends EventEmitter implements Pool {
     worker["filteredStderr"] = worker.stderr.pipe(createFilteredStreamTransform());
 
     const msgHandler = (data) => {
-      // In case of success: Call the callback that was passed to `runTask`,
-      // remove the `TaskInfo` associated with the Worker, and mark it as free
-      // again.
-      Promise.all([worker[kWorkerCapturedStdoutPromise], worker[kWorkerCapturedStderrPromise]]).then(() => {
-        const { err, results } = data;
-        const weight = worker[kTaskInfo].weight;
-        worker[kTaskInfo].done(err, results);
-        worker[kTaskInfo] = null;
+      if (data.type === "status") {
+        // In case of success: Call the callback that was passed to `runTask`,
+        // remove the `TaskInfo` associated with the Worker, and mark it as free
+        // again.
+        Promise.all([worker[kWorkerCapturedStdoutPromise], worker[kWorkerCapturedStderrPromise]]).then(() => {
+          const { err, results } = data;
+          const weight = worker[kTaskInfo].weight;
+          worker[kTaskInfo].done(err, results);
+          worker[kTaskInfo] = null;
 
-        this.availability += weight;
-        this.freeWorkers.push(worker);
-        this.emit(kWorkerFreedEvent);
-      });
+          this.availability += weight;
+          this.checkMemoryUsage(worker);
+        });
+      } else if (data.type === "report-memory-usage") {
+        this.maxWorkerMemoryUsage = Math.max(this.maxWorkerMemoryUsage, data.memoryUsage);
+
+        let limit = this.options.workerIdleMemoryLimit ?? os.totalmem();
+
+        if (limit && data.memoryUsage > limit) {
+          this.restartWorker(worker);
+        } else {
+          this.freeWorker(worker);
+        }
+      }
     };
 
     worker.on("message", msgHandler);
@@ -196,13 +214,11 @@ export class WorkerPool extends EventEmitter implements Pool {
         }
 
         this.emit("error", err);
-        // Remove the worker from the list and start a new Worker to replace the
-        // current one.
-        this.workers.splice(this.workers.indexOf(worker), 1);
-        this.addNewWorker();
+        this.restartWorker(worker);
       });
     };
 
+    // The 'error' event is emitted if the worker thread throws an uncaught exception. In that case, the worker is terminated.
     worker.on("error", errHandler);
 
     this.workers.push(worker);
@@ -241,6 +257,7 @@ export class WorkerPool extends EventEmitter implements Pool {
 
     if (this.freeWorkers.length > 0) {
       const worker = this.freeWorkers.pop();
+
       const work = this.queue[workIndex];
 
       this.availability -= work.weight;
@@ -270,6 +287,28 @@ export class WorkerPool extends EventEmitter implements Pool {
         worker.postMessage({ type: "start", task: { ...task, weight: work.weight }, id });
       }
     }
+  }
+
+  checkMemoryUsage(worker: Worker) {
+    worker.postMessage({ type: "check-memory-usage" });
+  }
+
+  freeWorker(worker: Worker) {
+    this.freeWorkers.push(worker);
+    this.emit(kWorkerFreedEvent);
+  }
+
+  restartWorker(worker: Worker) {
+    worker.terminate();
+
+    const freeWorkerIndex = this.freeWorkers.indexOf(worker);
+
+    if (freeWorkerIndex !== -1) {
+      this.freeWorkers.splice(freeWorkerIndex, 1); // remove from free workers list
+    }
+
+    this.workers.splice(this.workers.indexOf(worker), 1);
+    this.addNewWorker();
   }
 
   async close() {

--- a/packages/worker-threads-pool/src/types/Pool.ts
+++ b/packages/worker-threads-pool/src/types/Pool.ts
@@ -2,6 +2,9 @@ import type { Worker } from "worker_threads";
 import type { Readable } from "stream";
 import type { AbortSignal } from "abort-controller";
 
+export interface PoolStats {
+  maxWorkerMemoryUsage: number; // in bytes
+}
 export interface Pool {
   exec(
     data: unknown,
@@ -10,5 +13,8 @@ export interface Pool {
     cleanup?: (args: any) => void,
     abortSignal?: AbortSignal
   ): Promise<unknown>;
+
+  stats(): PoolStats;
+
   close(): Promise<unknown>;
 }

--- a/packages/worker-threads-pool/src/types/WorkerPoolOptions.ts
+++ b/packages/worker-threads-pool/src/types/WorkerPoolOptions.ts
@@ -3,5 +3,6 @@ import type { WorkerOptions } from "worker_threads";
 export interface WorkerPoolOptions {
   maxWorkers?: number;
   script: string;
+  workerIdleMemoryLimit?: number; // in bytes
   workerOptions?: WorkerOptions;
 }


### PR DESCRIPTION
With workers, we sometimes have "run-away" scripts that has leaks. We also could have node itself have memory leaks. This would "stall" the pool or even make it extra slow! Like `jest-worker`, we need to handle this case by providing users a way to turn to restarting workers if necessary.

1. added "workerIdleMemoryLimit" option to config
2. log-level silly to display max used memory
3. report summary to display max used memory limit (even info log level)