### PR TITLE
Create a new "simplified" TargetGraphBuilder that isn't used for workspaces

### DIFF
--- a/change/@lage-run-cli-e3e99f2a-bc2b-4a5b-8921-f5200fb29a07.json
+++ b/change/@lage-run-cli-e3e99f2a-bc2b-4a5b-8921-f5200fb29a07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update api from targetgraphbuilder",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-13888901-e3b3-4b04-9054-837b0d8dd32b.json
+++ b/change/@lage-run-scheduler-13888901-e3b3-4b04-9054-837b0d8dd32b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update api from targetgraphbuilder",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-4b0c84fd-b3b4-48bd-a1e4-8f77fb3fea13.json
+++ b/change/@lage-run-target-graph-4b0c84fd-b3b4-48bd-a1e4-8f77fb3fea13.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "refactoring TargetGraphBuilder to be able to be used as a non-workspace graph builder",
+  "packageName": "@lage-run/target-graph",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -49,5 +49,5 @@ export function createTargetGraph(options: CreateTargetGraphOptions) {
     }
   }
 
-  return builder.buildTargetGraph(tasks, packages);
+  return builder.build(tasks, packages);
 }

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "@lage-run/logger";
-import { TargetGraphBuilder } from "@lage-run/target-graph";
+import { WorkspaceTargetGraphBuilder } from "@lage-run/target-graph";
 import type { PackageInfos } from "workspace-tools";
 import { getFilteredPackages } from "../../filter/getFilteredPackages.js";
 import type { PipelineDefinition } from "../../types/PipelineDefinition.js";
