### PR TITLE
Refactoring WorkerPool implementation to prepare for more work in this area

### DIFF
--- a/change/@lage-run-worker-threads-pool-403325dc-c812-40c6-897b-234e33714d1c.json
+++ b/change/@lage-run-worker-threads-pool-403325dc-c812-40c6-897b-234e33714d1c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Refactoring the worker threads pool to use proper classes for Worker",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -2,9 +2,9 @@ import type { Readable } from "stream";
 import type { WorkerOptions } from "worker_threads";
 import type { Pool } from "./types/Pool.js";
 import type { Logger } from "@lage-run/logger";
+import type { IWorker } from "./types/WorkerQueue.js";
 
 import { WorkerPool } from "./WorkerPool.js";
-import { IWorker } from "./types/WorkerQueue.js";
 
 interface AggregatedPoolOptions {
   groupBy: (data: any) => string;

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -1,9 +1,10 @@
 import type { Readable } from "stream";
-import type { Worker, WorkerOptions } from "worker_threads";
+import type { WorkerOptions } from "worker_threads";
 import type { Pool } from "./types/Pool.js";
 import type { Logger } from "@lage-run/logger";
 
 import { WorkerPool } from "./WorkerPool.js";
+import { IWorker } from "./types/WorkerQueue.js";
 
 interface AggregatedPoolOptions {
   groupBy: (data: any) => string;
@@ -77,7 +78,7 @@ export class AggregatedPool implements Pool {
   async exec(
     data: Record<string, unknown>,
     weight: number,
-    setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
+    setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (args: any) => void,
     abortSignal?: AbortSignal
   ): Promise<unknown> {

--- a/packages/worker-threads-pool/src/Task.ts
+++ b/packages/worker-threads-pool/src/Task.ts
@@ -17,7 +17,7 @@ export class TaskInfo extends AsyncResource {
     super("WorkerPoolTaskInfo");
 
     if (options.setup) {
-      this.runInAsyncScope(options.setup, null, options.worker, options.worker["filteredStdout"], options.worker["filteredStderr"]);
+      this.runInAsyncScope(options.setup, null, options.worker, options.worker.stdout, options.worker.stderr);
     }
   }
 

--- a/packages/worker-threads-pool/src/Task.ts
+++ b/packages/worker-threads-pool/src/Task.ts
@@ -1,0 +1,47 @@
+import { AsyncResource } from "async_hooks";
+import { Readable } from "stream";
+import { IWorker } from "./types/WorkerQueue.js";
+
+export interface TaskInfoOptions {
+  id: string;
+  setup: undefined | ((worker: IWorker, stdout: Readable, stderr: Readable) => void);
+  cleanup: undefined | ((worker: IWorker) => void);
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  worker: IWorker;
+  weight: number;
+}
+
+export class TaskInfo extends AsyncResource {
+  constructor(private options: TaskInfoOptions) {
+    super("WorkerPoolTaskInfo");
+
+    if (options.setup) {
+      this.runInAsyncScope(options.setup, null, options.worker, options.worker["filteredStdout"], options.worker["filteredStderr"]);
+    }
+  }
+
+  get id() {
+    return this.options.id;
+  }
+
+  get weight() {
+    return this.options.weight;
+  }
+
+  done(err: Error, results: unknown) {
+    const { cleanup, worker, resolve, reject } = this.options;
+
+    if (cleanup) {
+      this.runInAsyncScope(cleanup, null, worker);
+    }
+
+    if (err) {
+      this.runInAsyncScope(reject, null, err, worker);
+    } else {
+      this.runInAsyncScope(resolve, null, results, worker);
+    }
+
+    this.emitDestroy();
+  }
+}

--- a/packages/worker-threads-pool/src/TaskInfo.ts
+++ b/packages/worker-threads-pool/src/TaskInfo.ts
@@ -1,6 +1,7 @@
+import type { Readable } from "stream";
+import type { IWorker } from "./types/WorkerQueue.js";
+
 import { AsyncResource } from "async_hooks";
-import { Readable } from "stream";
-import { IWorker } from "./types/WorkerQueue.js";
 
 export interface TaskInfoOptions {
   id: string;

--- a/packages/worker-threads-pool/src/TaskInfo.ts
+++ b/packages/worker-threads-pool/src/TaskInfo.ts
@@ -10,6 +10,7 @@ export interface TaskInfoOptions {
   reject: (reason: unknown) => void;
   worker: IWorker;
   weight: number;
+  abortSignal?: AbortSignal;
 }
 
 export class TaskInfo extends AsyncResource {
@@ -27,6 +28,10 @@ export class TaskInfo extends AsyncResource {
 
   get weight() {
     return this.options.weight;
+  }
+
+  get abortSignal() {
+    return this.options.abortSignal;
   }
 
   done(err: Error, results: unknown) {

--- a/packages/worker-threads-pool/src/ThreadWorker.ts
+++ b/packages/worker-threads-pool/src/ThreadWorker.ts
@@ -136,7 +136,7 @@ export class ThreadWorker extends EventEmitter implements IWorker {
     }
 
     this.status = "free";
-    this.emit(workerFreeEvent, { weight: this.weight });
+    this.emit(workerFreeEvent, { weight });
   }
 
   #captureWorkerStdioStreams(worker: Worker) {

--- a/packages/worker-threads-pool/src/ThreadWorker.ts
+++ b/packages/worker-threads-pool/src/ThreadWorker.ts
@@ -1,0 +1,246 @@
+import { createFilteredStreamTransform } from "./createFilteredStreamTransform.js";
+import { createInterface } from "readline";
+import { endMarker, startMarker } from "./stdioStreamMarkers.js";
+import { EventEmitter } from "events";
+import { Readable } from "stream";
+import { TaskInfo } from "./Task.js";
+import { Worker } from "worker_threads";
+import crypto from "crypto";
+import os from "os";
+import type { IWorker } from "./types/WorkerQueue.js";
+import type { QueueItem } from "./types/WorkerQueue.js";
+import type { WorkerOptions as ThreadWorkerOptions } from "worker_threads";
+
+export interface WorkerOptions {
+  workerOptions?: ThreadWorkerOptions;
+  workerIdleMemoryLimit?: number;
+}
+
+interface StdioInfo {
+  stream: Readable;
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+const workerFreeEvent = "free";
+
+export class ThreadWorker extends EventEmitter implements IWorker {
+  #taskInfo: TaskInfo | undefined;
+
+  #stdoutInfo: StdioInfo = { stream: new Readable(), promise: Promise.resolve(), resolve: () => {} };
+  #stderrInfo: StdioInfo = { stream: new Readable(), promise: Promise.resolve(), resolve: () => {} };
+
+  // @ts-ignore TS2564
+  #worker: Worker;
+
+  status: "free" | "busy" = "busy";
+  restarts = 0;
+
+  maxWorkerMemoryUsage = 0;
+
+  constructor(private script: string, private options: WorkerOptions) {
+    super();
+    this.#createNewWorker();
+  }
+
+  #createNewWorker() {
+    const { workerOptions } = this.options;
+    const script = this.script;
+    const worker = new Worker(script, { ...workerOptions, stdout: true, stderr: true });
+
+    this.#captureWorkerStdioStreams();
+
+    const filteredStdout = worker.stdout.pipe(createFilteredStreamTransform());
+    const filteredStderr = worker.stderr.pipe(createFilteredStreamTransform());
+
+    let capturedStdoutResolve = () => {};
+    const capturedStdoutPromise = new Promise<void>((resolve) => {
+      capturedStdoutResolve = resolve;
+      resolve();
+    });
+
+    let capturedStderrResolve = () => {};
+    const capturedStderrPromise = new Promise<void>((resolve) => {
+      capturedStderrResolve = resolve;
+      resolve();
+    });
+
+    const msgHandler = (data) => {
+      if (data.type === "status") {
+        // In case of success: Call the callback that was passed to `runTask`,
+        // remove the `TaskInfo` associated with the Worker, and mark it as free
+        // again.
+        Promise.all([this.#stdoutInfo.promise, this.#stderrInfo.promise]).then(() => {
+          const { err, results } = data;
+
+          if (this.#taskInfo) {
+            this.#taskInfo.done(err, results);
+            this.#taskInfo = undefined;
+            this.checkMemoryUsage();
+          }
+        });
+      } else if (data.type === "report-memory-usage") {
+        this.maxWorkerMemoryUsage = Math.max(this.maxWorkerMemoryUsage, data.memoryUsage);
+
+        const limit = this.options.workerIdleMemoryLimit ?? os.totalmem();
+
+        if (limit && data.memoryUsage > limit) {
+          this.restart();
+        } else {
+          this.#ready();
+        }
+      }
+    };
+
+    worker.on("message", msgHandler);
+
+    const errHandler = (err) => {
+      Promise.all([this.#stdoutInfo.promise, this.#stderrInfo.promise]).then(() => {
+        // In case of an uncaught exception: Call the callback that was passed to
+        // `runTask` with the error.
+        if (this.#taskInfo) {
+          this.#taskInfo.done(err, null);
+        }
+
+        this.emit("error", err);
+        this.restart();
+      });
+    };
+
+    // The 'error' event is emitted if the worker thread throws an uncaught exception. In that case, the worker is terminated.
+    worker.on("error", errHandler);
+
+    // Assign the new worker to private properties
+    this.#worker = worker;
+
+    this.#stdoutInfo = {
+      stream: filteredStdout,
+      promise: capturedStdoutPromise,
+      resolve: capturedStdoutResolve,
+    };
+
+    this.#stderrInfo = {
+      stream: filteredStderr,
+      promise: capturedStderrPromise,
+      resolve: capturedStderrResolve,
+    };
+
+    this.#ready();
+  }
+
+  #ready() {
+    this.status = "free";
+    this.emit(workerFreeEvent);
+  }
+
+  #captureWorkerStdioStreams() {
+    const stdout = this.#worker.stdout;
+    const stdoutInterface = createInterface({
+      input: stdout,
+      crlfDelay: Infinity,
+    });
+
+    const stderr = this.#worker.stderr;
+    const stderrInterface = createInterface({
+      input: stderr,
+      crlfDelay: Infinity,
+    });
+
+    const lineHandlerFactory = (outputType: string) => {
+      let lines: string[] = [];
+      let resolve: () => void;
+
+      return (line: string) => {
+        if (!this.#taskInfo) {
+          // Somehow this lineHandler function is called AFTER the worker has been freed.
+          // This can happen if there are stray setTimeout(), etc. with callbacks that outputs some messages in stdout/stderr
+          // In this case, we will ignore the output
+
+          return;
+        }
+
+        if (line.includes(startMarker(this.#taskInfo.id))) {
+          lines = [];
+          if (outputType === "stdout") {
+            resolve = this.#stdoutInfo.resolve;
+          } else {
+            resolve = this.#stderrInfo.resolve;
+          }
+        } else if (line.includes(endMarker(this.#taskInfo.id))) {
+          resolve();
+        } else {
+          lines.push(line);
+        }
+      };
+    };
+
+    const stdoutLineHandler = lineHandlerFactory("stdout");
+    const stderrLineHandler = lineHandlerFactory("stderr");
+
+    stdoutInterface.on("line", stdoutLineHandler);
+    stderrInterface.on("line", stderrLineHandler);
+  }
+
+  start(work: QueueItem, abortSignal?: AbortSignal) {
+    this.status = "busy";
+
+    const { task, resolve, reject, cleanup, setup } = work;
+
+    abortSignal?.addEventListener("abort", () => {
+      this.#worker.postMessage({ type: "abort" });
+    });
+
+    const id = crypto.randomBytes(32).toString("hex");
+
+    this.#taskInfo = new TaskInfo({ id, weight: work.weight, cleanup, resolve, reject, worker: this, setup });
+
+    // Create a pair of promises that are only resolved when a specific task end marker is detected
+    // in the worker's stdout/stderr streams.
+    this.#stdoutInfo.promise = new Promise<void>((onResolve) => {
+      this.#stdoutInfo.resolve = onResolve;
+    });
+
+    this.#stderrInfo.promise = new Promise<void>((onResolve) => {
+      this.#stderrInfo.resolve = onResolve;
+    });
+
+    this.#worker.postMessage({ type: "start", task: { ...task, weight: work.weight }, id });
+  }
+
+  get weight() {
+    return this.#taskInfo?.weight ?? 1;
+  }
+
+  get stdout() {
+    return this.#stdoutInfo.stream;
+  }
+
+  get stderr() {
+    return this.#stderrInfo.stream;
+  }
+
+  get resourceLimits() {
+    return this.#worker.resourceLimits;
+  }
+
+  get threadId() {
+    return this.#worker.threadId;
+  }
+
+  terminate() {
+    this.#worker.terminate();
+    this.#worker.removeAllListeners();
+    this.#worker.unref();
+  }
+
+  restart() {
+    this.restarts++;
+    this.status = "busy";
+    this.#worker.terminate();
+    this.#createNewWorker();
+  }
+
+  async checkMemoryUsage() {
+    this.#worker.postMessage({ type: "check-memory-usage" });
+  }
+}

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -27,7 +27,7 @@ export class WorkerPool extends EventEmitter implements Pool {
 
     this.ensureWorkers();
 
-    // Any time the kWorkerFreedEvent is emitted, dispatch
+    // Any time the workerFreedEvent is emitted, dispatch
     // the next task pending in the queue, if any.
     this.on(workerFreedEvent, () => {
       if (this.queue.length > 0) {
@@ -98,8 +98,9 @@ export class WorkerPool extends EventEmitter implements Pool {
       return;
     }
 
+    // This is to immediate execute tasks if there ARE free workers
+    // If there are no free workers, the "workerFreedEvent" will call this function again to start the task
     const worker = this.workers.find((w) => w.status === "free");
-
     if (worker) {
       const work = this.queue[workIndex];
       this.queue.splice(workIndex, 1);

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from "events";
-import { IWorker, QueueItem } from "./types/WorkerQueue.js";
 import { ThreadWorker } from "./ThreadWorker.js";
 import os from "os";
+
+import type { IWorker, QueueItem } from "./types/WorkerQueue.js";
 import type { Pool } from "./types/Pool.js";
 import type { Readable } from "stream";
 import type { WorkerPoolOptions } from "./types/WorkerPoolOptions.js";

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -1,97 +1,23 @@
-/**
- * Heavily based on a publically available worker pool implementation in node.js documentation:
- * https://nodejs.org/api/async_context.html#using-asyncresource-for-a-worker-thread-pool
- */
-
-import { AsyncResource } from "async_hooks";
-import { createFilteredStreamTransform } from "./createFilteredStreamTransform.js";
-import { createInterface } from "readline";
-import { endMarker, startMarker } from "./stdioStreamMarkers.js";
 import { EventEmitter } from "events";
-import { Worker } from "worker_threads";
-import crypto from "crypto";
+import { IWorker, QueueItem } from "./types/WorkerQueue.js";
+import { ThreadWorker } from "./ThreadWorker.js";
 import os from "os";
 import type { Pool } from "./types/Pool.js";
 import type { Readable } from "stream";
-
 import type { WorkerPoolOptions } from "./types/WorkerPoolOptions.js";
 
-const kTaskInfo = Symbol("kTaskInfo");
-const kWorkerFreedEvent = Symbol("kWorkerFreedEvent");
-
-const kWorkerCapturedStdoutResolve = Symbol("kWorkerCapturedStdoutResolve");
-const kWorkerCapturedStderrResolve = Symbol("kWorkerCapturedStderrResolve");
-
-const kWorkerCapturedStdoutPromise = Symbol("kWorkerCapturedStdoutPromise");
-const kWorkerCapturedStderrPromise = Symbol("kWorkerCapturedStderrPromise");
-
-class WorkerPoolTaskInfo extends AsyncResource {
-  constructor(
-    private options: {
-      id: string;
-      setup: undefined | ((worker: Worker, stdout: Readable, stderr: Readable) => void);
-      cleanup: undefined | ((worker: Worker) => void);
-      resolve: (value: unknown) => void;
-      reject: (reason: unknown) => void;
-      worker: Worker;
-      weight: number;
-    }
-  ) {
-    super("WorkerPoolTaskInfo");
-
-    if (options.setup) {
-      this.runInAsyncScope(options.setup, null, options.worker, options.worker["filteredStdout"], options.worker["filteredStderr"]);
-    }
-  }
-
-  get id() {
-    return this.options.id;
-  }
-
-  get weight() {
-    return this.options.weight;
-  }
-
-  done(err: Error, results: unknown) {
-    const { cleanup, worker, resolve, reject } = this.options;
-
-    if (cleanup) {
-      this.runInAsyncScope(cleanup, null, worker);
-    }
-
-    if (err) {
-      this.runInAsyncScope(reject, null, err, worker);
-    } else {
-      this.runInAsyncScope(resolve, null, results, worker);
-    }
-
-    this.emitDestroy();
-  }
-}
-
-interface QueueItem {
-  setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void;
-  cleanup?: (worker: Worker) => void;
-  task: Record<string, unknown>;
-  weight: number;
-  resolve: (value?: unknown) => void;
-  reject: (reason: unknown) => void;
-}
+const workerFreedEvent = "free";
 
 export class WorkerPool extends EventEmitter implements Pool {
-  workers: Worker[] = [];
-  freeWorkers: Worker[] = [];
+  workers: IWorker[] = [];
+  freeWorkers: IWorker[] = [];
   queue: QueueItem[] = [];
   maxWorkers = 0;
-  availability = 0;
-  maxWorkerMemoryUsage = 0;
-  workerRestarts = 0;
 
   constructor(private options: WorkerPoolOptions) {
     super();
 
     this.maxWorkers = this.options.maxWorkers ?? os.cpus().length - 1;
-    this.availability = this.maxWorkers;
 
     this.workers = [];
     this.freeWorkers = [];
@@ -101,11 +27,24 @@ export class WorkerPool extends EventEmitter implements Pool {
 
     // Any time the kWorkerFreedEvent is emitted, dispatch
     // the next task pending in the queue, if any.
-    this.on(kWorkerFreedEvent, () => {
+    this.on(workerFreedEvent, () => {
       if (this.queue.length > 0) {
         this._exec();
       }
     });
+  }
+
+  get availability() {
+    const busyWorkerWeight = this.workers.map((w) => (w.status === "busy" ? w.weight : 0)).reduce((acc, weight) => acc + weight, 0);
+    return this.maxWorkers - busyWorkerWeight;
+  }
+
+  get workerRestarts() {
+    return this.workers.reduce((acc, worker) => acc + worker.restarts, 0);
+  }
+
+  get maxWorkerMemoryUsage() {
+    return this.workers.reduce((acc, worker) => Math.max(acc, worker.maxWorkerMemoryUsage), 0);
   }
 
   stats() {
@@ -123,124 +62,17 @@ export class WorkerPool extends EventEmitter implements Pool {
     }
   }
 
-  captureWorkerStdioStreams(worker: Worker) {
-    const stdout = worker.stdout;
-    const stdoutInterface = createInterface({
-      input: stdout,
-      crlfDelay: Infinity,
-    });
-
-    const stderr = worker.stderr;
-    const stderrInterface = createInterface({
-      input: stderr,
-      crlfDelay: Infinity,
-    });
-
-    const lineHandlerFactory = (outputType: string) => {
-      let lines: string[] = [];
-      let resolve: () => void;
-
-      return (line: string) => {
-        if (!worker[kTaskInfo]) {
-          // Somehow this lineHandler function is called AFTER the worker has been freed.
-          // This can happen if there are stray setTimeout(), etc. with callbacks that outputs some messages in stdout/stderr
-          // In this case, we will ignore the output
-
-          return;
-        }
-
-        if (line.includes(startMarker(worker[kTaskInfo].id))) {
-          lines = [];
-          if (outputType === "stdout") {
-            resolve = worker[kWorkerCapturedStdoutResolve];
-          } else {
-            resolve = worker[kWorkerCapturedStderrResolve];
-          }
-        } else if (line.includes(endMarker(worker[kTaskInfo].id))) {
-          resolve();
-        } else {
-          lines.push(line);
-        }
-      };
-    };
-
-    const stdoutLineHandler = lineHandlerFactory("stdout");
-    const stderrLineHandler = lineHandlerFactory("stderr");
-
-    stdoutInterface.on("line", stdoutLineHandler);
-    stderrInterface.on("line", stderrLineHandler);
-  }
-
   addNewWorker() {
     const { script, workerOptions } = this.options;
-    const worker = new Worker(script, { ...workerOptions, stdout: true, stderr: true });
-
-    worker[kWorkerCapturedStderrPromise] = Promise.resolve();
-    worker[kWorkerCapturedStdoutPromise] = Promise.resolve();
-
-    this.captureWorkerStdioStreams(worker);
-
-    worker["filteredStdout"] = worker.stdout.pipe(createFilteredStreamTransform());
-    worker["filteredStderr"] = worker.stderr.pipe(createFilteredStreamTransform());
-
-    const msgHandler = (data) => {
-      if (data.type === "status") {
-        // In case of success: Call the callback that was passed to `runTask`,
-        // remove the `TaskInfo` associated with the Worker, and mark it as free
-        // again.
-        Promise.all([worker[kWorkerCapturedStdoutPromise], worker[kWorkerCapturedStderrPromise]]).then(() => {
-          const { err, results } = data;
-          const weight = worker[kTaskInfo].weight;
-          worker[kTaskInfo].done(err, results);
-          worker[kTaskInfo] = null;
-
-          this.availability += weight;
-          this.checkMemoryUsage(worker);
-        });
-      } else if (data.type === "report-memory-usage") {
-        this.maxWorkerMemoryUsage = Math.max(this.maxWorkerMemoryUsage, data.memoryUsage);
-
-        const limit = this.options.workerIdleMemoryLimit ?? os.totalmem();
-
-        if (limit && data.memoryUsage > limit) {
-          this.restartWorker(worker);
-        } else {
-          this.freeWorker(worker);
-        }
-      }
-    };
-
-    worker.on("message", msgHandler);
-
-    const errHandler = (err) => {
-      Promise.all([worker[kWorkerCapturedStdoutPromise], worker[kWorkerCapturedStderrPromise]]).then(() => {
-        // In case of an uncaught exception: Call the callback that was passed to
-        // `runTask` with the error.
-        if (worker[kTaskInfo]) {
-          const weight = worker[kTaskInfo].weight;
-          worker[kTaskInfo].done(err, null);
-          this.availability += weight;
-        }
-
-        this.emit("error", err);
-        this.restartWorker(worker);
-      });
-    };
-
-    // The 'error' event is emitted if the worker thread throws an uncaught exception. In that case, the worker is terminated.
-    worker.on("error", errHandler);
-
-    this.workers.push(worker);
-
-    this.freeWorkers.push(worker);
-    this.emit(kWorkerFreedEvent);
+    const worker = new ThreadWorker(script, { workerOptions, workerIdleMemoryLimit: this.options.workerIdleMemoryLimit });
+    worker.on("free", () => this.emit(workerFreedEvent));
   }
 
   exec(
     task: Record<string, unknown>,
     weight: number,
-    setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
-    cleanup?: (worker: Worker) => void,
+    setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void,
+    cleanup?: (worker: IWorker) => void,
     abortSignal?: AbortSignal
   ) {
     if (abortSignal?.aborted) {
@@ -264,70 +96,16 @@ export class WorkerPool extends EventEmitter implements Pool {
       return;
     }
 
-    if (this.freeWorkers.length > 0) {
-      const worker = this.freeWorkers.pop();
+    const worker = this.workers.find((w) => w.status === "free");
 
+    if (worker) {
       const work = this.queue[workIndex];
-
-      this.availability -= work.weight;
       this.queue.splice(workIndex, 1);
-
-      const { task, resolve, reject, cleanup, setup } = work;
-
-      if (worker) {
-        abortSignal?.addEventListener("abort", () => {
-          worker.postMessage({ type: "abort" });
-        });
-
-        const id = crypto.randomBytes(32).toString("hex");
-
-        worker[kTaskInfo] = new WorkerPoolTaskInfo({ id, weight: work.weight, cleanup, resolve, reject, worker, setup });
-
-        // Create a pair of promises that are only resolved when a specific task end marker is detected
-        // in the worker's stdout/stderr streams.
-        worker[kWorkerCapturedStdoutPromise] = new Promise<void>((onResolve) => {
-          worker[kWorkerCapturedStdoutResolve] = onResolve;
-        });
-
-        worker[kWorkerCapturedStderrPromise] = new Promise<void>((onResolve) => {
-          worker[kWorkerCapturedStderrResolve] = onResolve;
-        });
-
-        worker.postMessage({ type: "start", task: { ...task, weight: work.weight }, id });
-      }
+      worker.start(work, abortSignal);
     }
-  }
-
-  checkMemoryUsage(worker: Worker) {
-    worker.postMessage({ type: "check-memory-usage" });
-  }
-
-  freeWorker(worker: Worker) {
-    this.freeWorkers.push(worker);
-    this.emit(kWorkerFreedEvent);
-  }
-
-  restartWorker(worker: Worker) {
-    this.workerRestarts++;
-
-    worker.terminate();
-
-    const freeWorkerIndex = this.freeWorkers.indexOf(worker);
-
-    if (freeWorkerIndex !== -1) {
-      this.freeWorkers.splice(freeWorkerIndex, 1); // remove from free workers list
-    }
-
-    this.workers.splice(this.workers.indexOf(worker), 1);
-    this.addNewWorker();
   }
 
   async close() {
-    for (const worker of this.workers) {
-      worker.removeAllListeners();
-      worker.unref();
-    }
-
     await Promise.all(this.workers.map((worker) => worker.terminate()));
   }
 }

--- a/packages/worker-threads-pool/src/types/Pool.ts
+++ b/packages/worker-threads-pool/src/types/Pool.ts
@@ -1,5 +1,5 @@
-import type { Worker } from "worker_threads";
 import type { Readable } from "stream";
+import { IWorker } from "./WorkerQueue";
 
 export interface PoolStats {
   maxWorkerMemoryUsage: number; // in bytes
@@ -9,7 +9,7 @@ export interface Pool {
   exec(
     data: unknown,
     weight: number,
-    setup?: (worker: Worker, stdout: Readable, stderr: Readable) => void,
+    setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (args: any) => void,
     abortSignal?: AbortSignal
   ): Promise<unknown>;

--- a/packages/worker-threads-pool/src/types/Pool.ts
+++ b/packages/worker-threads-pool/src/types/Pool.ts
@@ -1,5 +1,5 @@
 import type { Readable } from "stream";
-import { IWorker } from "./WorkerQueue";
+import type { IWorker } from "./WorkerQueue.js";
 
 export interface PoolStats {
   maxWorkerMemoryUsage: number; // in bytes

--- a/packages/worker-threads-pool/src/types/WorkerQueue.ts
+++ b/packages/worker-threads-pool/src/types/WorkerQueue.ts
@@ -1,5 +1,6 @@
 import type { ResourceLimits } from "worker_threads";
 import { Readable } from "stream";
+import EventEmitter from "events";
 
 export interface QueueItem {
   setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void;
@@ -10,7 +11,7 @@ export interface QueueItem {
   reject: (reason: unknown) => void;
 }
 
-export interface IWorker {
+export interface IWorker extends EventEmitter {
   start(work: QueueItem, abortSignal?: AbortSignal): void;
   stdout: Readable;
   stderr: Readable;

--- a/packages/worker-threads-pool/src/types/WorkerQueue.ts
+++ b/packages/worker-threads-pool/src/types/WorkerQueue.ts
@@ -1,6 +1,6 @@
 import type { ResourceLimits } from "worker_threads";
-import { Readable } from "stream";
-import EventEmitter from "events";
+import type { Readable } from "stream";
+import type EventEmitter from "events";
 
 export interface QueueItem {
   setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void;

--- a/packages/worker-threads-pool/src/types/WorkerQueue.ts
+++ b/packages/worker-threads-pool/src/types/WorkerQueue.ts
@@ -1,0 +1,25 @@
+import type { ResourceLimits } from "worker_threads";
+import { Readable } from "stream";
+
+export interface QueueItem {
+  setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void;
+  cleanup?: (worker: IWorker) => void;
+  task: Record<string, unknown>;
+  weight: number;
+  resolve: (value?: unknown) => void;
+  reject: (reason: unknown) => void;
+}
+
+export interface IWorker {
+  start(work: QueueItem, abortSignal?: AbortSignal): void;
+  stdout: Readable;
+  stderr: Readable;
+  resourceLimits?: ResourceLimits;
+  threadId: number;
+  terminate(): void;
+  restart(): void;
+  weight: number;
+  status: "free" | "busy";
+  maxWorkerMemoryUsage: number;
+  restarts: number;
+}

--- a/scripts/config/eslintrc.js
+++ b/scripts/config/eslintrc.js
@@ -7,6 +7,8 @@ module.exports = {
     "@typescript-eslint/consistent-type-exports": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-require-imports": "error",
     "no-console": "error",
     "file-extension-in-import-ts/file-extension-in-import-ts": "error"


### PR DESCRIPTION
Currently the entirety of the WorkerPool.ts is borrowed from the node.js documentation on Async Hooks. However, the code there is geared towards not having types. We've experienced "race condition" issues with the "startMarker()" trying to access an id off of the `worker[kTaskInfo]` when that was `null`. This was easily caught by a type checker. So, in this refactor, we are moving several pieces of code out of WorkerPool and into a properly abstracted `ThreadWorker` design:

1. created a `ThreadWorker` class that WRAPS a worker_threads `Worker` instance
2. `ThreadWorker` has a status for "free" | "busy"
3. `ThreadWorker` encapsulates all the "hacky" dangling properties tacked on as Symbol(xyz) from the original implementation (became bona fide #private members)
4. `ThreadWorker` has a lifecycle management within itself to restart the actual `worker_threads` worker instance
5. `WorkerPool` has been simplified to account for this change
6. `TaskInfo` got promoted to a new class file
7. `WorkerQueue` file created to accommodate the Pool as well as the Worker types