### PR TITLE
Import() instead of require() everywhere

### DIFF
--- a/change/@lage-run-cli-bea390c0-5dbf-4f88-9a1b-d11802763a9d.json
+++ b/change/@lage-run-cli-bea390c0-5dbf-4f88-9a1b-d11802763a9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "switching from require() to import() where possible",
+  "packageName": "@lage-run/cli",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-49889b36-7ef3-4bce-880e-52d5ba3e0b70.json
+++ b/change/@lage-run-scheduler-49889b36-7ef3-4bce-880e-52d5ba3e0b70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "switching from require() to import() where possible",
+  "packageName": "@lage-run/scheduler",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -92,7 +92,7 @@ export async function runAction(options: RunOptions, command: Command) {
     maxWorkersPerTask: new Map([...getMaxWorkersPerTask(filteredPipeline, options.concurrency), ...maxWorkersPerTaskMap]),
     runners: {
       npmScript: {
-        script: require.resolve("./runners/NpmScriptRunner"),
+        script: require.resolve("./runners/NpmScriptRunner.js"),
         options: {
           nodeArg: options.nodeArg,
           taskArgs,
@@ -100,7 +100,7 @@ export async function runAction(options: RunOptions, command: Command) {
         },
       },
       worker: {
-        script: require.resolve("./runners/WorkerRunner"),
+        script: require.resolve("./runners/WorkerRunner.js"),
         options: {
           taskArgs,
         },

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -91,7 +91,7 @@ export async function watchAction(options: RunOptions, command: Command) {
     maxWorkersPerTask: new Map([...getMaxWorkersPerTask(filteredPipeline, options.concurrency), ...maxWorkersPerTaskMap]),
     runners: {
       npmScript: {
-        script: require.resolve("./runners/NpmScriptRunner"),
+        script: require.resolve("./runners/NpmScriptRunner.js"),
         options: {
           nodeArg: options.nodeArg,
           taskArgs,
@@ -99,7 +99,7 @@ export async function watchAction(options: RunOptions, command: Command) {
         },
       },
       worker: {
-        script: require.resolve("./runners/WorkerRunner"),
+        script: require.resolve("./runners/WorkerRunner.js"),
         options: {
           taskArgs,
         },

--- a/packages/scheduler/src/runners/TargetRunnerPicker.ts
+++ b/packages/scheduler/src/runners/TargetRunnerPicker.ts
@@ -24,7 +24,6 @@ export class TargetRunnerPicker {
       const config = this.options[target.type];
       const { script, options } = config;
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const runnerModule = await import(script);
 
       const base = path.basename(script);

--- a/packages/scheduler/src/runners/TargetRunnerPicker.ts
+++ b/packages/scheduler/src/runners/TargetRunnerPicker.ts
@@ -11,7 +11,7 @@ export interface TargetRunnerPickerOptions {
 export class TargetRunnerPicker {
   constructor(private options: TargetRunnerPickerOptions) {}
 
-  pick(target: Target): TargetRunner {
+  async pick(target: Target): Promise<TargetRunner> {
     if (target.id === getStartTargetId()) {
       return NoOpRunner;
     }
@@ -25,7 +25,7 @@ export class TargetRunnerPicker {
       const { script, options } = config;
 
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const runnerModule = require(script);
+      const runnerModule = await import(script);
 
       const base = path.basename(script);
       const runnerName = base.replace(path.extname(base), "");

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -54,7 +54,7 @@ export class WorkerRunner implements TargetRunner {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const scriptModule = require(scriptFile);
+    const scriptModule = await import(scriptFile);
     const runFn = typeof scriptModule.default === "function" ? scriptModule.default : scriptModule;
 
     if (typeof runFn !== "function") {

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -53,7 +53,6 @@ export class WorkerRunner implements TargetRunner {
       throw new Error('WorkerRunner: "script" configuration is required - e.g. { type: "worker", script: "./worker.js" }');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const scriptModule = await import(scriptFile);
     const runFn = typeof scriptModule.default === "function" ? scriptModule.default : scriptModule;
 

--- a/packages/scheduler/src/workers/targetWorker.ts
+++ b/packages/scheduler/src/workers/targetWorker.ts
@@ -20,7 +20,7 @@ function setup(options: TargetWorkerDataOptions) {
 const { runnerPicker } = setup(workerData);
 
 async function run(data: any, abortSignal?: AbortSignal) {
-  const runner = runnerPicker.pick(data.target);
+  const runner = await runnerPicker.pick(data.target);
   await runner.run({
     ...data,
     abortSignal,

--- a/scripts/config/eslintrc.js
+++ b/scripts/config/eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     "@typescript-eslint/consistent-type-exports": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-require-imports": "error",
     "no-console": "error",
     "file-extension-in-import-ts/file-extension-in-import-ts": "error"
   },


### PR DESCRIPTION
Now that we have esm loading support, we should import() any script so that it could handle both .cjs or .mjs files for worker scripts.