### PR TITLE
Fix dynamic import() for cjs format in rollup + get rid of getPackageAndTask usage outside target-graph package

### DIFF
--- a/change/@lage-run-lage-48abf91a-5602-4006-a98d-5998bc9208a2.json
+++ b/change/@lage-run-lage-48abf91a-5602-4006-a98d-5998bc9208a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing real imports with rollup as well as getting rid of getPackageAndTask implementation details",
+  "packageName": "@lage-run/lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-reporters-412230b6-c87b-4c3a-b7db-b4a81cdfab97.json
+++ b/change/@lage-run-reporters-412230b6-c87b-4c3a-b7db-b4a81cdfab97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "get rid of getPackageAndTask references",
+  "packageName": "@lage-run/reporters",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-b845b64f-2d52-456c-936b-7ecbbf7f8549.json
+++ b/change/@lage-run-scheduler-b845b64f-2d52-456c-936b-7ecbbf7f8549.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing real imports with rollup as well as getting rid of getPackageAndTask implementation details",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-13158e55-6bd5-4ebe-9693-ce67fc420f31.json
+++ b/change/@lage-run-target-graph-13158e55-6bd5-4ebe-9693-ce67fc420f31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "marking getPackageAndTask as internal - it was an unintentional export.",
+  "packageName": "@lage-run/target-graph",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-tests/src/basic.test.ts
+++ b/packages/e2e-tests/src/basic.test.ts
@@ -4,7 +4,6 @@ import { filterEntry, parseNdJson } from "./parseNdJson.js";
 describe("basics", () => {
   it("basic test case", () => {
     const repo = new Monorepo("basics");
-    console.log(repo.root);
 
     repo.init();
     repo.install();
@@ -23,6 +22,6 @@ describe("basics", () => {
     expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "test", "success"))).toBeTruthy();
     expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "lint", "success"))).toBeFalsy();
 
-    // repo.cleanup();
+    repo.cleanup();
   });
 });

--- a/packages/e2e-tests/src/basic.test.ts
+++ b/packages/e2e-tests/src/basic.test.ts
@@ -4,6 +4,7 @@ import { filterEntry, parseNdJson } from "./parseNdJson.js";
 describe("basics", () => {
   it("basic test case", () => {
     const repo = new Monorepo("basics");
+    console.log(repo.root);
 
     repo.init();
     repo.install();
@@ -22,6 +23,6 @@ describe("basics", () => {
     expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "test", "success"))).toBeTruthy();
     expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "lint", "success"))).toBeFalsy();
 
-    repo.cleanup();
+    // repo.cleanup();
   });
 });

--- a/packages/e2e-tests/src/transitiveTaskDeps.test.ts
+++ b/packages/e2e-tests/src/transitiveTaskDeps.test.ts
@@ -96,7 +96,7 @@ describe("transitive task deps test", () => {
     expect(indices[getTargetId("b", "transpile")]).toBeUndefined();
     expect(indices[getTargetId("c", "transpile")]).toBeUndefined();
 
-    // repo.cleanup();
+    repo.cleanup();
   });
 
   it("only runs direct dependencies for ^ prefix dependencies -- ", () => {

--- a/packages/lage2/rollup.config.js
+++ b/packages/lage2/rollup.config.js
@@ -3,6 +3,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { terser } from "rollup-plugin-terser";
 import alias from "@rollup/plugin-alias";
+import { retainDynamicImport } from "./scripts/retain-dynamic-import-plugin.js";
 
 export default [
   {
@@ -30,10 +31,11 @@ export default [
         ignoreDynamicRequires: true,
       }),
       json(),
+      retainDynamicImport(),
       terser(),
     ],
     external: ["fsevents"],
-    inlineDynamicImports: true
+    inlineDynamicImports: true,
   },
   {
     input: "./index.js",
@@ -55,7 +57,7 @@ export default [
       json(),
       terser(),
     ],
-    inlineDynamicImports: true
+    inlineDynamicImports: true,
   },
   {
     input: "@lage-run/scheduler/lib/workers/targetWorker.js",
@@ -75,8 +77,9 @@ export default [
         ignoreDynamicRequires: true,
       }),
       json(),
+      retainDynamicImport(),
       terser(),
     ],
-    inlineDynamicImports: true
+    inlineDynamicImports: true,
   },
 ];

--- a/packages/lage2/scripts/retain-dynamic-import-plugin.js
+++ b/packages/lage2/scripts/retain-dynamic-import-plugin.js
@@ -1,0 +1,19 @@
+export function retainDynamicImport() {
+  return {
+    name: 'retain-dynamic-import',
+    resolveDynamicImport(specifier) {
+      if (typeof specifier === 'string') {
+        return null;
+      }
+      return false;
+    },
+    renderDynamicImport(entry) {
+      if (!entry.targetModuleId) {
+        return {
+          left: 'import(',
+          right: ')'
+        };
+      }
+    }
+  };
+}

--- a/packages/reporters/src/AdoReporter.ts
+++ b/packages/reporters/src/AdoReporter.ts
@@ -1,5 +1,4 @@
 import { formatDuration, hrToSeconds } from "@lage-run/format-hrtime";
-import { getPackageAndTask } from "@lage-run/target-graph";
 import { isTargetStatusLogEntry } from "./isTargetStatusLogEntry.js";
 import { LogLevel } from "@lage-run/logger";
 import chalk from "chalk";
