### PR TITLE
Fix reporter: ado log grouping fix (empty script) & make cache tasks use simplescheduler

### DIFF
--- a/change/@lage-run-cli-98f2ed6e-c1ac-42c1-b0fb-c6b37a9ebc3e.json
+++ b/change/@lage-run-cli-98f2ed6e-c1ac-42c1-b0fb-c6b37a9ebc3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Using lage for prune and clear on cache and get reporter in shape for ADO",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-format-hrtime-bd3e1418-d200-4152-9e80-d97edb9861f7.json
+++ b/change/@lage-run-format-hrtime-bd3e1418-d200-4152-9e80-d97edb9861f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "handle empty case for hrtimeDiffs",
+  "packageName": "@lage-run/format-hrtime",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-reporters-3ebf01fc-5163-4e29-bfff-eccf52c013fc.json
+++ b/change/@lage-run-reporters-3ebf01fc-5163-4e29-bfff-eccf52c013fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Using lage for prune and clear on cache and get reporter in shape for ADO",
+  "packageName": "@lage-run/reporters",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-fa27678d-ce47-478c-86b3-f483baab7efc.json
+++ b/change/@lage-run-scheduler-fa27678d-ce47-478c-86b3-f483baab7efc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Using lage for prune and clear on cache and get reporter in shape for ADO",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-types-72d30b2d-bb64-4d6d-a49b-636c40ae991d.json
+++ b/change/@lage-run-scheduler-types-72d30b2d-bb64-4d6d-a49b-636c40ae991d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Using lage for prune and clear on cache and get reporter in shape for ADO",
+  "packageName": "@lage-run/scheduler-types",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/cache/action.ts
+++ b/packages/cli/src/commands/cache/action.ts
@@ -19,9 +19,20 @@ export async function cacheAction(options: CacheOptions, command: Command) {
   initializeReporters(logger, options);
 
   if (options.clear) {
-    return await clearCache(process.cwd(), config.cacheOptions.internalCacheFolder, logger);
+    return await clearCache({
+      cwd: process.cwd(),
+      internalCacheFolder: config.cacheOptions.internalCacheFolder,
+      logger,
+      concurrency: options.concurrency,
+    });
   } else if (options.prune) {
-    return await pruneCache(options.prune, process.cwd(), config.cacheOptions.internalCacheFolder, logger);
+    return await pruneCache({
+      pruneDays: options.prune,
+      cwd: process.cwd(),
+      internalCacheFolder: config.cacheOptions.internalCacheFolder,
+      logger,
+      concurrency: options.concurrency,
+    });
   }
 
   command.help();

--- a/packages/cli/src/commands/cache/clearCache.ts
+++ b/packages/cli/src/commands/cache/clearCache.ts
@@ -1,36 +1,75 @@
-import { getCacheDir, removeCacheEntry } from "./cacheDir.js";
+import { getCacheDir } from "./cacheDir.js";
+import { getConfig } from "../../config/getConfig.js";
 import { getWorkspaceRoot, getWorkspaces } from "workspace-tools";
-import type { Logger } from "@lage-run/logger";
-import { stat } from "fs/promises";
-import fs from "fs";
+import { SimpleScheduler } from "@lage-run/scheduler";
+import { TargetGraphBuilder } from "@lage-run/target-graph";
 import path from "path";
+import type { Logger } from "@lage-run/logger";
+import { getConcurrency } from "../../config/getConcurrency.js";
 
-export async function clearCache(cwd: string, internalCacheFolder: string, logger: Logger) {
+export interface ClearCacheOptions {
+  cwd: string;
+  internalCacheFolder: string;
+  logger: Logger;
+  concurrency: number;
+}
+
+export async function clearCache(options: ClearCacheOptions) {
+  const { logger, cwd, internalCacheFolder } = options;
+
+  const config = await getConfig(cwd);
   const workspaceRoot = getWorkspaceRoot(cwd);
+  const concurrency = getConcurrency(options.concurrency, config.concurrency);
 
   if (!workspaceRoot) {
     return;
   }
 
+  const graphBuilder = new TargetGraphBuilder();
   const workspaces = getWorkspaces(workspaceRoot);
 
   for (const workspace of workspaces) {
-    logger.info(`clear cache for ${workspace.name}`);
     const cachePath = getCacheDir(workspace.path, internalCacheFolder);
     const logOutputCachePath = path.join(workspace.path, "node_modules/.cache/lage/output/");
-    await Promise.all([clearPath(cachePath), clearPath(logOutputCachePath)]);
+
+    graphBuilder.addTarget({
+      packageName: workspace.name,
+      cwd: workspace.path,
+      dependencies: [],
+      dependents: [],
+      id: `${workspace.name}#clearCache`,
+      label: `Clearing Cache for ${workspace.name}`,
+      task: "clearCache",
+      type: "worker",
+      depSpecs: [],
+      options: {
+        clearPaths: [cachePath, logOutputCachePath],
+      },
+    });
   }
-}
 
-async function clearPath(cachePath: string) {
-  if (fs.existsSync(cachePath)) {
-    const entries = fs.readdirSync(cachePath);
+  const graph = graphBuilder.build();
 
-    for (const entry of entries) {
-      const entryPath = path.join(cachePath, entry);
-      const entryStat = await stat(entryPath);
+  const scheduler = new SimpleScheduler({
+    logger,
+    concurrency,
+    continueOnError: true,
+    shouldCache: false,
+    shouldResetCache: false,
+    maxWorkersPerTask: new Map(),
+    runners: {
+      worker: {
+        script: require.resolve("./runners/ClearCacheRunner.js"),
+        options: {},
+      },
+    },
+    workerIdleMemoryLimit: config.workerIdleMemoryLimit, // in bytes
+  });
 
-      await removeCacheEntry(entryPath, entryStat);
-    }
-  }
+  const summary = await scheduler.run(workspaceRoot, graph);
+  await scheduler.cleanup();
+
+  logger.reporters.forEach((reporter) => {
+    reporter.summarize(summary);
+  });
 }

--- a/packages/cli/src/commands/cache/runners/ClearCacheRunner.ts
+++ b/packages/cli/src/commands/cache/runners/ClearCacheRunner.ts
@@ -1,0 +1,30 @@
+import { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
+import fs from "fs";
+import path from "path";
+import { stat } from "fs/promises";
+import { removeCacheEntry } from "../cacheDir";
+
+export class ClearCacheRunner implements TargetRunner {
+  async shouldRun() {
+    return true;
+  }
+  async run(runOptions: TargetRunnerOptions): Promise<void> {
+    const { target } = runOptions;
+
+    console.log("Clearing cache for " + target.packageName);
+
+    const { clearPaths } = target.options!;
+
+    for (const cachePath of clearPaths) {
+      if (fs.existsSync(cachePath)) {
+        const entries = fs.readdirSync(cachePath);
+
+        for (const entry of entries) {
+          const entryPath = path.join(cachePath, entry);
+          const entryStat = await stat(entryPath);
+          await removeCacheEntry(entryPath, entryStat);
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/commands/cache/runners/ClearCacheRunner.ts
+++ b/packages/cli/src/commands/cache/runners/ClearCacheRunner.ts
@@ -1,8 +1,8 @@
-import { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
+import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
 import fs from "fs";
 import path from "path";
 import { stat } from "fs/promises";
-import { removeCacheEntry } from "../cacheDir";
+import { removeCacheEntry } from "../cacheDir.js";
 
 export class ClearCacheRunner implements TargetRunner {
   async shouldRun() {
@@ -10,9 +10,6 @@ export class ClearCacheRunner implements TargetRunner {
   }
   async run(runOptions: TargetRunnerOptions): Promise<void> {
     const { target } = runOptions;
-
-    console.log("Clearing cache for " + target.packageName);
-
     const { clearPaths } = target.options!;
 
     for (const cachePath of clearPaths) {

--- a/packages/cli/src/commands/cache/runners/PruneCacheRunner.ts
+++ b/packages/cli/src/commands/cache/runners/PruneCacheRunner.ts
@@ -1,8 +1,8 @@
-import { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
+import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
 import fs from "fs";
 import path from "path";
 import { stat } from "fs/promises";
-import { removeCacheEntry } from "../cacheDir";
+import { removeCacheEntry } from "../cacheDir.js";
 
 const MS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
@@ -12,9 +12,6 @@ export class PruneCacheRunner implements TargetRunner {
   }
   async run(runOptions: TargetRunnerOptions): Promise<void> {
     const { target } = runOptions;
-
-    console.log("Pruning cache for " + target.packageName);
-
     const { clearPaths, prunePeriod, now } = target.options!;
 
     for (const cachePath of clearPaths) {

--- a/packages/cli/src/commands/cache/runners/PruneCacheRunner.ts
+++ b/packages/cli/src/commands/cache/runners/PruneCacheRunner.ts
@@ -1,0 +1,35 @@
+import { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
+import fs from "fs";
+import path from "path";
+import { stat } from "fs/promises";
+import { removeCacheEntry } from "../cacheDir";
+
+const MS_IN_A_DAY = 1000 * 60 * 60 * 24;
+
+export class PruneCacheRunner implements TargetRunner {
+  async shouldRun() {
+    return true;
+  }
+  async run(runOptions: TargetRunnerOptions): Promise<void> {
+    const { target } = runOptions;
+
+    console.log("Pruning cache for " + target.packageName);
+
+    const { clearPaths, prunePeriod, now } = target.options!;
+
+    for (const cachePath of clearPaths) {
+      if (fs.existsSync(cachePath)) {
+        const entries = fs.readdirSync(cachePath);
+
+        for (const entry of entries) {
+          const entryPath = path.join(cachePath, entry);
+          const entryStat = await stat(entryPath);
+
+          if (now - entryStat.mtime.getTime() > prunePeriod * MS_IN_A_DAY) {
+            await removeCacheEntry(entryPath, entryStat);
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/format-hrtime/src/formatDuration.ts
+++ b/packages/format-hrtime/src/formatDuration.ts
@@ -21,7 +21,7 @@ export function hrToSeconds(hrtime: [number, number]) {
  * @param end
  * @returns
  */
-export function hrtimeDiff(start: [number, number], end: [number, number]): [number, number] {
+export function hrtimeDiff(start: [number, number] = [0, 0], end: [number, number] = [0, 0]): [number, number] {
   const sec = end[0] - start[0];
   const nsec = end[1] - start[1];
 

--- a/packages/reporters/src/AdoReporter.ts
+++ b/packages/reporters/src/AdoReporter.ts
@@ -6,6 +6,7 @@ import type { Reporter, LogEntry } from "@lage-run/logger";
 import type { SchedulerRunSummary, TargetStatus } from "@lage-run/scheduler-types";
 import type { TargetMessageEntry, TargetStatusEntry } from "./types/TargetLogEntry.js";
 import type { Writable } from "stream";
+import { slowestTargetRuns } from "./slowestTargetRuns.js";
 
 const colors = {
   [LogLevel.info]: chalk.white,
@@ -177,7 +178,9 @@ export class AdoReporter implements Reporter {
     this.logStream.write(chalk.cyanBright(`##[section]Summary\n`));
 
     if (targetRuns.size > 0) {
-      for (const wrappedTarget of targetRuns.values()) {
+      const slowestTargets = slowestTargetRuns([...targetRuns.values()]);
+
+      for (const wrappedTarget of slowestTargets) {
         const colorFn = statusColorFn[wrappedTarget.status];
         const target = wrappedTarget.target;
 

--- a/packages/reporters/src/LogReporter.ts
+++ b/packages/reporters/src/LogReporter.ts
@@ -11,6 +11,7 @@ import type { TargetMessageEntry, TargetStatusEntry } from "./types/TargetLogEnt
 import type { Writable } from "stream";
 import crypto from "crypto";
 import { formatBytes } from "./formatBytes.js";
+import { slowestTargetRuns } from "./slowestTargetRuns.js";
 
 const colors = {
   [LogLevel.info]: chalk.white,
@@ -219,7 +220,9 @@ export class LogReporter implements Reporter {
 
       this.hr();
 
-      for (const wrappedTarget of targetRuns.values()) {
+      const slowestTargets = slowestTargetRuns([...targetRuns.values()]);
+
+      for (const wrappedTarget of slowestTargets) {
         if (wrappedTarget.target.hidden) {
           continue;
         }

--- a/packages/reporters/src/components/SummaryInfo.tsx
+++ b/packages/reporters/src/components/SummaryInfo.tsx
@@ -2,6 +2,7 @@ import { formatDuration, hrtimeDiff, hrToSeconds } from '@lage-run/format-hrtime
 import { LogEntry } from '@lage-run/logger';
 import { Box, Newline, Text } from 'ink';
 import * as React from 'react';
+import { slowestTargetRuns } from '../slowestTargetRuns';
 import type { SummaryWithLogs } from '../types/progressBarTypes';
 import { ErrorMessages } from './ErrorMessages';
 
@@ -14,7 +15,8 @@ export function SummaryInfo(props: SummaryInfoProps) {
   const { schedulerRunSummary, logEntries } = summary;
   const { targetRunByStatus, targetRuns, duration } = schedulerRunSummary;
 
-  const slowestTargetRuns = [...targetRuns.values()].sort((a, b) => parseFloat(hrToSeconds(hrtimeDiff(a.duration, b.duration))));
+  const slowestTargets = slowestTargetRuns([...targetRuns.values()]);
+  
   const { failed, aborted, skipped, success, pending } = targetRunByStatus;
 
   const errors =
@@ -29,7 +31,7 @@ export function SummaryInfo(props: SummaryInfoProps) {
       <Text color="yellow">Slowest targets</Text>
 
       <Box flexDirection="column" marginLeft={2} marginY={1}>
-        {slowestTargetRuns
+        {slowestTargets
           .slice(0, 10)
           .filter((run) => !run.target.hidden)
           .map((targetRun) => (

--- a/packages/reporters/src/slowestTargetRuns.ts
+++ b/packages/reporters/src/slowestTargetRuns.ts
@@ -1,0 +1,8 @@
+import { hrtimeDiff, hrToSeconds } from "@lage-run/format-hrtime";
+import type { TargetRun } from "@lage-run/scheduler-types";
+
+export function slowestTargetRuns(targetRuns: TargetRun[]) {
+  return targetRuns
+    .sort((a, b) => parseFloat(hrToSeconds(hrtimeDiff(a.duration, b.duration))))
+    .filter((run) => run.status !== "skipped" && !run.target.hidden);
+}

--- a/packages/scheduler-types/src/types/TargetRunner.ts
+++ b/packages/scheduler-types/src/types/TargetRunner.ts
@@ -7,6 +7,7 @@ export interface TargetRunnerOptions {
 }
 
 export interface TargetRunner {
+  shouldRun(target: Target): Promise<boolean>;
   run(options: TargetRunnerOptions): Promise<void>;
   cleanup?(): Promise<void> | void;
 }

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -283,9 +283,14 @@ export class SimpleScheduler implements TargetScheduler {
         target.onQueued();
 
         try {
-          const runner = await this.runnerPicker.pick(target.target);
+          let shouldRun = true;
 
-          const shouldRun = await runner.shouldRun(target.target);
+          try {
+            const runner = await this.runnerPicker.pick(target.target);
+            shouldRun = await runner.shouldRun(target.target);
+          } catch (e) {
+            // pass - default to run anyway
+          }
 
           if (shouldRun) {
             await target.run();

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -3,13 +3,14 @@ import { formatBytes } from "./formatBytes.js";
 import { categorizeTargetRuns } from "./categorizeTargetRuns.js";
 import { getStartTargetId, sortTargetsByPriority } from "@lage-run/target-graph";
 import { WrappedTarget } from "./WrappedTarget.js";
+import { TargetRunnerPicker } from "./runners/TargetRunnerPicker.js";
 
 import type { CacheProvider, TargetHasher } from "@lage-run/cache";
 import type { Logger } from "@lage-run/logger";
 import type { TargetGraph } from "@lage-run/target-graph";
 import type { TargetScheduler, SchedulerRunResults, SchedulerRunSummary, TargetRunSummary } from "@lage-run/scheduler-types";
 import type { Pool } from "@lage-run/worker-threads-pool";
-import { TargetRunnerPicker, TargetRunnerPickerOptions } from "./runners/TargetRunnerPicker.js";
+import type { TargetRunnerPickerOptions } from "./runners/TargetRunnerPicker.js";
 
 export interface SimpleSchedulerOptions {
   logger: Logger;

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -9,7 +9,7 @@ import type { Logger } from "@lage-run/logger";
 import type { TargetGraph } from "@lage-run/target-graph";
 import type { TargetScheduler, SchedulerRunResults, SchedulerRunSummary, TargetRunSummary } from "@lage-run/scheduler-types";
 import type { Pool } from "@lage-run/worker-threads-pool";
-import type { TargetRunnerPickerOptions } from "./runners/TargetRunnerPicker.js";
+import { TargetRunnerPicker, TargetRunnerPickerOptions } from "./runners/TargetRunnerPicker.js";
 
 export interface SimpleSchedulerOptions {
   logger: Logger;
@@ -43,6 +43,7 @@ export class SimpleScheduler implements TargetScheduler {
   abortController: AbortController = new AbortController();
   abortSignal: AbortSignal = this.abortController.signal;
   pool: Pool;
+  runnerPicker: TargetRunnerPicker;
 
   runPromise = Promise.resolve() as Promise<any>;
 
@@ -64,6 +65,8 @@ export class SimpleScheduler implements TargetScheduler {
         },
         workerIdleMemoryLimit: options.workerIdleMemoryLimit, // in bytes
       });
+
+    this.runnerPicker = new TargetRunnerPicker(options.runners);
   }
 
   getTargetsByPriority() {
@@ -193,28 +196,33 @@ export class SimpleScheduler implements TargetScheduler {
   }
 
   getReadyTargets() {
-    const readyTargets: WrappedTarget[] = [];
+    const readyTargets: Set<WrappedTarget> = new Set();
 
     for (const target of this.getTargetsByPriority()) {
+      // Skip the start target
       if (target.id === getStartTargetId()) {
         continue;
       }
 
       const targetRun = this.targetRuns.get(target.id)!;
-      const targetDeps = targetRun.target.dependencies;
 
-      // filter all dependencies for those that are "ready"
-      const ready = targetDeps.every((dep) => {
-        const fromTarget = this.targetRuns.get(dep)!;
-        return fromTarget.successful || dep === getStartTargetId();
-      });
+      // If the target is already running, then we can't run it again
+      if (targetRun.status === "pending") {
+        const targetDeps = targetRun.target.dependencies;
 
-      if (ready && targetRun.status === "pending") {
-        readyTargets.push(targetRun);
+        // Target is only ready when all its deps are "successful" or that it is a root target
+        const ready = targetDeps.every((dep) => {
+          const fromTarget = this.targetRuns.get(dep)!;
+          return fromTarget.successful || dep === getStartTargetId();
+        });
+
+        if (ready) {
+          readyTargets.add(targetRun);
+        }
       }
     }
 
-    return readyTargets;
+    return [...readyTargets];
   }
 
   isAllDone() {
@@ -271,9 +279,18 @@ export class SimpleScheduler implements TargetScheduler {
       // This do-while loop only runs again if something causes this target to rerun (asynchronously triggering a re-run)
       do {
         this.rerunTargets.delete(target.target.id);
+        target.onQueued();
 
         try {
-          await target.run();
+          const runner = await this.runnerPicker.pick(target.target);
+
+          const shouldRun = await runner.shouldRun(target.target);
+
+          if (shouldRun) {
+            await target.run();
+          } else {
+            target.status = "skipped";
+          }
         } catch (e) {
           runError = e;
         }

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -155,8 +155,6 @@ export class WrappedTarget implements TargetRun {
   async run() {
     const { target, logger, shouldCache, abortController } = this.options;
 
-    this.onQueued();
-
     const abortSignal = abortController.signal;
 
     if (abortSignal.aborted) {

--- a/packages/scheduler/src/runners/NoOpRunner.ts
+++ b/packages/scheduler/src/runners/NoOpRunner.ts
@@ -1,6 +1,10 @@
 import type { TargetRunner } from "@lage-run/scheduler-types";
 
 export const NoOpRunner: TargetRunner = {
+  async shouldRun() {
+    return true;
+  },
+
   async run() {
     // pass
   },

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -1,5 +1,5 @@
 import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
-import { Target } from "@lage-run/target-graph";
+import type { Target } from "@lage-run/target-graph";
 import { pathToFileURL } from "url";
 
 export interface WorkerRunnerOptions {

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -1,4 +1,5 @@
 import type { TargetRunner, TargetRunnerOptions } from "@lage-run/scheduler-types";
+import { Target } from "@lage-run/target-graph";
 import { pathToFileURL } from "url";
 
 export interface WorkerRunnerOptions {
@@ -45,9 +46,36 @@ export class WorkerRunner implements TargetRunner {
 
   constructor(private options: WorkerRunnerOptions) {}
 
+  async shouldRun(target: Target): Promise<boolean> {
+    const scriptModule = await this.getScriptModule(target);
+
+    if (typeof scriptModule.shouldRun === "function") {
+      return await scriptModule.shouldRun(target);
+    }
+
+    return true;
+  }
+
   async run(runOptions: TargetRunnerOptions) {
     const { target, weight, abortSignal } = runOptions;
     const { taskArgs } = this.options;
+
+    const scriptModule = await this.getScriptModule(target);
+    const runFn =
+      typeof scriptModule.run === "function"
+        ? scriptModule.run
+        : typeof scriptModule.default === "function"
+        ? scriptModule.default
+        : scriptModule;
+
+    if (typeof runFn !== "function") {
+      throw new Error("WorkerRunner: worker script must export a function; you likely need to use `module.exports = function() {...}`");
+    }
+
+    await runFn({ target, weight, taskArgs, abortSignal });
+  }
+
+  async getScriptModule(target: Target) {
     const scriptFile = target.options?.worker ?? target.options?.script;
 
     if (!scriptFile) {
@@ -60,13 +88,6 @@ export class WorkerRunner implements TargetRunner {
       importScript = pathToFileURL(importScript).toString();
     }
 
-    const scriptModule = await import(importScript);
-    const runFn = typeof scriptModule.default === "function" ? scriptModule.default : scriptModule;
-
-    if (typeof runFn !== "function") {
-      throw new Error("WorkerRunner: worker script must export a function; you likely need to use `module.exports = function() {...}`");
-    }
-
-    await runFn({ target, weight, taskArgs, abortSignal });
+    return await import(importScript);
   }
 }

--- a/packages/scheduler/tests/SimpleScheduler.test.ts
+++ b/packages/scheduler/tests/SimpleScheduler.test.ts
@@ -261,6 +261,10 @@ describe("SimpleScheduler", () => {
         "results": "failed",
         "targetRunByStatus": {
           "aborted": [
+            "a#build",
+            "c#build",
+            "e#build",
+            "f#build",
             "g#build",
           ],
           "failed": [],
@@ -273,10 +277,6 @@ describe("SimpleScheduler", () => {
           "skipped": [],
           "success": [
             "__start",
-            "a#build",
-            "c#build",
-            "e#build",
-            "f#build",
           ],
         },
         "targetRuns": Map {
@@ -285,7 +285,7 @@ describe("SimpleScheduler", () => {
             "target": "__start",
           },
           "a#build" => {
-            "status": "success",
+            "status": "aborted",
             "target": "a#build",
           },
           "b#build" => {
@@ -293,7 +293,7 @@ describe("SimpleScheduler", () => {
             "target": "b#build",
           },
           "c#build" => {
-            "status": "success",
+            "status": "aborted",
             "target": "c#build",
           },
           "d#build" => {
@@ -301,11 +301,11 @@ describe("SimpleScheduler", () => {
             "target": "d#build",
           },
           "e#build" => {
-            "status": "success",
+            "status": "aborted",
             "target": "e#build",
           },
           "f#build" => {
-            "status": "success",
+            "status": "aborted",
             "target": "f#build",
           },
           "g#build" => {

--- a/packages/scheduler/tests/SimpleScheduler.watchmode.test.ts
+++ b/packages/scheduler/tests/SimpleScheduler.watchmode.test.ts
@@ -34,6 +34,9 @@ describe("SimpleScheduler watch mode", () => {
     const hasher = new TargetHasher({ root, environmentGlob: [] });
 
     const runner: TargetRunner = {
+      async shouldRun() {
+        return true;
+      },
       run: jest.fn(),
     };
 
@@ -80,6 +83,9 @@ describe("SimpleScheduler watch mode", () => {
     const hasher = new TargetHasher({ root, environmentGlob: [] });
 
     const runner: TargetRunner = {
+      async shouldRun() {
+        return true;
+      },
       run: jest.fn(),
     };
 

--- a/packages/scheduler/tests/WrappedTarget.test.ts
+++ b/packages/scheduler/tests/WrappedTarget.test.ts
@@ -54,6 +54,9 @@ describe("WrappedTarget", () => {
     const logger = new Logger();
 
     const runner = {
+      async shouldRun() {
+        return true;
+      },
       async run() {
         // nothing
       },
@@ -99,6 +102,9 @@ describe("WrappedTarget", () => {
     const wrappedTargets: WrappedTarget[] = [];
 
     const runner = {
+      async shouldRun() {
+        return true;
+      },
       async run() {
         // nothing
       },
@@ -273,6 +279,9 @@ describe("WrappedTarget", () => {
     const logger = new Logger();
 
     const runner = {
+      async shouldRun() {
+        return true;
+      },
       async run() {
         // nothing
       },

--- a/packages/scheduler/tests/fixtures/AbortEarlyRunner.js
+++ b/packages/scheduler/tests/fixtures/AbortEarlyRunner.js
@@ -3,6 +3,10 @@ class AbortEarlyRunner {
     this.failPackage = packageName;
   }
 
+  async shouldRun() {
+    return true;
+  }
+
   run(target, abortSignal) {
     return new Promise((resolve, reject) => {
       if (target.packageName === this.failPackage) {

--- a/packages/scheduler/tests/fixtures/FailOnPackageRunner.js
+++ b/packages/scheduler/tests/fixtures/FailOnPackageRunner.js
@@ -3,6 +3,10 @@ class FailOnPackageRunner {
     this.failPackage = packageName;
   }
 
+  async shouldRun() {
+    return true;
+  }
+
   run(target, abortSignal) {
     return new Promise((resolve, reject) => {
       if (target.packageName === this.failPackage) {


### PR DESCRIPTION
# Overview

Currently, there's a bug in the streaming (ADO, Log Reporter) log reporters that would log "too much". Even for targets that should not run - e.g. a npm task target that doesn't have a npm script defined for that task. A concrete example is a package.json that doesn't have a "build" script. `lage build` for all packages still display the package that do not have that "build" script.

# Detailed implementation

1. TargetRunner now accepts (requires) a "shouldRun()" function
2. SimpleScheduler will NOT schedule a target to be submitted to the workers if the "shouldRun()" function results in false
3. Cache tasks are changed in relation to the new progress reporter. The way we changed this is to now use the `SimpleScheduler` to run a target graph comprised of all the packages in a workspace with no dependencies. This means the scheduler will assign workers to do the cache cleaning in parallel up to the same config for `concurrency` as the "run" command.


# Versioning this change
This fix should bump the lage v by a minor