### PR TITLE
Reporter + error on no target fix

### DIFF
--- a/change/@lage-run-cli-178430b2-5426-4de3-a293-99ab4cb7bb3b.json
+++ b/change/@lage-run-cli-178430b2-5426-4de3-a293-99ab4cb7bb3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sets the default to progress",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-reporters-b93662dd-d4e3-4dbe-8ea4-c1756722ea59.json
+++ b/change/@lage-run-reporters-b93662dd-d4e3-4dbe-8ea4-c1756722ea59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding some more niceties to progress reporter",
+  "packageName": "@lage-run/reporters",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-526bfc8f-0019-40f4-9ab8-3a0857aa4767.json
+++ b/change/@lage-run-scheduler-526bfc8f-0019-40f4-9ab8-3a0857aa4767.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sets the default to progress",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,8 @@
 import { Command } from "commander";
 
-import { runCommand } from "./commands/run";
-import { cacheCommand } from "./commands/cache";
+import { runCommand } from "./commands/run/index.js";
+import { cacheCommand } from "./commands/cache/index.js";
+import { NoTargetFoundError } from "./types/errors.js";
 
 async function main() {
   const program = new Command();
@@ -12,7 +13,16 @@ async function main() {
 }
 
 main().catch((err) => {
-  // eslint-disable-next-line no-console
-  console.error(err);
+  /* eslint-disable no-console */
+  switch (err) {
+    case NoTargetFoundError:
+      console.log("lage: no targets found that matches the given scope.");
+      break;
+    default:
+      console.error(err);
+      break;
+  }
+  /* eslint-enable no-console */
+
   process.exitCode = 1;
 });

--- a/packages/cli/src/commands/addLoggerOptions.ts
+++ b/packages/cli/src/commands/addLoggerOptions.ts
@@ -2,9 +2,10 @@ import type { Command } from "commander";
 import { Option } from "commander";
 
 export function addLoggerOptions(program: Command) {
+  const isCI = process.env.CI || process.env.TF_BUILD;
   return program
     .option("--reporter <reporter...>", "reporter", "npmLog")
-    .addOption(new Option("--progress").conflicts("--reporter"))
+    .addOption(new Option("--progress").conflicts("--reporter").default(!isCI))
     .addOption(new Option("--log-level <level>", "log level").choices(["info", "warn", "error", "verbose", "silly"]).conflicts("--verbose"))
     .option("--verbose", "verbose output");
 }

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -19,6 +19,7 @@ interface RunOptions extends ReporterInitOptions {
   ignore: string[];
   unstableWatch: boolean;
   maxWorkersPerTask: string[];
+  allowNoTargetRuns: boolean;
 }
 
 export async function action(options: RunOptions, command: Command) {

--- a/packages/cli/src/commands/run/createProfileReporter.ts
+++ b/packages/cli/src/commands/run/createProfileReporter.ts
@@ -3,7 +3,7 @@ import { ChromeTraceEventsReporter } from "@lage-run/reporters";
 export function createProfileReporter(options: { concurrency: number; profile: string | boolean | undefined }) {
   const { concurrency, profile } = options;
   return new ChromeTraceEventsReporter({
-    concurrency: concurrency,
+    concurrency,
     outputFile: typeof profile === "string" ? profile : undefined,
   });
 }

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -15,6 +15,7 @@ addLoggerOptions(runCommand)
   .option("--include-dependencies|--dependencies", 'adds the scoped packages dependencies as the "entry points" for the target graph run')
   .option("--since <since>", "only runs packages that have changed since the given commit, tag, or branch")
   .option("--to <scope...>", "runs up to a package (shorthand for --scope=<scope...> --no-dependents)")
+  .option("--allow-no-target-runs")
 
   // Run Command Options
   .option("--grouped", "groups the logs", false)

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import os from "os";
 import { action } from "./action.js";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 import { isRunningFromCI } from "../isRunningFromCI.js";
@@ -8,18 +7,7 @@ const runCommand = new Command("run");
 
 addLoggerOptions(runCommand)
   .action(action)
-  .option(
-    "-c, --concurrency <n>",
-    "concurrency",
-    (value) => {
-      if (value.endsWith("%")) {
-        return (parseInt(value.slice(0, -1)) / 100) * os.cpus().length;
-      } else {
-        return parseInt(value) || os.cpus().length - 1;
-      }
-    },
-    os.cpus().length - 1
-  )
+  .option("-c, --concurrency <n>", "concurrency", (value) => parseInt(value, 10))
   .option("--max-workers-per-task <maxWorkersPerTarget...>", "set max worker per task, e.g. --max-workers-per-task build=2 test=4", [])
   // Common Options
   .option("--scope <scope...>", "scopes the run to a subset of packages (by default, includes the dependencies and dependents as well)")

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -16,6 +16,9 @@ import createLogger from "@lage-run/logger";
 
 import type { ReporterInitOptions } from "@lage-run/reporters";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
+import { getConcurrency } from "../../config/getConcurrency.js";
+import type { TargetGraph } from "@lage-run/target-graph";
+import { NoTargetFoundError } from "../../types/errors.js";
 
 interface RunOptions extends ReporterInitOptions {
   concurrency: number;
@@ -37,14 +40,18 @@ interface RunOptions extends ReporterInitOptions {
 export async function runAction(options: RunOptions, command: Command) {
   const cwd = process.cwd();
   const config = await getConfig(cwd);
+  const concurrency = getConcurrency(options.concurrency, config.concurrency);
 
   // Configure logger
   const logger = createLogger();
 
-  initializeReporters(logger, options);
+  initializeReporters(logger, { ...options, concurrency });
 
   if (options.profile !== undefined) {
-    const reporter = createProfileReporter(options);
+    const reporter = createProfileReporter({
+      concurrency,
+      profile: options.profile,
+    });
     logger.addReporter(reporter);
   }
 
@@ -69,6 +76,8 @@ export async function runAction(options: RunOptions, command: Command) {
     packageInfos,
   });
 
+  validateTargetGraph(targetGraph);
+
   const { cacheProvider, hasher } = createCache({
     root,
     logger,
@@ -76,7 +85,7 @@ export async function runAction(options: RunOptions, command: Command) {
     skipLocalCache: options.skipLocalCache,
   });
 
-  logger.verbose(`Running with ${options.concurrency} workers`);
+  logger.verbose(`Running with ${concurrency} workers`);
 
   const filteredPipeline = filterPipelineDefinitions(targetGraph.targets.values(), config.pipeline);
 
@@ -84,13 +93,13 @@ export async function runAction(options: RunOptions, command: Command) {
 
   const scheduler = new SimpleScheduler({
     logger,
-    concurrency: options.concurrency,
+    concurrency,
     cacheProvider,
     hasher,
     continueOnError: options.continue,
     shouldCache: options.cache,
     shouldResetCache: options.resetCache,
-    maxWorkersPerTask: new Map([...getMaxWorkersPerTask(filteredPipeline, options.concurrency), ...maxWorkersPerTaskMap]),
+    maxWorkersPerTask: new Map([...getMaxWorkersPerTask(filteredPipeline, concurrency), ...maxWorkersPerTaskMap]),
     runners: {
       npmScript: {
         script: require.resolve("./runners/NpmScriptRunner.js"),
@@ -124,5 +133,12 @@ function displaySummaryAndExit(summary: SchedulerRunSummary, reporters: Reporter
 
   for (const reporter of reporters) {
     reporter.summarize(summary);
+  }
+}
+
+function validateTargetGraph(targetGraph: TargetGraph) {
+  const visibleTargets = Array.from(targetGraph.targets.values()).filter((target) => !target.hidden);
+  if (visibleTargets.length === 0) {
+    throw NoTargetFoundError;
   }
 }

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -17,6 +17,7 @@ import createLogger, { LogLevel } from "@lage-run/logger";
 import type { ReporterInitOptions } from "@lage-run/reporters";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
 import type { Target } from "@lage-run/target-graph";
+import { getConcurrency } from "../../config/getConcurrency.js";
 
 interface RunOptions extends ReporterInitOptions {
   concurrency: number;
@@ -38,6 +39,7 @@ interface RunOptions extends ReporterInitOptions {
 export async function watchAction(options: RunOptions, command: Command) {
   const cwd = process.cwd();
   const config = await getConfig(cwd);
+  const concurrency = getConcurrency(options.concurrency, config.concurrency);
 
   // Configure logger
   const logger = createLogger();
@@ -83,13 +85,13 @@ export async function watchAction(options: RunOptions, command: Command) {
 
   const scheduler = new SimpleScheduler({
     logger,
-    concurrency: options.concurrency,
+    concurrency,
     cacheProvider,
     hasher,
     continueOnError: true,
     shouldCache: options.cache,
     shouldResetCache: options.resetCache,
-    maxWorkersPerTask: new Map([...getMaxWorkersPerTask(filteredPipeline, options.concurrency), ...maxWorkersPerTaskMap]),
+    maxWorkersPerTask: new Map([...getMaxWorkersPerTask(filteredPipeline, concurrency), ...maxWorkersPerTaskMap]),
     runners: {
       npmScript: {
         script: require.resolve("./runners/NpmScriptRunner.js"),

--- a/packages/cli/src/config/getConcurrency.ts
+++ b/packages/cli/src/config/getConcurrency.ts
@@ -1,0 +1,5 @@
+import os from "os";
+
+export function getConcurrency(optionsConcurrency: number | undefined, configConcurrency: number | undefined): number {
+  return optionsConcurrency || configConcurrency || os.cpus().length - 1;
+}

--- a/packages/cli/src/config/getConfig.ts
+++ b/packages/cli/src/config/getConfig.ts
@@ -33,5 +33,6 @@ export async function getConfig(cwd: string): Promise<ConfigOptions> {
     runners: config?.runners ?? {},
     workerIdleMemoryLimit: config?.workerIdleMemoryLimit ?? os.totalmem(), // 0 means no limit,
     concurrency: config?.concurrency ?? os.cpus().length - 1,
+    allowNoTargetRuns: config?.allowNoTargetRuns ?? false,
   };
 }

--- a/packages/cli/src/config/getConfig.ts
+++ b/packages/cli/src/config/getConfig.ts
@@ -31,6 +31,7 @@ export async function getConfig(cwd: string): Promise<ConfigOptions> {
     ],
     loggerOptions: config?.loggerOptions ?? {},
     runners: config?.runners ?? {},
-    workerIdleMemoryLimit: config?.workerIdleMemoryLimit ?? os.totalmem(), // 0 means no limit
+    workerIdleMemoryLimit: config?.workerIdleMemoryLimit ?? os.totalmem(), // 0 means no limit,
+    concurrency: config?.concurrency ?? os.cpus().length - 1,
   };
 }

--- a/packages/cli/src/types/ConfigOptions.ts
+++ b/packages/cli/src/types/ConfigOptions.ts
@@ -60,4 +60,9 @@ export interface ConfigOptions {
    * Maximum number of concurrent tasks to run
    */
   concurrency: number;
+
+  /**
+   * Allows for no targets run
+   */
+  allowNoTargetRuns: boolean;
 }

--- a/packages/cli/src/types/ConfigOptions.ts
+++ b/packages/cli/src/types/ConfigOptions.ts
@@ -55,4 +55,9 @@ export interface ConfigOptions {
    * Maximum worker idle memory, this would cause workers to restart if they exceed this limit. This is useful to prevent memory leaks.
    */
   workerIdleMemoryLimit: number; // in bytes
+
+  /**
+   * Maximum number of concurrent tasks to run
+   */
+  concurrency: number;
 }

--- a/packages/cli/src/types/errors.ts
+++ b/packages/cli/src/types/errors.ts
@@ -1,0 +1,1 @@
+export const NoTargetFoundError = new Error("No target found");

--- a/packages/reporters/src/ChromeTraceEventsReporter.ts
+++ b/packages/reporters/src/ChromeTraceEventsReporter.ts
@@ -27,12 +27,6 @@ export interface ChromeTraceEventsReporterOptions {
   categorize?: (targetRun?: TargetRun) => string;
 }
 
-function range(len: number) {
-  return Array(len)
-    .fill(0)
-    .map((_, idx) => idx + 1);
-}
-
 function hrTimeToMicroseconds(hr: [number, number]) {
   return hr[0] * 1e6 + hr[1] * 1e-3;
 }
@@ -48,8 +42,6 @@ export class ChromeTraceEventsReporter implements Reporter {
   logStream: Writable;
   consoleLogStream: Writable = process.stdout;
 
-  private threads: number[];
-  private targetIdThreadMap: Map<string, number> = new Map();
   private events: TraceEventsObject = {
     traceEvents: [],
     displayTimeUnit: "ms",
@@ -58,7 +50,6 @@ export class ChromeTraceEventsReporter implements Reporter {
 
   constructor(private options: ChromeTraceEventsReporterOptions) {
     this.outputFile = options.outputFile ?? getTimeBasedFilename("profile");
-    this.threads = range(options.concurrency);
 
     if (!fs.existsSync(path.dirname(this.outputFile))) {
       fs.mkdirSync(path.dirname(this.outputFile), { recursive: true });
@@ -89,7 +80,7 @@ export class ChromeTraceEventsReporter implements Reporter {
         ts: hrTimeToMicroseconds(targetRun.startTime) - hrTimeToMicroseconds(startTime), // in microseconds
         dur: hrTimeToMicroseconds(targetRun.duration ?? [0, 1000]), // in microseconds
         pid: 1,
-        tid: targetRun.threadId ?? 0,
+        tid: targetRun.threadId,
       } as CompleteEvent;
 
       if (categorize) {

--- a/packages/reporters/src/components/ProgressReporterApp.tsx
+++ b/packages/reporters/src/components/ProgressReporterApp.tsx
@@ -73,7 +73,6 @@ export function ProgressReporterApp(props: ProgressReporterAppProps) {
   return (
     <Box flexDirection="column">
       <Text>Lage running tasks with {props.concurrency} workers</Text>
-      <Text color="yellow">[warning: this progress reporter is currently in beta and unstable]</Text>
       {summary ? (
         <SummaryInfo summary={summary} />
       ) : (

--- a/packages/reporters/src/components/ProgressStatus.tsx
+++ b/packages/reporters/src/components/ProgressStatus.tsx
@@ -1,16 +1,20 @@
+import { formatDuration, hrToSeconds } from "@lage-run/format-hrtime";
 import { Box, Text } from "ink";
 import * as React from "react";
 import { Progress } from "../types/progressBarTypes";
 
 export interface ProgressStatusProps {
-  progress: Progress
+  progress: Progress;
+  currentTime: [number, number];
 }
 
-export function ProgressStatus(props: { progress: Progress }) {
+export function ProgressStatus(props: ProgressStatusProps) {
   const { waiting, completed, total } = props.progress;
   const percentage = total > 0 ? `${((completed / total) * 100).toFixed(2)}%` : "0%";
 
-  const status = `Waiting: ${waiting} | Completed: ${completed} | Total: ${total} | ${percentage}`;
+  const status = `Waiting: ${waiting} | Completed: ${completed} | Total: ${total} | ${percentage} | ${formatDuration(
+    hrToSeconds(props.currentTime)
+  )}`;
 
   return (
     <Box>

--- a/packages/reporters/src/components/ThreadItem.tsx
+++ b/packages/reporters/src/components/ThreadItem.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 import { Box, Text } from "ink";
 
-export function ThreadItem(props: { targetId: string }) {
-  const { targetId } = props;
-  return <Box>{targetId ? <Text color="whiteBright">[ {targetId} ]</Text> : <Text color="gray">[ IDLE ]</Text>}</Box>;
+export function ThreadItem(props: { threadId: string | number; targetId: string }) {
+  const { targetId, threadId } = props;
+  return (
+    <Box>
+      <Box width="2">
+        <Text>{threadId}</Text>
+      </Box>
+      {targetId ? <Text color="whiteBright">{targetId} </Text> : <Text color="gray">IDLE</Text>}
+    </Box>
+  );
 }

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -237,8 +237,7 @@ export class WrappedTarget implements TargetRun {
     this.result = pool.exec(
       { target },
       target.weight ?? 1,
-      (worker, stdout, stderr) => {
-        this.threadId = worker.threadId;
+      (_worker, stdout, stderr) => {
         this.onStart();
 
         stdout.pipe(bufferStdout.transform);


### PR DESCRIPTION
Fixes #519 - like jest, we should really throw if no target has been run. Unless this is specifically allowed, we likely have hit a strange case. In CI systems with `--since` options, it is recommended to use `--allow-no-target-runs` in the case where there are changes that do not need to invoke certain commands.

ProgressReporter also now reports the threadId correctly. It adds the "elapsed time". It also became the default non-CI reporter