@@ -202,15 +201,19 @@ export class AdoReporter implements Reporter {
 
     if (failed && failed.length > 0) {
       for (const targetId of failed) {
-        const { packageName, task } = getPackageAndTask(targetId);
-        const taskLogs = this.logEntries.get(targetId);
+        const target = targetRuns.get(targetId)?.target;
 
-        this.logStream.write(`##[error] [${chalk.magenta(packageName)} ${chalk.cyan(task)}] ${chalk.redBright("ERROR DETECTED")}\n`);
+        if (target) {
+          const { packageName, task } = target;
+          const taskLogs = this.logEntries.get(targetId);
 
-        if (taskLogs) {
-          for (const entry of taskLogs) {
-            // Log each entry separately to prevent truncation
-            this.logStream.write(`##[error] ${entry.msg}\n`);
+          this.logStream.write(`##[error] [${chalk.magenta(packageName)} ${chalk.cyan(task)}] ${chalk.redBright("ERROR DETECTED")}\n`);
+
+          if (taskLogs) {
+            for (const entry of taskLogs) {
+              // Log each entry separately to prevent truncation
+              this.logStream.write(`##[error] ${entry.msg}\n`);
+            }
           }
         }
       }

--- a/packages/reporters/src/LogReporter.ts
+++ b/packages/reporters/src/LogReporter.ts
@@ -1,5 +1,4 @@
 import { formatDuration, hrtimeDiff, hrToSeconds } from "@lage-run/format-hrtime";
-import { getPackageAndTask } from "@lage-run/target-graph";
 import { isTargetStatusLogEntry } from "./isTargetStatusLogEntry.js";
 import { LogLevel } from "@lage-run/logger";
 import ansiRegex from "ansi-regex";
@@ -256,19 +255,23 @@ export class LogReporter implements Reporter {
 
     if (failed && failed.length > 0) {
       for (const targetId of failed) {
-        const { packageName, task } = getPackageAndTask(targetId);
-        const failureLogs = this.logEntries.get(targetId);
+        const target = targetRuns.get(targetId)?.target;
 
-        this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
+        if (target) {
+          const { packageName, task } = target;
+          const failureLogs = this.logEntries.get(targetId);
 
-        if (failureLogs) {
-          for (const entry of failureLogs) {
-            // Log each entry separately to prevent truncation
-            this.print(entry.msg);
+          this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
+
+          if (failureLogs) {
+            for (const entry of failureLogs) {
+              // Log each entry separately to prevent truncation
+              this.print(entry.msg);
+            }
           }
-        }
 
-        this.hr();
+          this.hr();
+        }
       }
     }
 

--- a/packages/scheduler/src/runners/TargetRunnerPicker.ts
+++ b/packages/scheduler/src/runners/TargetRunnerPicker.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { getStartTargetId } from "@lage-run/target-graph";
 import type { Target } from "@lage-run/target-graph";
 import type { TargetRunner } from "@lage-run/scheduler-types";
+import { pathToFileURL } from "url";
 
 export interface TargetRunnerPickerOptions {
   [key: string]: { script: string; options: any };
@@ -23,7 +24,13 @@ export class TargetRunnerPicker {
       const config = this.options[target.type];
       const { script, options } = config;
 
-      const runnerModule = await import(script);
+      let importScript = script;
+
+      if (!importScript.startsWith("file://")) {
+        importScript = pathToFileURL(importScript).toString();
+      }
+
+      const runnerModule = await import(importScript);
 
       const base = path.basename(script);
       const runnerName = base.replace(path.extname(base), "");

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -1,4 +1,5 @@
 import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
+import { pathToFileURL } from "url";
 
 export interface WorkerRunnerOptions {
   taskArgs: string[];
@@ -53,7 +54,13 @@ export class WorkerRunner implements TargetRunner {
       throw new Error('WorkerRunner: "script" configuration is required - e.g. { type: "worker", script: "./worker.js" }');
     }
 
-    const scriptModule = await import(scriptFile);
+    let importScript = scriptFile;
+
+    if (!importScript.startsWith("file://")) {
+      importScript = pathToFileURL(importScript).toString();
+    }
+
+    const scriptModule = await import(importScript);
     const runFn = typeof scriptModule.default === "function" ? scriptModule.default : scriptModule;
 
     if (typeof runFn !== "function") {

--- a/packages/target-graph/src/index.ts
+++ b/packages/target-graph/src/index.ts
@@ -3,6 +3,6 @@ export type { TargetGraph } from "./types/TargetGraph.js";
 export type { TargetConfig } from "./types/TargetConfig.js";
 
 export { sortTargetsByPriority } from "./sortTargetsByPriority.js";
-export { getPackageAndTask, getTargetId, getStartTargetId } from "./targetId.js";
+export { getTargetId, getStartTargetId } from "./targetId.js";
 export { detectCycles } from "./detectCycles.js";
 export { TargetGraphBuilder } from "./TargetGraphBuilder.js";

--- a/packages/target-graph/src/targetId.ts
+++ b/packages/target-graph/src/targetId.ts
@@ -14,6 +14,7 @@ export function getTargetId(pkgName: string | undefined, task: string) {
  *
  * If the packageName is //, that means that the task is meant to be run at the repo root level.
  *
+ * @internal
  * @param targetId
  * @returns
  */


### PR DESCRIPTION
We begin hiding the implementation details of target-graph's id structure. 

Next, we noticed that the dynamic import() wasn't generated correctly