### PR TITLE
fixing the monorepo fixture package

### DIFF
--- a/lage.config.js
+++ b/lage.config.js
@@ -43,11 +43,11 @@ module.exports = {
     start: [],
     "@lage-run/e2e-tests#test": {
       type: "npmScript",
-      dependsOn: ["build"],
+      dependsOn: ["build", "^^transpile"],
     },
     "lage#test": {
       type: "npmScript",
-      dependsOn: ["build"],
+      dependsOn: ["build", "transpile"],
     },
     "@lage-run/lage#bundle": {
       type: "npmScript",


### PR DESCRIPTION
1. the e2e test monorepo fixtures isn't "installing" all of lage v2's packages.
2. fixing the lage.config.js to actually have the right task deps