### PR TITLE
Added logging for exit code

### DIFF
--- a/change/lage-a9f2f86d-37d4-403e-a66e-a1348310d4e3.json
+++ b/change/lage-a9f2f86d-37d4-403e-a66e-a1348310d4e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added logging for exit code",
+  "packageName": "lage",
+  "email": "viditmathur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/src/task/NpmScriptTask.ts
+++ b/packages/lage/src/task/NpmScriptTask.ts
@@ -61,13 +61,12 @@ export class NpmScriptTask {
       cp.on("exit", handleChildProcessExit);
 
       function handleChildProcessExit(code: number) {
-        logger.verbose(`Exiting ${[npmCmd, ...npmArgs].join(" ")} with exit code ${code}`);
-
         if (code === 0) {
           NpmScriptTask.activeProcesses.delete(cp);
           return resolve();
         }
 
+        logger.verbose(`Exiting ${[npmCmd, ...npmArgs].join(" ")} with exit code ${code}`);
         cp.stdout.destroy();
         cp.stdin.destroy();
         reject();

--- a/packages/lage/src/task/NpmScriptTask.ts
+++ b/packages/lage/src/task/NpmScriptTask.ts
@@ -61,6 +61,8 @@ export class NpmScriptTask {
       cp.on("exit", handleChildProcessExit);
 
       function handleChildProcessExit(code: number) {
+        logger.verbose(`Exiting ${[npmCmd, ...npmArgs].join(" ")} with exit code ${code}`);
+
         if (code === 0) {
           NpmScriptTask.activeProcesses.delete(cp);
           return resolve();


### PR DESCRIPTION
Sometimes the underlying child process may exit with error, but may not produce relevant logs, not knowing the exit status received from the child process makes it hard to debug a `lage` verb failure, this log will help in knowing the exit status code from the child process, and root cause the failure reasons.