### PR TITLE
Get rid of third party abort-controller package

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn lage depcheck
 
       - name: Build, Test, Lint (Linux)
-        run: yarn lage build test lint --concurrency 2 --log-level silly
+        run: yarn lage build test lint --concurrency 2 --verbose
         env:
           BACKFILL_CACHE_PROVIDER: ${{ secrets.backfill_cache_provider }}
           BACKFILL_CACHE_PROVIDER_OPTIONS: ${{ secrets.backfill_cache_provider_options }}

--- a/change/@lage-run-scheduler-a78ec31a-0aff-492c-a8cb-8720e774ef14.json
+++ b/change/@lage-run-scheduler-a78ec31a-0aff-492c-a8cb-8720e774ef14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "get rid of third party abort-controller impl",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-types-748e0bfd-5beb-48b2-84fd-3578fdf61fe8.json
+++ b/change/@lage-run-scheduler-types-748e0bfd-5beb-48b2-84fd-3578fdf61fe8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "get rid of third party abort-controller impl",
+  "packageName": "@lage-run/scheduler-types",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-worker-threads-pool-7442117c-690c-4208-b355-28f29cf9de24.json
+++ b/change/@lage-run-worker-threads-pool-7442117c-690c-4208-b355-28f29cf9de24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "get rid of third party abort-controller impl",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler-types/package.json
+++ b/packages/scheduler-types/package.json
@@ -14,8 +14,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "@lage-run/target-graph": "^0.5.2",
-    "abort-controller": "^3.0.0"
+    "@lage-run/target-graph": "^0.5.2"
   },
   "devDependencies": {
     "monorepo-scripts": "*"

--- a/packages/scheduler-types/src/types/TargetRunner.ts
+++ b/packages/scheduler-types/src/types/TargetRunner.ts
@@ -1,5 +1,4 @@
 import type { Target } from "@lage-run/target-graph";
-import type { AbortSignal } from "abort-controller";
 
 export interface TargetRunnerOptions {
   target: Target;

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -18,7 +18,7 @@
     "@lage-run/target-graph": "^0.5.3",
     "@lage-run/logger": "^1.2.2",
     "@lage-run/cache": "^0.1.28",
-    "@lage-run/worker-threads-pool": "^0.4.3",
+    "@lage-run/worker-threads-pool": "^0.4.3"
   },
   "devDependencies": {
     "@lage-run/scheduler-types": "^0.2.5",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -18,8 +18,7 @@
     "@lage-run/target-graph": "^0.5.2",
     "@lage-run/logger": "^1.2.1",
     "@lage-run/cache": "^0.1.27",
-    "@lage-run/worker-threads-pool": "^0.4.2",
-    "abort-controller": "^3.0.0"
+    "@lage-run/worker-threads-pool": "^0.4.2"
   },
   "devDependencies": {
     "@lage-run/scheduler-types": "^0.2.4",

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -1,9 +1,7 @@
-import { AbortController } from "abort-controller";
 import { categorizeTargetRuns } from "./categorizeTargetRuns.js";
 import { getStartTargetId, sortTargetsByPriority } from "@lage-run/target-graph";
 import { WrappedTarget } from "./WrappedTarget.js";
 
-import type { AbortSignal } from "abort-controller";
 import type { CacheProvider, TargetHasher } from "@lage-run/cache";
 import type { Logger } from "@lage-run/logger";
 import type { TargetGraph, Target } from "@lage-run/target-graph";

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -6,7 +6,6 @@ import fs from "fs";
 import path from "path";
 import { mkdir, writeFile } from "fs/promises";
 
-import type { AbortController } from "abort-controller";
 import type { CacheProvider } from "@lage-run/cache";
 import type { Pool } from "@lage-run/worker-threads-pool";
 import type { TargetHasher } from "@lage-run/cache";

--- a/packages/scheduler/src/workers/targetWorker.ts
+++ b/packages/scheduler/src/workers/targetWorker.ts
@@ -1,7 +1,6 @@
 import { registerWorker } from "@lage-run/worker-threads-pool";
 import { TargetRunnerPicker } from "../runners/TargetRunnerPicker.js";
 import { workerData } from "worker_threads";
-import type { AbortSignal } from "abort-controller";
 import type { TargetRunnerPickerOptions } from "../runners/TargetRunnerPicker.js";
 
 interface TargetWorkerDataOptions {

--- a/packages/scheduler/tests/NpmScriptRunner.test.ts
+++ b/packages/scheduler/tests/NpmScriptRunner.test.ts
@@ -1,8 +1,6 @@
 import "child_process";
-import { AbortController } from "abort-controller";
 import { ChildProcess } from "child_process";
 import { getTargetId, Target } from "@lage-run/target-graph";
-import { Logger, LogLevel, Reporter } from "@lage-run/logger";
 import { NpmScriptRunner } from "../src/runners/NpmScriptRunner";
 import { waitFor } from "./waitFor";
 import os from "os";

--- a/packages/scheduler/tests/WrappedTarget.test.ts
+++ b/packages/scheduler/tests/WrappedTarget.test.ts
@@ -2,7 +2,6 @@ import { Target } from "@lage-run/target-graph";
 import { WrappedTarget } from "../src/WrappedTarget";
 
 import path from "path";
-import AbortController, { AbortSignal } from "abort-controller";
 import { CacheProvider, TargetHasher } from "@lage-run/cache";
 import { Logger } from "@lage-run/logger";
 import { TargetRunner } from "@lage-run/scheduler-types";

--- a/packages/worker-threads-pool/package.json
+++ b/packages/worker-threads-pool/package.json
@@ -15,8 +15,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "@lage-run/logger": "^1.2.1",
-    "abort-controller": "^3.0.0"
+    "@lage-run/logger": "^1.2.1"
   },
   "devDependencies": {
     "monorepo-scripts": "*"

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -1,4 +1,3 @@
-import type { AbortSignal } from "abort-controller";
 import type { Readable } from "stream";
 import type { Worker, WorkerOptions } from "worker_threads";
 import type { Pool } from "./types/Pool.js";

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -14,7 +14,6 @@ import os from "os";
 import type { Pool } from "./types/Pool.js";
 import type { Readable } from "stream";
 
-import type { AbortSignal } from "abort-controller";
 import type { WorkerPoolOptions } from "./types/WorkerPoolOptions.js";
 
 const kTaskInfo = Symbol("kTaskInfo");

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -1,8 +1,6 @@
 import { parentPort } from "worker_threads";
-import { AbortController } from "abort-controller";
 import { endMarker, startMarker } from "./stdioStreamMarkers.js";
 
-import type { AbortSignal } from "abort-controller";
 import type { MessagePort } from "worker_threads";
 
 export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<void> | void) {

--- a/packages/worker-threads-pool/src/types/Pool.ts
+++ b/packages/worker-threads-pool/src/types/Pool.ts
@@ -1,6 +1,5 @@
 import type { Worker } from "worker_threads";
 import type { Readable } from "stream";
-import type { AbortSignal } from "abort-controller";
 
 export interface PoolStats {
   maxWorkerMemoryUsage: number; // in bytes

--- a/packages/worker-threads-pool/tests/fixtures/registerWorker.fixture.js
+++ b/packages/worker-threads-pool/tests/fixtures/registerWorker.fixture.js
@@ -1,5 +1,4 @@
 const { parentPort } = require("worker_threads");
-const { AbortController } = require("abort-controller");
 
 const START_WORKER_STREAM_MARKER = "## WORKER:START:";
 const END_WORKER_STREAM_MARKER = "## WORKER:END:";

--- a/types/global/index.d.ts
+++ b/types/global/index.d.ts
@@ -1,0 +1,5 @@
+declare interface AbortSignal {
+  abort(): void;
+  addEventListener: (event: string, listener: () => void) => void;
+  removeEventListener: (event: string, listener: () => void) => void;
+}


### PR DESCRIPTION
node.js has an abort controller built-in. Let's use that instead!