### PR TITLE
Cloudpack / watch mode support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "semi": true,
   "singleQuote": false,
   "trailingComma": "es5",
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "tabWidth": 2
 }

--- a/change/@lage-run-cli-d147eb43-cbc9-48d0-a9cb-f82485fc4449.json
+++ b/change/@lage-run-cli-d147eb43-cbc9-48d0-a9cb-f82485fc4449.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing the watch mode to use the newer simple scheduler",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-e40d72bc-9628-46ac-9e6f-77d473687887.json
+++ b/change/@lage-run-scheduler-e40d72bc-9628-46ac-9e6f-77d473687887.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adding provision for the run() to pay attention to previous and currently running targetRun's",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-types-387adddd-8db2-4453-8610-85574a52686c.json
+++ b/change/@lage-run-scheduler-types-387adddd-8db2-4453-8610-85574a52686c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a \"rerun\" flag for \"run()\"",
+  "packageName": "@lage-run/scheduler-types",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -16,6 +16,7 @@ import createLogger, { LogLevel } from "@lage-run/logger";
 
 import type { ReporterInitOptions } from "@lage-run/reporters";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
+import type { Target } from "@lage-run/target-graph";
 
 interface RunOptions extends ReporterInitOptions {
   concurrency: number;
@@ -128,11 +129,16 @@ export async function watchAction(options: RunOptions, command: Command) {
   const watcher = watch(root);
   watcher.on("change", (packageName) => {
     reporter.resetLogEntries();
+    const targets = new Map<string, Target>();
     for (const target of targetGraph.targets.values()) {
-      if (target.packageName === packageName && scheduler.onTargetChange) {
-        scheduler.onTargetChange(target.id);
+      if (target.packageName === packageName) {
+        targets.set(target.id, target);
       }
     }
+
+    const deltaGraph = { targets };
+
+    scheduler.run(root, deltaGraph, true);
   });
 }
 

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -42,7 +42,6 @@ export async function watchAction(options: RunOptions, command: Command) {
   // Configure logger
   const logger = createLogger();
   const reporter = new LogReporter({
-    grouped: true,
     logLevel: LogLevel[options.logLevel],
   });
   logger.addReporter(reporter);
@@ -127,7 +126,7 @@ export async function watchAction(options: RunOptions, command: Command) {
 
   // When initial run is done, disable fetching of caches on all targets, keep writing to the cache
   const watcher = watch(root);
-  watcher.on("change", (packageName) => {
+  watcher.on("change", async (packageName) => {
     reporter.resetLogEntries();
     const targets = new Map<string, Target>();
     for (const target of targetGraph.targets.values()) {
@@ -138,7 +137,8 @@ export async function watchAction(options: RunOptions, command: Command) {
 
     const deltaGraph = { targets };
 
-    scheduler.run(root, deltaGraph, true);
+    const summary = await scheduler.run(root, deltaGraph, true);
+    displaySummary(summary, logger.reporters);
   });
 }
 

--- a/packages/scheduler-types/src/types/TargetScheduler.ts
+++ b/packages/scheduler-types/src/types/TargetScheduler.ts
@@ -3,7 +3,7 @@ import type { SchedulerRunSummary } from "./SchedulerRunSummary.js";
 
 export interface TargetScheduler {
   abort(): void;
-  run(root: string, targetGraph: TargetGraph): Promise<SchedulerRunSummary>;
+  run(root: string, targetGraph: TargetGraph, shouldRerun: boolean): Promise<SchedulerRunSummary>;
   onTargetChange?(targetId: string): void;
   cleanup(): void;
 }

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -94,12 +94,14 @@ export class SimpleScheduler implements TargetScheduler {
       if (prevTargetRun) {
         targetRun = prevTargetRun;
 
+        // If previous run has been successful, then we may want to rerun
         if (prevTargetRun.successful && shouldRerun) {
-          // this happens when a target has noted to have been changed from the outside, and we need to re-run it
           this.markTargetAndDependentsPending(target.id);
         } else if (prevTargetRun.waiting) {
-          // this happens when several run() calls have resulted in this targetRun to be queued
-          targetRun.shouldRerun = true;
+          targetRun.shouldRerun = shouldRerun;
+        } else if (!prevTargetRun.successful) {
+          // If previous run has failed, we should rerun
+          this.markTargetAndDependentsPending(target.id);
         }
       } else {
         targetRun = new WrappedTarget({
@@ -235,9 +237,10 @@ export class SimpleScheduler implements TargetScheduler {
   }
 
   async #generateTargetRunPromise(target: WrappedTarget) {
-    if (target.successful && !target.shouldRerun) {
-      return target.result;
-    }
+    // if (target.result && target.successful && !target.shouldRerun) {
+    //   await target.result;
+    //   await this.scheduleReadyTargets();
+    // }
 
     do {
       target.shouldRerun = false;

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -41,7 +41,6 @@ export class WrappedTarget implements TargetRun {
   status: TargetStatus;
 
   result: Promise<{ stdoutBuffer: string; stderrBuffer: string }> | undefined;
-  shouldRerun = false;
 
   get abortController() {
     return this.options.abortController;
@@ -230,10 +229,6 @@ export class WrappedTarget implements TargetRun {
 
     const bufferStdout = bufferTransform();
     const bufferStderr = bufferTransform();
-
-    if (!this.shouldRerun && this.result && this.successful) {
-      return this.result;
-    }
 
     this.result = pool.exec(
       { target },

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -40,7 +40,7 @@ export class WrappedTarget implements TargetRun {
   target: Target;
   status: TargetStatus;
 
-  result: Promise<unknown> | undefined;
+  result: Promise<{ stdoutBuffer: string; stderrBuffer: string }> | undefined;
   shouldRerun = false;
 
   get abortController() {
@@ -231,6 +231,10 @@ export class WrappedTarget implements TargetRun {
     const bufferStdout = bufferTransform();
     const bufferStderr = bufferTransform();
 
+    if (!this.shouldRerun && this.result && this.successful) {
+      return this.result;
+    }
+
     this.result = pool.exec(
       { target },
       target.weight ?? 1,
@@ -259,7 +263,7 @@ export class WrappedTarget implements TargetRun {
         releaseStderr();
       },
       abortSignal
-    );
+    ) as Promise<{ stdoutBuffer: string; stderrBuffer: string }>;
 
     await this.result;
 

--- a/packages/scheduler/tests/SimpleScheduler.test.ts
+++ b/packages/scheduler/tests/SimpleScheduler.test.ts
@@ -4,44 +4,7 @@ import { SimpleScheduler } from "../src/SimpleScheduler";
 import { getStartTargetId, Target, TargetGraph } from "@lage-run/target-graph";
 import { Pool } from "@lage-run/worker-threads-pool";
 import { TargetRunner } from "@lage-run/scheduler-types";
-
-class InProcPool implements Pool {
-  constructor(private runner: TargetRunner) {}
-  exec({ target }: { target: Target }) {
-    return this.runner.run({ target, weight: 1 });
-  }
-  stats() {
-    return {
-      workerRestarts: 0,
-      maxWorkerMemoryUsage: 0,
-    };
-  }
-  close() {
-    return Promise.resolve();
-  }
-}
-
-class SingleSchedulePool implements Pool {
-  count = 0;
-  constructor(private runner: TargetRunner, private concurrency: number) {}
-  exec({ target }: { target: Target }) {
-    if (this.concurrency > this.count) {
-      this.count++;
-      return this.runner.run({ target, weight: 1 });
-    }
-
-    return Promise.reject(new Error("Pool is full"));
-  }
-  stats() {
-    return {
-      workerRestarts: 0,
-      maxWorkerMemoryUsage: 0,
-    };
-  }
-  close() {
-    return Promise.resolve();
-  }
-}
+import { InProcPool, SingleSchedulePool } from "./fixtures/pools";
 
 /**
  * Purely manually managed target graph.

--- a/packages/scheduler/tests/SimpleScheduler.watchmode.test.ts
+++ b/packages/scheduler/tests/SimpleScheduler.watchmode.test.ts
@@ -1,0 +1,127 @@
+import { CacheProvider, TargetHasher } from "@lage-run/cache";
+import { Logger } from "@lage-run/logger";
+import { SimpleScheduler } from "../src/SimpleScheduler";
+import { InProcPool } from "./fixtures/pools";
+import { getTargetId, Target, TargetGraphBuilder } from "@lage-run/target-graph";
+import { TargetRunner } from "@lage-run/scheduler-types";
+
+function createTarget(packageName: string, task: string): Target {
+  const id = getTargetId(packageName, task);
+  return {
+    id,
+    label: `${packageName} - ${task}`,
+    packageName,
+    task,
+    cwd: `packages/${packageName}`,
+    dependencies: [],
+    dependents: [],
+    depSpecs: [],
+  };
+}
+
+describe("SimpleScheduler watch mode", () => {
+  it("should not execute the target runner twice by default", async () => {
+    const root = "/root-of-repo";
+    const logger = new Logger();
+
+    const cacheProvider: CacheProvider = {
+      clear: jest.fn(),
+      fetch: jest.fn(),
+      put: jest.fn(),
+      purge: jest.fn(),
+    };
+
+    const hasher = new TargetHasher({ root, environmentGlob: [] });
+
+    const runner: TargetRunner = {
+      run: jest.fn(),
+    };
+
+    const scheduler = new SimpleScheduler({
+      logger,
+      concurrency: 4,
+      cacheProvider,
+      hasher,
+      maxWorkersPerTask: new Map(),
+      continueOnError: true,
+      shouldCache: true,
+      shouldResetCache: false,
+      runners: {},
+      pool: new InProcPool(runner),
+      workerIdleMemoryLimit: 1024 * 1024 * 1024,
+    });
+
+    // these would normally come from the CLI
+    const builder = new TargetGraphBuilder();
+
+    builder.addTarget(createTarget("a", "build"));
+
+    const graph = builder.build();
+
+    await scheduler.run(root, graph);
+    await scheduler.run(root, graph);
+
+    await scheduler.cleanup();
+
+    expect(runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("should re-run all the targets if a target said to re-run is a root node", async () => {
+    const root = "/root-of-repo";
+    const logger = new Logger();
+
+    const cacheProvider: CacheProvider = {
+      clear: jest.fn(),
+      fetch: jest.fn(),
+      put: jest.fn(),
+      purge: jest.fn(),
+    };
+
+    const hasher = new TargetHasher({ root, environmentGlob: [] });
+
+    const runner: TargetRunner = {
+      run: jest.fn(),
+    };
+
+    const scheduler = new SimpleScheduler({
+      logger,
+      concurrency: 4,
+      cacheProvider,
+      hasher,
+      maxWorkersPerTask: new Map(),
+      continueOnError: true,
+      shouldCache: true,
+      shouldResetCache: false,
+      runners: {},
+      pool: new InProcPool(runner),
+      workerIdleMemoryLimit: 1024 * 1024 * 1024,
+    });
+
+    // these would normally come from the CLI
+    const builder = new TargetGraphBuilder();
+
+    const targetA = createTarget("a", "build");
+
+    builder.addTarget(targetA);
+    builder.addTarget(createTarget("b", "build"));
+    builder.addTarget(createTarget("c", "build"));
+
+    builder.addDependency("a#build", "b#build");
+    builder.addDependency("b#build", "c#build");
+
+    const graph = builder.build();
+
+    await scheduler.run(root, graph);
+
+    const newGraph = {
+      targets: new Map([["a#build", targetA]]),
+    };
+
+    await scheduler.run(root, newGraph, true);
+
+    await scheduler.cleanup();
+
+    // There are 3 targets defined
+    expect(runner.run).toHaveBeenCalledTimes(6);
+  });
+});

--- a/packages/scheduler/tests/fixtures/pools.ts
+++ b/packages/scheduler/tests/fixtures/pools.ts
@@ -1,0 +1,41 @@
+import { TargetRunner } from "@lage-run/scheduler-types";
+import { Target } from "@lage-run/target-graph";
+import { Pool } from "@lage-run/worker-threads-pool";
+
+export class InProcPool implements Pool {
+  constructor(private runner: TargetRunner) {}
+  exec({ target }: { target: Target }) {
+    return this.runner.run({ target, weight: 1 });
+  }
+  stats() {
+    return {
+      workerRestarts: 0,
+      maxWorkerMemoryUsage: 0,
+    };
+  }
+  close() {
+    return Promise.resolve();
+  }
+}
+
+export class SingleSchedulePool implements Pool {
+  count = 0;
+  constructor(private runner: TargetRunner, private concurrency: number) {}
+  exec({ target }: { target: Target }) {
+    if (this.concurrency > this.count) {
+      this.count++;
+      return this.runner.run({ target, weight: 1 });
+    }
+
+    return Promise.reject(new Error("Pool is full"));
+  }
+  stats() {
+    return {
+      workerRestarts: 0,
+      maxWorkerMemoryUsage: 0,
+    };
+  }
+  close() {
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
Fixes #487 - 

Watch action changes: 
- instead of relying on the extra "onTargetChange()" exposed previously from SimpleScheduler, we reuse "run()" but now with a new parameter
- inside run() - we first examine whether each of the "targetRun" has been completed before
- if a target was completed before, and it is marked as "rerun" (giving the caller the opportunity to adjust WHEN to rerun a target), then it would mark target & its dependents as "pending"
- if a target was scheduled to run but was still in the pending state or in queue, then simply set the "rerun" flag - maybe by the time this target gets to run, another version of it would be running!
- if the target was aborted / failed while having a rerun flag, then mark the target and the dependents as 'pending' 

This allows the watch mode + cloudpack integration to happen smoothly.