### PR TITLE
Support the v1 --to flag

### DIFF
--- a/change/@lage-run-cli-37bb9d05-f03b-4ebc-b858-e9515730c325.json
+++ b/change/@lage-run-cli-37bb9d05-f03b-4ebc-b858-e9515730c325.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "support \"to\" flag",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -9,6 +9,7 @@ interface RunOptions extends ReporterInitOptions {
   dependencies: boolean;
   dependents: boolean;
   since: string;
+  to: string[];
   scope: string[];
   skipLocalCache: boolean;
   continue: boolean;

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -25,6 +25,7 @@ interface RunOptions extends ReporterInitOptions {
   dependents: boolean;
   since: string;
   scope: string[];
+  to: string[];
   skipLocalCache: boolean;
   continue: boolean;
   cache: boolean;
@@ -57,11 +58,11 @@ export async function runAction(options: RunOptions, command: Command) {
     logger,
     root,
     dependencies: options.dependencies,
-    dependents: options.dependents,
+    dependents: options.dependents && !options.to, // --to is a short hand for --scope + --no-dependents
     ignore: options.ignore.concat(config.ignore),
     pipeline: config.pipeline,
     repoWideChanges: config.repoWideChanges,
-    scope: options.scope,
+    scope: (options.scope ?? []).concat(options.to ?? []), // --to is a short hand for --scope + --no-dependents
     since: options.since,
     outputs: config.cacheOptions.outputGlob,
     tasks,

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -25,6 +25,7 @@ interface RunOptions extends ReporterInitOptions {
   dependents: boolean;
   since: string;
   scope: string[];
+  to: string[];
   skipLocalCache: boolean;
   continue: boolean;
   cache: boolean;
@@ -55,11 +56,11 @@ export async function watchAction(options: RunOptions, command: Command) {
     logger,
     root,
     dependencies: options.dependencies,
-    dependents: options.dependents,
+    dependents: options.dependents && !options.to, // --to is a short hand for --scope + --no-dependents
     ignore: options.ignore.concat(config.ignore),
     pipeline: config.pipeline,
     repoWideChanges: config.repoWideChanges,
-    scope: options.scope,
+    scope: (options.scope ?? []).concat(options.to ?? []), // --to is a short hand for --scope + --no-dependents
     since: options.since,
     outputs: config.cacheOptions.outputGlob,
     tasks,


### PR DESCRIPTION
--to is an alias for both `scope` and `no-dependents` flags: `--scope xyz --no-dependents`

 