### PR TITLE
Scheduler types

### DIFF
--- a/change/@lage-run-scheduler-b8cb9893-f54a-410a-9962-cb3f6e456c26.json
+++ b/change/@lage-run-scheduler-b8cb9893-f54a-410a-9962-cb3f6e456c26.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding scheduler-types as a dep not devDep to scheduler",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -18,10 +18,10 @@
     "@lage-run/target-graph": "^0.6.1",
     "@lage-run/logger": "^1.2.2",
     "@lage-run/cache": "^0.2.2",
-    "@lage-run/worker-threads-pool": "^0.4.4"
+    "@lage-run/worker-threads-pool": "^0.4.4",
+    "@lage-run/scheduler-types": "^0.2.8"
   },
   "devDependencies": {
-    "@lage-run/scheduler-types": "^0.2.8",
     "monorepo-scripts": "*"
   },
   "publishConfig": {


### PR DESCRIPTION
We now promote the scheduler-types package as a "prod" dep for scheduler instead of devDep for easier debugging