@@ -22,7 +22,7 @@ interface CreateTargetGraphOptions {
 export function createTargetGraph(options: CreateTargetGraphOptions) {
   const { logger, root, dependencies, dependents, since, scope, repoWideChanges, ignore, pipeline, outputs, tasks, packageInfos } = options;
 
-  const builder = new TargetGraphBuilder(root, packageInfos);
+  const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
 
   const packages = getFilteredPackages({
     root,

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -42,7 +42,6 @@ export class SimpleScheduler implements TargetScheduler {
   targetsByPriority: Target[] = [];
   abortController: AbortController = new AbortController();
   abortSignal: AbortSignal = this.abortController.signal;
-  dependencies: [string, string][] = [];
   pool: Pool;
   runPromise = Promise.resolve() as Promise<any>;
 
@@ -82,8 +81,7 @@ export class SimpleScheduler implements TargetScheduler {
     const { continueOnError, logger, cacheProvider, shouldCache, shouldResetCache, hasher } = this.options;
     const { pool, abortController } = this;
 
-    const { dependencies, targets } = targetGraph;
-    this.dependencies = dependencies;
+    const { targets } = targetGraph;
 
     this.targetsByPriority = sortTargetsByPriority([...targets.values()]);
     for (const target of targets.values()) {

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -1,0 +1,79 @@
+import type { TargetConfig } from "./types/TargetConfig.js";
+import type { Target } from "./types/Target.js";
+
+import { getPackageAndTask, getTargetId } from "./targetId.js";
+import { getWeight } from "./getWeight.js";
+
+export interface TargetFactoryOptions {
+  root: string;
+  resolve(packageName: string): string;
+}
+
+export class TargetFactory {
+  constructor(private options: TargetFactoryOptions) {}
+
+  /**
+   * Creates a package task `Target`
+   * @param packageName
+   * @param task
+   * @param config
+   * @returns a package task `Target`
+   */
+  createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
+    const { resolve } = this.options;
+    const { options, deps, dependsOn, cache, inputs, outputs, priority, maxWorkers, environmentGlob, weight } = config;
+    const cwd = resolve(packageName);
+
+    const target = {
+      id: getTargetId(packageName, task),
+      label: `${packageName} - ${task}`,
+      type: config.type,
+      packageName,
+      task,
+      cache: cache !== false,
+      cwd,
+      depSpecs: dependsOn ?? deps ?? [],
+      dependencies: [],
+      dependents: [],
+      inputs,
+      outputs,
+      priority,
+      maxWorkers,
+      environmentGlob,
+      weight: 1,
+      options,
+    };
+
+    target.weight = getWeight(target, weight, maxWorkers);
+
+    return target;
+  }
+
+  createGlobalTarget(id: string, config: TargetConfig): Target {
+    const { root } = this.options;
+    const { options, deps, dependsOn, inputs, outputs, priority, maxWorkers, environmentGlob, weight } = config;
+    const { task } = getPackageAndTask(id);
+    const target = {
+      id,
+      label: id,
+      type: config.type,
+      task,
+      cache: false,
+      cwd: root,
+      depSpecs: dependsOn ?? deps ?? [],
+      dependencies: [],
+      dependents: [],
+      inputs,
+      outputs,
+      priority,
+      maxWorkers,
+      environmentGlob,
+      weight: 1,
+      options,
+    };
+
+    target.weight = getWeight(target, weight, maxWorkers);
+
+    return target;
+  }
+}

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -1,16 +1,10 @@
-import { createDependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
 import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId.js";
 import { prioritize } from "./prioritize.js";
-import { expandDepSpecs } from "./expandDepSpecs.js";
 
 import path from "path";
 
-import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
-import type { PackageInfos } from "workspace-tools";
 import type { Target } from "./types/Target.js";
 import type { TargetConfig } from "./types/TargetConfig.js";
-import { detectCycles } from "./detectCycles.js";
-import { getWeight } from "./getWeight.js";
 
 /**
  * TargetGraphBuilder class provides a builder API for registering target configs. It exposes a method called `generateTargetGraph` to
@@ -21,7 +15,7 @@ import { getWeight } from "./getWeight.js";
  * ```typescript
  * const rootDir = process.cwd();
  * const packageInfos = getPackageInfos(rootDir);
- * const builder = new TargetGraphBuilder(rootDir, packageInfos);
+ * const builder = new WorkspaceTargetGraphBuilder(rootDir, packageInfos);
  * const targetGraph = builder.buildTargetGraph([...packages], [...tasks]);
  * ```
  */
@@ -29,207 +23,12 @@ export class TargetGraphBuilder {
   /** A map of targets - used internally for looking up generated targets from the target configurations */
   private targets: Map<string, Target> = new Map();
 
-  /** List of target to target dependency, represents the _full_ target graph during dependency expansion */
-  private dependencies: [string, string][] = [];
-
-  /** A cache of the dependencyMap for packages, used inside dependency expansion */
-  private dependencyMap: DependencyMap;
-
   /**
    * Initializes the builder with package infos
    * @param root the root directory of the workspace
    * @param packageInfos the package infos for the workspace
    */
-  constructor(private root: string, private packageInfos: PackageInfos) {
-    this.dependencyMap = createDependencyMap(packageInfos, { withDevDependencies: true, withPeerDependencies: false });
-  }
-
-  /**
-   * Creates a global `Target`
-   * @param id
-   * @param config
-   * @returns a generated global Target
-   */
-  private createGlobalTarget(id: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
-    const { task } = getPackageAndTask(id);
-    const targetId = getTargetId(undefined, task);
-    const target = {
-      id: targetId,
-      label: targetId,
-      type: config.type,
-      task,
-      // TODO: backfill currently cannot cache global targets!
-      // NOTE: We should force cache inputs to be defined for global targets
-      cache: false,
-      cwd: this.root,
-      depSpecs: dependsOn ?? deps ?? [],
-      dependencies: [],
-      dependents: [],
-      inputs,
-      outputs,
-      priority,
-      maxWorkers,
-      environmentGlob,
-      weight: 1,
-      options,
-    };
-
-    target.weight = getWeight(target, config.weight, maxWorkers);
-
-    return target;
-  }
-
-  /**
-   * Creates a package task `Target`
-   * @param packageName
-   * @param task
-   * @param config
-   * @returns a package task `Target`
-   */
-  private createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, cache, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
-    const info = this.packageInfos[packageName];
-    const target = {
-      id: getTargetId(packageName, task),
-      label: `${packageName} - ${task}`,
-      type: config.type,
-      packageName,
-      task,
-      cache: cache !== false,
-      cwd: path.dirname(info.packageJsonPath),
-      depSpecs: dependsOn ?? deps ?? [],
-      dependencies: [],
-      dependents: [],
-      inputs,
-      outputs,
-      priority,
-      maxWorkers,
-      environmentGlob,
-      weight: 1,
-      options,
-    };
-
-    target.weight = getWeight(target, config.weight, maxWorkers);
-
-    return target;
-  }
-
-  /**
-   * Filters out targets that are not part of the entry point.
-   * @param tasks
-   * @param scope
-   * @returns a list of target to target dependencies
-   */
-  private createSubGraph(tasks: string[], scope?: string[]) {
-    const targetGraph: [string, string][] = [];
-    const knownDeps = new Set<string>();
-
-    const knownDepsKey = (from: string, to: string) => {
-      return `${from}->${to}`;
-    };
-
-    const addTargetGraphEdge = (from: string, to: string) => {
-      if (knownDeps.has(knownDepsKey(from, to))) {
-        return;
-      }
-      knownDeps.add(knownDepsKey(from, to));
-      targetGraph.push([from, to]);
-    };
-
-    const queue: string[] = [];
-
-    if (!scope) {
-      scope = Object.keys(this.packageInfos);
-    }
-
-    for (const task of tasks) {
-      // package task
-      for (const pkg of scope) {
-        if (this.targets.has(getTargetId(pkg, task))) {
-          queue.push(getTargetId(pkg, task));
-          addTargetGraphEdge(getStartTargetId(), getTargetId(pkg, task));
-        }
-      }
-
-      // if we have global targets, send those into the queue
-      for (const target of this.targets.values()) {
-        if (target.task === task && !target.packageName) {
-          queue.push(target.id);
-          addTargetGraphEdge(getStartTargetId(), target.id);
-        }
-      }
-    }
-
-    const visited = new Set<string>();
-
-    while (queue.length > 0) {
-      const id = queue.shift()!;
-
-      if (visited.has(id)) {
-        continue;
-      }
-
-      visited.add(id);
-
-      for (const [from, to] of this.dependencies) {
-        if (to === id) {
-          // dedupe the targetGraph edges
-          if (targetGraph.find(([fromId, toId]) => fromId === from && toId === to) === undefined) {
-            addTargetGraphEdge(from, to);
-          }
-
-          if (from) {
-            queue.push(from);
-          }
-        }
-      }
-    }
-
-    return targetGraph;
-  }
-
-  /**
-   * Generates new `Target`, indexed by the id based on a new target configuration.
-   *
-   * @param id
-   * @param targetDefinition
-   */
-  addTargetConfig(id: string, config: TargetConfig = {}): void {
-    // Generates a target definition from the target config
-    if (id.startsWith("//") || id.startsWith("#")) {
-      const target = this.createGlobalTarget(id, config);
-      this.targets.set(target.id, target);
-    } else if (id.includes("#")) {
-      const { packageName, task } = getPackageAndTask(id);
-      const target = this.createPackageTarget(packageName!, task, config);
-      this.targets.set(target.id, target);
-    } else {
-      const packages = Object.keys(this.packageInfos);
-      for (const packageName of packages) {
-        const task = id;
-        const target = this.createPackageTarget(packageName!, task, config);
-        this.targets.set(target.id, target);
-      }
-    }
-  }
-
-  /**
-   * Builds a scoped target graph for given tasks and packages
-   *
-   * Steps:
-   * 1. expands the dependency specs from the target definitions
-   * 2. sub-graph filtered from the full dependency graph
-   * 3. filtering all targets to just only the ones listed in the sub-graph
-   * 4. returns the sub-graph
-   *
-   * @param tasks
-   * @param scope
-   * @returns
-   */
-  buildTargetGraph(tasks: string[], scope?: string[]) {
-    this.dependencies = expandDepSpecs(this.targets, this.dependencyMap);
-
+  constructor(private root: string) {
     const startId = getStartTargetId();
     this.targets.set(startId, {
       id: startId,
@@ -242,44 +41,95 @@ export class TargetGraphBuilder {
       depSpecs: [],
       weight: 1,
     } as Target);
+  }
 
-    const subGraphEdges = this.createSubGraph(tasks, scope);
-    const subGraphTargets: Map<string, Target> = new Map();
+  /**
+   * Creates a global `Target`
+   * @param id
+   * @param config
+   * @returns a generated global Target
+   */
+  addGlobalTarget(id: string, config: TargetConfig): Target {
+    const { options, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
+    const { task } = getPackageAndTask(id);
+    const targetId = getTargetId(undefined, task);
+    const target = {
+      id: targetId,
+      label: targetId,
+      type: config.type,
+      task,
+      // TODO: backfill currently cannot cache global targets!
+      // NOTE: We should force cache inputs to be defined for global targets
+      cache: false,
+      cwd: this.root,
+      depSpecs: [],
+      dependencies: [],
+      dependents: [],
+      inputs,
+      outputs,
+      priority,
+      maxWorkers,
+      environmentGlob,
+      weight: 1,
+      options,
+    };
 
-    // Delay setting up the "dependents" and "dependencies" of the targets until the subgraph is defined
-    // This will ensure that the only dependencies present in the returned results are from the subgraph
-    for (const [from, to] of subGraphEdges) {
-      if (this.targets.has(from)) {
-        const target = this.targets.get(from)!;
+    this.targets.set(target.id, target);
+    this.addDependency(getStartTargetId(), target.id);
 
-        subGraphTargets.set(from, target);
+    return target;
+  }
 
-        target.dependents = target.dependents ?? [];
-        target.dependents.push(to);
-      }
+  /**
+   * Creates a package task `Target`
+   * @param packageName
+   * @param task
+   * @param config
+   * @returns a package task `Target`
+   */
+  addPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
+    const { options, cache, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
+    const cwd = path.relative(this.root, path.dirname(require.resolve(path.join(packageName, "package.json"), { paths: [this.root] })));
+    const target = {
+      id: getTargetId(packageName, task),
+      label: `${packageName} - ${task}`,
+      type: config.type,
+      packageName,
+      task,
+      cache: cache !== false,
+      cwd,
+      depSpecs: [],
+      dependencies: [],
+      dependents: [],
+      inputs,
+      outputs,
+      priority,
+      maxWorkers,
+      environmentGlob,
+      weight: 1,
+      options,
+    };
 
-      if (this.targets.has(to)) {
-        const target = this.targets.get(to)!;
-        subGraphTargets.set(to, target);
+    this.targets.set(target.id, target);
+    this.addDependency(getStartTargetId(), target.id);
 
-        target.dependencies = target.dependencies ?? [];
-        target.dependencies.push(from);
-      }
-    }
+    return target;
+  }
 
-    // Ensure we do not have cycles in the subgraph
-    const cycleInfo = detectCycles(this.targets);
-    if (cycleInfo.hasCycle) {
-      throw new Error("Cycles detected in the target graph: " + cycleInfo.cycle!.concat(cycleInfo.cycle![0]).join(" -> "));
-    }
+  addDependency(from: string, to: string) {
+    this.targets.get(to)?.dependencies.push(from);
+    this.targets.get(from)?.dependents.push(to);
+  }
 
-    // Add priority to the SUB-GRAPH, because the aggregated priorities are in the context of the final graph
+  /**
+   * Builds a target graph for given tasks and packages
+   */
+  build() {
     // The full graph might produce a different aggregated priority value for a target
-    prioritize(subGraphTargets);
+    prioritize(this.targets);
 
     return {
-      targets: subGraphTargets,
-      dependencies: subGraphEdges,
+      targets: this.targets,
     };
   }
 }

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -1,16 +1,14 @@
 import { createDependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
-import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId.js";
-import { prioritize } from "./prioritize.js";
+import { getPackageAndTask, getTargetId } from "./targetId.js";
 import { expandDepSpecs } from "./expandDepSpecs.js";
 
 import path from "path";
 
 import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
 import type { PackageInfos } from "workspace-tools";
-import type { Target } from "./types/Target.js";
 import type { TargetConfig } from "./types/TargetConfig.js";
-import { detectCycles } from "./detectCycles.js";
-import { getWeight } from "./getWeight.js";
+import { TargetGraphBuilder } from "./TargetGraphBuilder.js";
+import { TargetFactory } from "./TargetFactory.js";
 
 /**
  * TargetGraphBuilder class provides a builder API for registering target configs. It exposes a method called `generateTargetGraph` to
@@ -26,164 +24,27 @@ import { getWeight } from "./getWeight.js";
  * ```
  */
 export class WorkspaceTargetGraphBuilder {
-  /** A map of targets - used internally for looking up generated targets from the target configurations */
-  private targets: Map<string, Target> = new Map();
-
   /** A cache of the dependencyMap for packages, used inside dependency expansion */
   private dependencyMap: DependencyMap;
+
+  private graphBuilder: TargetGraphBuilder;
+
+  private targetFactory: TargetFactory;
 
   /**
    * Initializes the builder with package infos
    * @param root the root directory of the workspace
    * @param packageInfos the package infos for the workspace
    */
-  constructor(private root: string, private packageInfos: PackageInfos) {
+  constructor(root: string, private packageInfos: PackageInfos) {
     this.dependencyMap = createDependencyMap(packageInfos, { withDevDependencies: true, withPeerDependencies: false });
-  }
-
-  /**
-   * Creates a global `Target`
-   * @param id
-   * @param config
-   * @returns a generated global Target
-   */
-  private createGlobalTarget(id: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
-    const { task } = getPackageAndTask(id);
-    const targetId = getTargetId(undefined, task);
-    const target = {
-      id: targetId,
-      label: targetId,
-      type: config.type,
-      task,
-      // TODO: backfill currently cannot cache global targets!
-      // NOTE: We should force cache inputs to be defined for global targets
-      cache: false,
-      cwd: this.root,
-      depSpecs: dependsOn ?? deps ?? [],
-      dependencies: [],
-      dependents: [],
-      inputs,
-      outputs,
-      priority,
-      maxWorkers,
-      environmentGlob,
-      weight: 1,
-      options,
-    };
-
-    target.weight = getWeight(target, config.weight, maxWorkers);
-
-    return target;
-  }
-
-  /**
-   * Creates a package task `Target`
-   * @param packageName
-   * @param task
-   * @param config
-   * @returns a package task `Target`
-   */
-  private createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
-    const { options, dependsOn, deps, cache, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
-    const info = this.packageInfos[packageName];
-    const target = {
-      id: getTargetId(packageName, task),
-      label: `${packageName} - ${task}`,
-      type: config.type,
-      packageName,
-      task,
-      cache: cache !== false,
-      cwd: path.dirname(info.packageJsonPath),
-      depSpecs: dependsOn ?? deps ?? [],
-      dependencies: [],
-      dependents: [],
-      inputs,
-      outputs,
-      priority,
-      maxWorkers,
-      environmentGlob,
-      weight: 1,
-      options,
-    };
-
-    target.weight = getWeight(target, config.weight, maxWorkers);
-
-    return target;
-  }
-
-  /**
-   * Filters out targets that are not part of the entry point.
-   * @param tasks
-   * @param scope
-   * @returns a list of target to target dependencies
-   */
-  private createSubGraph(dependencies: [string, string][], tasks: string[], scope?: string[]) {
-    const targetGraph: [string, string][] = [];
-    const knownDeps = new Set<string>();
-
-    const knownDepsKey = (from: string, to: string) => {
-      return `${from}->${to}`;
-    };
-
-    const addTargetGraphEdge = (from: string, to: string) => {
-      if (knownDeps.has(knownDepsKey(from, to))) {
-        return;
-      }
-      knownDeps.add(knownDepsKey(from, to));
-      targetGraph.push([from, to]);
-    };
-
-    const queue: string[] = [];
-
-    if (!scope) {
-      scope = Object.keys(this.packageInfos);
-    }
-
-    for (const task of tasks) {
-      // package task
-      for (const pkg of scope) {
-        if (this.targets.has(getTargetId(pkg, task))) {
-          queue.push(getTargetId(pkg, task));
-          addTargetGraphEdge(getStartTargetId(), getTargetId(pkg, task));
-        }
-      }
-
-      // if we have global targets, send those into the queue
-      for (const target of this.targets.values()) {
-        if (target.task === task && !target.packageName) {
-          queue.push(target.id);
-          addTargetGraphEdge(getStartTargetId(), target.id);
-        }
-      }
-    }
-
-    const visited = new Set<string>();
-
-    while (queue.length > 0) {
-      const id = queue.shift()!;
-
-      if (visited.has(id)) {
-        continue;
-      }
-
-      visited.add(id);
-
-      for (const [from, to] of dependencies) {
-        if (to === id) {
-          // dedupe the targetGraph edges
-          if (targetGraph.find(([fromId, toId]) => fromId === from && toId === to) === undefined) {
-            addTargetGraphEdge(from, to);
-          }
-
-          if (from) {
-            queue.push(from);
-          }
-        }
-      }
-    }
-
-    return targetGraph;
+    this.graphBuilder = new TargetGraphBuilder();
+    this.targetFactory = new TargetFactory({
+      root: root,
+      resolve(packageName: string) {
+        return path.dirname(packageInfos[packageName].packageJsonPath);
+      },
+    });
   }
 
   /**
@@ -195,18 +56,18 @@ export class WorkspaceTargetGraphBuilder {
   addTargetConfig(id: string, config: TargetConfig = {}): void {
     // Generates a target definition from the target config
     if (id.startsWith("//") || id.startsWith("#")) {
-      const target = this.createGlobalTarget(id, config);
-      this.targets.set(target.id, target);
+      const target = this.targetFactory.createGlobalTarget(id, config);
+      this.graphBuilder.addTarget(target);
     } else if (id.includes("#")) {
       const { packageName, task } = getPackageAndTask(id);
-      const target = this.createPackageTarget(packageName!, task, config);
-      this.targets.set(target.id, target);
+      const target = this.targetFactory.createPackageTarget(packageName!, task, config);
+      this.graphBuilder.addTarget(target);
     } else {
       const packages = Object.keys(this.packageInfos);
       for (const packageName of packages) {
         const task = id;
-        const target = this.createPackageTarget(packageName!, task, config);
-        this.targets.set(target.id, target);
+        const target = this.targetFactory.createPackageTarget(packageName!, task, config);
+        this.graphBuilder.addTarget(target);
       }
     }
   }
@@ -224,58 +85,31 @@ export class WorkspaceTargetGraphBuilder {
    * @param scope
    * @returns
    */
-  buildTargetGraph(tasks: string[], scope?: string[]) {
-    const fullDependencies = expandDepSpecs(this.targets, this.dependencyMap);
+  build(tasks: string[], scope?: string[]) {
+    // Expands the dependency specs from the target definitions
+    const fullDependencies = expandDepSpecs(this.graphBuilder.targets, this.dependencyMap);
 
-    const startId = getStartTargetId();
-    this.targets.set(startId, {
-      id: startId,
-      task: startId,
-      cwd: "",
-      label: "Start",
-      hidden: true,
-      dependencies: [],
-      dependents: [],
-      depSpecs: [],
-      weight: 1,
-    } as Target);
+    for (const [from, to] of fullDependencies) {
+      this.graphBuilder.addDependency(from, to);
+    }
 
-    const subGraphEdges = this.createSubGraph(fullDependencies, tasks, scope);
-    const subGraphTargets: Map<string, Target> = new Map();
-
-    // Delay setting up the "dependents" and "dependencies" of the targets until the subgraph is defined
-    // This will ensure that the only dependencies present in the returned results are from the subgraph
-    for (const [from, to] of subGraphEdges) {
-      if (this.targets.has(from)) {
-        const target = this.targets.get(from)!;
-
-        subGraphTargets.set(from, target);
-
-        target.dependents = target.dependents ?? [];
-        target.dependents.push(to);
-      }
-
-      if (this.targets.has(to)) {
-        const target = this.targets.get(to)!;
-        subGraphTargets.set(to, target);
-
-        target.dependencies = target.dependencies ?? [];
-        target.dependencies.push(from);
+    const subGraphEntries: string[] = [];
+    for (const task of tasks) {
+      if (scope) {
+        for (const packageName of scope) {
+          subGraphEntries.push(getTargetId(packageName, task));
+        }
+      } else {
+        for (const packageName of Object.keys(this.packageInfos)) {
+          subGraphEntries.push(getTargetId(packageName, task));
+        }
       }
     }
 
-    // Ensure we do not have cycles in the subgraph
-    const cycleInfo = detectCycles(this.targets);
-    if (cycleInfo.hasCycle) {
-      throw new Error("Cycles detected in the target graph: " + cycleInfo.cycle!.concat(cycleInfo.cycle![0]).join(" -> "));
-    }
-
-    // Add priority to the SUB-GRAPH, because the aggregated priorities are in the context of the final graph
-    // The full graph might produce a different aggregated priority value for a target
-    prioritize(subGraphTargets);
+    const subGraph = this.graphBuilder.subgraph(subGraphEntries);
 
     return {
-      targets: subGraphTargets,
+      targets: subGraph.targets,
     };
   }
 }

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -1,0 +1,281 @@
+import { createDependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
+import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId.js";
+import { prioritize } from "./prioritize.js";
+import { expandDepSpecs } from "./expandDepSpecs.js";
+
+import path from "path";
+
+import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
+import type { PackageInfos } from "workspace-tools";
+import type { Target } from "./types/Target.js";
+import type { TargetConfig } from "./types/TargetConfig.js";
+import { detectCycles } from "./detectCycles.js";
+import { getWeight } from "./getWeight.js";
+
+/**
+ * TargetGraphBuilder class provides a builder API for registering target configs. It exposes a method called `generateTargetGraph` to
+ * generate a topological graph of targets (package + task) and their dependencies.
+ *
+ * Usage:
+ *
+ * ```typescript
+ * const rootDir = process.cwd();
+ * const packageInfos = getPackageInfos(rootDir);
+ * const builder = new WorkspaceTargetGraphBuilder(rootDir, packageInfos);
+ * const targetGraph = builder.buildTargetGraph([...packages], [...tasks]);
+ * ```
+ */
+export class WorkspaceTargetGraphBuilder {
+  /** A map of targets - used internally for looking up generated targets from the target configurations */
+  private targets: Map<string, Target> = new Map();
+
+  /** A cache of the dependencyMap for packages, used inside dependency expansion */
+  private dependencyMap: DependencyMap;
+
+  /**
+   * Initializes the builder with package infos
+   * @param root the root directory of the workspace
+   * @param packageInfos the package infos for the workspace
+   */
+  constructor(private root: string, private packageInfos: PackageInfos) {
+    this.dependencyMap = createDependencyMap(packageInfos, { withDevDependencies: true, withPeerDependencies: false });
+  }
+
+  /**
+   * Creates a global `Target`
+   * @param id
+   * @param config
+   * @returns a generated global Target
+   */
+  private createGlobalTarget(id: string, config: TargetConfig): Target {
+    const { options, dependsOn, deps, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
+    const { task } = getPackageAndTask(id);
+    const targetId = getTargetId(undefined, task);
+    const target = {
+      id: targetId,
+      label: targetId,
+      type: config.type,
+      task,
+      // TODO: backfill currently cannot cache global targets!
+      // NOTE: We should force cache inputs to be defined for global targets
+      cache: false,
+      cwd: this.root,
+      depSpecs: dependsOn ?? deps ?? [],
+      dependencies: [],
+      dependents: [],
+      inputs,
+      outputs,
+      priority,
+      maxWorkers,
+      environmentGlob,
+      weight: 1,
+      options,
+    };
+
+    target.weight = getWeight(target, config.weight, maxWorkers);
+
+    return target;
+  }
+
+  /**
+   * Creates a package task `Target`
+   * @param packageName
+   * @param task
+   * @param config
+   * @returns a package task `Target`
+   */
+  private createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
+    const { options, dependsOn, deps, cache, inputs, outputs, priority, maxWorkers, environmentGlob } = config;
+    const info = this.packageInfos[packageName];
+    const target = {
+      id: getTargetId(packageName, task),
+      label: `${packageName} - ${task}`,
+      type: config.type,
+      packageName,
+      task,
+      cache: cache !== false,
+      cwd: path.dirname(info.packageJsonPath),
+      depSpecs: dependsOn ?? deps ?? [],
+      dependencies: [],
+      dependents: [],
+      inputs,
+      outputs,
+      priority,
+      maxWorkers,
+      environmentGlob,
+      weight: 1,
+      options,
+    };
+
+    target.weight = getWeight(target, config.weight, maxWorkers);
+
+    return target;
+  }
+
+  /**
+   * Filters out targets that are not part of the entry point.
+   * @param tasks
+   * @param scope
+   * @returns a list of target to target dependencies
+   */
+  private createSubGraph(dependencies: [string, string][], tasks: string[], scope?: string[]) {
+    const targetGraph: [string, string][] = [];
+    const knownDeps = new Set<string>();
+
+    const knownDepsKey = (from: string, to: string) => {
+      return `${from}->${to}`;
+    };
+
+    const addTargetGraphEdge = (from: string, to: string) => {
+      if (knownDeps.has(knownDepsKey(from, to))) {
+        return;
+      }
+      knownDeps.add(knownDepsKey(from, to));
+      targetGraph.push([from, to]);
+    };
+
+    const queue: string[] = [];
+
+    if (!scope) {
+      scope = Object.keys(this.packageInfos);
+    }
+
+    for (const task of tasks) {
+      // package task
+      for (const pkg of scope) {
+        if (this.targets.has(getTargetId(pkg, task))) {
+          queue.push(getTargetId(pkg, task));
+          addTargetGraphEdge(getStartTargetId(), getTargetId(pkg, task));
+        }
+      }
+
+      // if we have global targets, send those into the queue
+      for (const target of this.targets.values()) {
+        if (target.task === task && !target.packageName) {
+          queue.push(target.id);
+          addTargetGraphEdge(getStartTargetId(), target.id);
+        }
+      }
+    }
+
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const id = queue.shift()!;
+
+      if (visited.has(id)) {
+        continue;
+      }
+
+      visited.add(id);
+
+      for (const [from, to] of dependencies) {
+        if (to === id) {
+          // dedupe the targetGraph edges
+          if (targetGraph.find(([fromId, toId]) => fromId === from && toId === to) === undefined) {
+            addTargetGraphEdge(from, to);
+          }
+
+          if (from) {
+            queue.push(from);
+          }
+        }
+      }
+    }
+
+    return targetGraph;
+  }
+
+  /**
+   * Generates new `Target`, indexed by the id based on a new target configuration.
+   *
+   * @param id
+   * @param targetDefinition
+   */
+  addTargetConfig(id: string, config: TargetConfig = {}): void {
+    // Generates a target definition from the target config
+    if (id.startsWith("//") || id.startsWith("#")) {
+      const target = this.createGlobalTarget(id, config);
+      this.targets.set(target.id, target);
+    } else if (id.includes("#")) {
+      const { packageName, task } = getPackageAndTask(id);
+      const target = this.createPackageTarget(packageName!, task, config);
+      this.targets.set(target.id, target);
+    } else {
+      const packages = Object.keys(this.packageInfos);
+      for (const packageName of packages) {
+        const task = id;
+        const target = this.createPackageTarget(packageName!, task, config);
+        this.targets.set(target.id, target);
+      }
+    }
+  }
+
+  /**
+   * Builds a scoped target graph for given tasks and packages
+   *
+   * Steps:
+   * 1. expands the dependency specs from the target definitions
+   * 2. sub-graph filtered from the full dependency graph
+   * 3. filtering all targets to just only the ones listed in the sub-graph
+   * 4. returns the sub-graph
+   *
+   * @param tasks
+   * @param scope
+   * @returns
+   */
+  buildTargetGraph(tasks: string[], scope?: string[]) {
+    const fullDependencies = expandDepSpecs(this.targets, this.dependencyMap);
+
+    const startId = getStartTargetId();
+    this.targets.set(startId, {
+      id: startId,
+      task: startId,
+      cwd: "",
+      label: "Start",
+      hidden: true,
+      dependencies: [],
+      dependents: [],
+      depSpecs: [],
+      weight: 1,
+    } as Target);
+
+    const subGraphEdges = this.createSubGraph(fullDependencies, tasks, scope);
+    const subGraphTargets: Map<string, Target> = new Map();
+
+    // Delay setting up the "dependents" and "dependencies" of the targets until the subgraph is defined
+    // This will ensure that the only dependencies present in the returned results are from the subgraph
+    for (const [from, to] of subGraphEdges) {
+      if (this.targets.has(from)) {
+        const target = this.targets.get(from)!;
+
+        subGraphTargets.set(from, target);
+
+        target.dependents = target.dependents ?? [];
+        target.dependents.push(to);
+      }
+
+      if (this.targets.has(to)) {
+        const target = this.targets.get(to)!;
+        subGraphTargets.set(to, target);
+
+        target.dependencies = target.dependencies ?? [];
+        target.dependencies.push(from);
+      }
+    }
+
+    // Ensure we do not have cycles in the subgraph
+    const cycleInfo = detectCycles(this.targets);
+    if (cycleInfo.hasCycle) {
+      throw new Error("Cycles detected in the target graph: " + cycleInfo.cycle!.concat(cycleInfo.cycle![0]).join(" -> "));
+    }
+
+    // Add priority to the SUB-GRAPH, because the aggregated priorities are in the context of the final graph
+    // The full graph might produce a different aggregated priority value for a target
+    prioritize(subGraphTargets);
+
+    return {
+      targets: subGraphTargets,
+    };
+  }
+}

--- a/packages/target-graph/src/index.ts
+++ b/packages/target-graph/src/index.ts
@@ -5,4 +5,4 @@ export type { TargetConfig } from "./types/TargetConfig.js";
 export { sortTargetsByPriority } from "./sortTargetsByPriority.js";
 export { getPackageAndTask, getTargetId, getStartTargetId } from "./targetId.js";
 export { detectCycles } from "./detectCycles.js";
-export { TargetGraphBuilder } from "./TargetGraphBuilder.js";
+export { WorkspaceTargetGraphBuilder } from "./WorkspaceTargetGraphBuilder.js";

--- a/packages/target-graph/src/types/TargetGraph.ts
+++ b/packages/target-graph/src/types/TargetGraph.ts
@@ -2,5 +2,4 @@ import type { Target } from "../types/Target.js";
 
 export interface TargetGraph {
   targets: Map<string, Target>;
-  dependencies: [string, string][];
 }

--- a/packages/target-graph/tests/TargetGraphBuilder.test.ts
+++ b/packages/target-graph/tests/TargetGraphBuilder.test.ts
@@ -1,0 +1,198 @@
+import { TargetGraphBuilder } from "../src/TargetGraphBuilder";
+import { Target } from "../src/types/Target";
+
+describe("Target Graph Builder", () => {
+  it("should build a full graph", () => {
+    const target1 = createTarget("a", "build", 1);
+    const target2 = createTarget("b", "build", 1);
+
+    const builder = new TargetGraphBuilder();
+    builder.addTarget(target1);
+    builder.addTarget(target2);
+    builder.addDependency(target1.id, target2.id);
+
+    const targetGraph = builder.build();
+
+    expect(simplify(targetGraph.targets)).toMatchInlineSnapshot(`
+      [
+        {
+          "dependencies": [],
+          "dependents": [
+            "a#build",
+            "b#build",
+          ],
+          "id": "__start",
+          "priority": 0,
+        },
+        {
+          "dependencies": [
+            "__start",
+          ],
+          "dependents": [
+            "b#build",
+          ],
+          "id": "a#build",
+          "priority": 1,
+        },
+        {
+          "dependencies": [
+            "__start",
+            "a#build",
+          ],
+          "dependents": [],
+          "id": "b#build",
+          "priority": 2,
+        },
+      ]
+    `);
+  });
+
+  it("should build a subgraph", () => {
+    const target1 = createTarget("a", "build", 1);
+    const target2 = createTarget("b", "build", 1);
+    const target3 = createTarget("c", "build", 1);
+    const target4 = createTarget("d", "build", 1);
+
+    const builder = new TargetGraphBuilder();
+    builder.addTarget(target1);
+    builder.addTarget(target2);
+    builder.addTarget(target3);
+    builder.addTarget(target4);
+    builder.addDependency(target1.id, target2.id);
+    builder.addDependency(target1.id, target3.id);
+    builder.addDependency(target4.id, target1.id);
+
+    const targetGraph = builder.subgraph(["a#build"]);
+
+    expect(simplify(targetGraph.targets)).toMatchInlineSnapshot(`
+      [
+        {
+          "dependencies": [],
+          "dependents": [
+            "a#build",
+            "d#build",
+          ],
+          "id": "__start",
+          "priority": 0,
+        },
+        {
+          "dependencies": [
+            "__start",
+            "d#build",
+          ],
+          "dependents": [],
+          "id": "a#build",
+          "priority": 2,
+        },
+        {
+          "dependencies": [
+            "__start",
+          ],
+          "dependents": [
+            "a#build",
+          ],
+          "id": "d#build",
+          "priority": 1,
+        },
+      ]
+    `);
+  });
+
+  it("should build a subgraph with proper priorities", () => {
+    const target1 = createTarget("a", "build", 1);
+    const target2 = createTarget("b", "build", 100);
+    const target3 = createTarget("c", "build", 1);
+    const target4 = createTarget("d", "build", 1);
+
+    const builder = new TargetGraphBuilder();
+    builder.addTarget(target1);
+    builder.addTarget(target2);
+    builder.addTarget(target3);
+    builder.addTarget(target4);
+    builder.addDependency(target2.id, target1.id);
+    builder.addDependency(target3.id, target1.id);
+    builder.addDependency(target4.id, target1.id);
+
+    const targetGraph = builder.subgraph(["a#build"]);
+
+    expect(simplify(targetGraph.targets)).toMatchInlineSnapshot(`
+      [
+        {
+          "dependencies": [],
+          "dependents": [
+            "a#build",
+            "b#build",
+            "c#build",
+            "d#build",
+          ],
+          "id": "__start",
+          "priority": 0,
+        },
+        {
+          "dependencies": [
+            "__start",
+            "b#build",
+            "c#build",
+            "d#build",
+          ],
+          "dependents": [],
+          "id": "a#build",
+          "priority": 101,
+        },
+        {
+          "dependencies": [
+            "__start",
+          ],
+          "dependents": [
+            "a#build",
+          ],
+          "id": "b#build",
+          "priority": 100,
+        },
+        {
+          "dependencies": [
+            "__start",
+          ],
+          "dependents": [
+            "a#build",
+          ],
+          "id": "c#build",
+          "priority": 1,
+        },
+        {
+          "dependencies": [
+            "__start",
+          ],
+          "dependents": [
+            "a#build",
+          ],
+          "id": "d#build",
+          "priority": 1,
+        },
+      ]
+    `);
+  });
+});
+
+function createTarget(packageName: string, task: string, priority: number): Target {
+  return {
+    id: `${packageName}#${task}`,
+    label: `${packageName} - ${task}`,
+    task,
+    packageName,
+    dependencies: [],
+    dependents: [],
+    depSpecs: [],
+    priority,
+    cwd: `packages/${packageName}`,
+  } as Target;
+}
+
+function simplify(targets: Map<string, Target>): any[] {
+  return [...targets.entries()].map(([id, target]) => ({
+    id,
+    dependencies: target.dependencies,
+    dependents: target.dependents,
+    priority: target.priority,
+  }));
+}

--- a/scripts/config/jest.config.js
+++ b/scripts/config/jest.config.js
@@ -24,7 +24,12 @@ module.exports = {
   testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
   testPathIgnorePatterns: ["/node_modules/"],
   transform: {
-    "^.+\\.tsx?$": ["@swc/jest"],
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        isolatedModules: true,
+      },
+    ],
   },
   transformIgnorePatterns: ["/node_modules/", "\\.pnp\\.[^\\/]+$"],
   watchPathIgnorePatterns: ["/node_modules/"],


### PR DESCRIPTION
This PR refactors the following:

1. renamed TargetGraphBuilder -> WorkspaceTargetGraphBuilder
2. ripped out the code for creating targets outside the GraphBuilder's - created a TargetFactory
3. moved the subgraph, prioritize and detectCycle into a dedicated simpler "TargetGraphBuilder"

got tests and all :)