### PR TITLE
Add taskArgs to WorkerRunner scripts

### DIFF
--- a/change/@lage-run-cli-b8c094e8-d986-443d-be98-c40e542bd669.json
+++ b/change/@lage-run-cli-b8c094e8-d986-443d-be98-c40e542bd669.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adds taskArgs param for worker scripts",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-b8705ca5-5f0c-4d61-97d8-9410a2198f4b.json
+++ b/change/@lage-run-scheduler-b8705ca5-5f0c-4d61-97d8-9410a2198f4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adds taskArgs param for worker scripts",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -100,7 +100,9 @@ export async function runAction(options: RunOptions, command: Command) {
       },
       worker: {
         script: require.resolve("./runners/WorkerRunner"),
-        options: {},
+        options: {
+          taskArgs,
+        },
       },
       ...config.runners,
     },

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -99,7 +99,9 @@ export async function watchAction(options: RunOptions, command: Command) {
       },
       worker: {
         script: require.resolve("./runners/WorkerRunner"),
-        options: {},
+        options: {
+          taskArgs,
+        },
       },
       ...config.runners,
     },

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -39,7 +39,7 @@ export class WorkerRunner implements TargetRunner {
   static gracefulKillTimeout = 2500;
 
   async run(runOptions: TargetRunnerOptions) {
-    const { target, weight, abortSignal } = runOptions;
+    const { target, weight, abortSignal, taskArgs } = runOptions;
     const scriptFile = target.options?.worker ?? target.options?.script;
 
     if (!scriptFile) {
@@ -54,6 +54,6 @@ export class WorkerRunner implements TargetRunner {
       throw new Error("WorkerRunner: worker script must export a function; you likely need to use `module.exports = function() {...}`");
     }
 
-    await runFn({ target, weight, abortSignal });
+    await runFn({ target, weight, taskArgs, abortSignal });
   }
 }

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -1,5 +1,9 @@
 import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
 
+export interface WorkerRunnerOptions {
+  taskArgs: string[];
+}
+
 /**
  * Creates a workerpool per target task definition of "type: worker"
  *
@@ -38,8 +42,11 @@ import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-type
 export class WorkerRunner implements TargetRunner {
   static gracefulKillTimeout = 2500;
 
+  constructor(private options: WorkerRunnerOptions) {}
+
   async run(runOptions: TargetRunnerOptions) {
-    const { target, weight, abortSignal, taskArgs } = runOptions;
+    const { target, weight, abortSignal } = runOptions;
+    const { taskArgs } = this.options;
     const scriptFile = target.options?.worker ?? target.options?.script;
 
     if (!scriptFile) {

--- a/packages/scheduler/tests/WorkerRunner.test.ts
+++ b/packages/scheduler/tests/WorkerRunner.test.ts
@@ -6,7 +6,9 @@ import { WorkerRunner } from "../src/runners/WorkerRunner";
 describe("WorkerRunner", () => {
   it("can create a pool to run worker targets in parallel with worker_thread", async () => {
     const workerFixture = path.join(__dirname, "./fixtures/worker.js");
-    const runner = new WorkerRunner();
+    const runner = new WorkerRunner({
+      taskArgs: [],
+    });
 
     const target1 = {
       id: "a#work",


### PR DESCRIPTION
Currently, only NpmScriptRunner gets the taskArgs. This will allow taskArgs to be passed into WorkerRunner scripts. This would assist, for example, adding a `--fix` command line to the eslint worker.

# Impl Details

1. adds a `taskArgs` param to the TargetRunnerPicker options in `cli`
2. adds a `taskArgs` pass-through from WrappedTarget -> the WorkerRunner `run()` -> the script.