### PR TITLE
Allow for custom npm scripts

### DIFF
--- a/change/@lage-run-scheduler-f191e131-9ee9-4775-ab1c-d01f83f431f6.json
+++ b/change/@lage-run-scheduler-f191e131-9ee9-4775-ab1c-d01f83f431f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adding custom package.json script support",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler/src/runners/NpmScriptRunner.ts
+++ b/packages/scheduler/src/runners/NpmScriptRunner.ts
@@ -43,7 +43,7 @@ export class NpmScriptRunner implements TargetRunner {
   }
 
   private async hasNpmScript(target: Target) {
-    const { task } = target;
+    const task = target.options?.script ?? target.task;
     const packageJsonPath = join(target.cwd, "package.json");
     const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
     return packageJson.scripts?.[task];
@@ -58,6 +58,7 @@ export class NpmScriptRunner implements TargetRunner {
   async run(runOptions: TargetRunnerOptions) {
     const { target, weight, abortSignal } = runOptions;
     const { nodeOptions, npmCmd, taskArgs } = this.options;
+    const task = target.options?.script ?? target.task;
 
     let childProcess: ChildProcess | undefined;
 
@@ -104,7 +105,7 @@ export class NpmScriptRunner implements TargetRunner {
     /**
      * Actually spawn the npm client to run the task
      */
-    const npmRunArgs = this.getNpmArgs(target.task, taskArgs);
+    const npmRunArgs = this.getNpmArgs(task, taskArgs);
     const npmRunNodeOptions = [nodeOptions, target.options?.nodeOptions].filter((str) => str).join(" ");
 
     await new Promise<void>((resolve, reject) => {

--- a/packages/scheduler/tests/NpmScriptRunner.test.ts
+++ b/packages/scheduler/tests/NpmScriptRunner.test.ts
@@ -40,6 +40,7 @@ function createTarget(packageName: string): Target {
     id: `${packageName}#build`,
     task: "build",
     packageName,
+    options: {},
   };
 }
 
@@ -56,6 +57,35 @@ describe("NpmScriptRunner", () => {
     });
 
     const target = createTarget("a");
+
+    const exceptionSpy = jest.fn();
+    const runPromise = runner
+      .run({
+        target,
+        weight: 1,
+        abortSignal: abortController.signal,
+      })
+      .catch(() => exceptionSpy());
+
+    await waitFor(() => childProcesses.has(getChildProcessKey("a", target.task)));
+
+    await runPromise;
+
+    expect(exceptionSpy).not.toHaveBeenCalled();
+  });
+
+  it("can run a custom npm script to completion", async () => {
+    const abortController = new AbortController();
+
+    const runner = new NpmScriptRunner({
+      nodeOptions: "",
+      npmCmd,
+      taskArgs: ["--sleep=50"],
+    });
+
+    const target = createTarget("a");
+
+    target.options!.script = "custom";
 
     const exceptionSpy = jest.fn();
     const runPromise = runner

--- a/packages/scheduler/tests/fixtures/package-a/package.json
+++ b/packages/scheduler/tests/fixtures/package-a/package.json
@@ -1,6 +1,7 @@
 {
   "name": "package-a",
   "scripts": {
-    "build": "echo hello"
+    "build": "echo hello",
+    "custom": "echo custom"
   }
 }


### PR DESCRIPTION
This change adds the following capability to the lage config:

```js
module.exports = {
  pipeline: {
    build: ["^build"],
    "special-pkg#build": {
      type: "npmScript",
      dependsOn: ["^build"],
      options: {
        script: "custom-build"
      }
    }
  }
}
```