### PR TITLE
Fixes the race condition that exists inside the capturing of stdio & when the worker has been freed

### DIFF
--- a/change/@lage-run-worker-threads-pool-fe4ec967-a9ae-437d-95f0-924000a47d8b.json
+++ b/change/@lage-run-worker-threads-pool-fe4ec967-a9ae-437d-95f0-924000a47d8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a handling case for when lines are still being outputted but the worker is freed",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -141,6 +141,14 @@ export class WorkerPool extends EventEmitter implements Pool {
       let resolve: () => void;
 
       return (line: string) => {
+        if (!worker[kTaskInfo]) {
+          // Somehow this lineHandler function is called AFTER the worker has been freed.
+          // This can happen if there are stray setTimeout(), etc. with callbacks that outputs some messages in stdout/stderr
+          // In this case, we will ignore the output
+
+          return;
+        }
+
         if (line.includes(startMarker(worker[kTaskInfo].id))) {
           lines = [];
           if (outputType === "stdout") {


### PR DESCRIPTION
When there are stray "setTimeout()" calls that would console log something after the worker script has finished, the worker[kTaskInfo] would be null. This will lead to a crash. We are going to ignore these errors.