### PR TITLE
Task args should also affect cache key as they did in v1

### DIFF
--- a/change/@lage-run-cli-4a0ca53a-0d6f-44c7-ab75-59670a94a14f.json
+++ b/change/@lage-run-cli-4a0ca53a-0d6f-44c7-ab75-59670a94a14f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make sure to take the task args into account for caching",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/run/createCacheProvider.ts
+++ b/packages/cli/src/commands/run/createCacheProvider.ts
@@ -8,10 +8,11 @@ interface CreateCacheOptions {
   logger: Logger;
   root: string;
   skipLocalCache: boolean;
+  cliArgs: string[];
 }
 
 export function createCache(options: CreateCacheOptions) {
-  const { cacheOptions, logger, root, skipLocalCache } = options;
+  const { cacheOptions, logger, root, skipLocalCache, cliArgs } = options;
 
   const hasRemoteCacheConfig =
     !!cacheOptions?.cacheStorageConfig || !!process.env.BACKFILL_CACHE_PROVIDER || !!process.env.BACKFILL_CACHE_PROVIDER_OPTIONS;
@@ -41,6 +42,7 @@ export function createCache(options: CreateCacheOptions) {
     root,
     environmentGlob: cacheOptions?.environmentGlob ?? [],
     cacheKey: cacheOptions?.cacheKey,
+    cliArgs,
   });
 
   return { cacheProvider, hasher };

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -87,6 +87,7 @@ export async function runAction(options: RunOptions, command: Command) {
     logger,
     cacheOptions: config.cacheOptions,
     skipLocalCache: options.skipLocalCache,
+    cliArgs: taskArgs,
   });
 
   logger.verbose(`Running with ${concurrency} workers`);

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -77,6 +77,7 @@ export async function watchAction(options: RunOptions, command: Command) {
     logger,
     cacheOptions: config.cacheOptions,
     skipLocalCache: false,
+    cliArgs: taskArgs,
   });
 
   const filteredPipeline = filterPipelineDefinitions(targetGraph.targets.values(), config.pipeline);

--- a/packages/e2e-tests/src/basic.test.ts
+++ b/packages/e2e-tests/src/basic.test.ts
@@ -23,4 +23,63 @@ describe("basics", () => {
 
     repo.cleanup();
   });
+
+  it("basic test case - with task args", () => {
+    const repo = new Monorepo("basics-with-task-args");
+
+    repo.init();
+    repo.addPackage("a", ["b"]);
+    repo.addPackage("b");
+
+    repo.install();
+
+    // run once without params
+    repo.run("test");
+
+    // run with some params, expected actual runs
+    const results = repo.run("test", ["--1", "--2"]);
+    const output = results.stdout + results.stderr;
+    const jsonOutput = parseNdJson(output);
+
+    expect(jsonOutput.find((entry) => filterEntry(entry.data, "b", "build", "success"))).toBeTruthy();
+    expect(jsonOutput.find((entry) => filterEntry(entry.data, "b", "test", "success"))).toBeTruthy();
+    expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "build", "success"))).toBeTruthy();
+    expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "test", "success"))).toBeTruthy();
+    expect(jsonOutput.find((entry) => filterEntry(entry.data, "a", "lint", "success"))).toBeFalsy();
+
+    // run with some params, expected skips
+    const results2 = repo.run("test", ["--1", "--2"]);
+    const output2 = results2.stdout + results2.stderr;
+    const jsonOutput2 = parseNdJson(output2);
+
+    expect(jsonOutput2.find((entry) => filterEntry(entry.data, "b", "build", "skipped"))).toBeTruthy();
+    expect(jsonOutput2.find((entry) => filterEntry(entry.data, "b", "test", "skipped"))).toBeTruthy();
+    expect(jsonOutput2.find((entry) => filterEntry(entry.data, "a", "build", "skipped"))).toBeTruthy();
+    expect(jsonOutput2.find((entry) => filterEntry(entry.data, "a", "test", "skipped"))).toBeTruthy();
+    expect(jsonOutput2.find((entry) => filterEntry(entry.data, "a", "lint", "skipped"))).toBeFalsy();
+
+    // run with some lage specific params, expected skips
+    const results3 = repo.run("test", ["--concurrency", "1"]);
+    const output3 = results3.stdout + results3.stderr;
+    const jsonOutput3 = parseNdJson(output3);
+
+    expect(jsonOutput3.find((entry) => filterEntry(entry.data, "b", "build", "skipped"))).toBeTruthy();
+    expect(jsonOutput3.find((entry) => filterEntry(entry.data, "b", "test", "skipped"))).toBeTruthy();
+    expect(jsonOutput3.find((entry) => filterEntry(entry.data, "a", "build", "skipped"))).toBeTruthy();
+    expect(jsonOutput3.find((entry) => filterEntry(entry.data, "a", "test", "skipped"))).toBeTruthy();
+    expect(jsonOutput3.find((entry) => filterEntry(entry.data, "a", "lint", "skipped"))).toBeFalsy();
+
+    // run with some params AND lage specific params, expected skips
+    const results4 = repo.run("test", ["--1", "--2", "--concurrency", "1"]);
+    const output4 = results4.stdout + results4.stderr;
+    const jsonOutput4 = parseNdJson(output4);
+
+    expect(jsonOutput4.find((entry) => filterEntry(entry.data, "b", "build", "skipped"))).toBeTruthy();
+    expect(jsonOutput4.find((entry) => filterEntry(entry.data, "b", "test", "skipped"))).toBeTruthy();
+    expect(jsonOutput4.find((entry) => filterEntry(entry.data, "a", "build", "skipped"))).toBeTruthy();
+    expect(jsonOutput4.find((entry) => filterEntry(entry.data, "a", "test", "skipped"))).toBeTruthy();
+    expect(jsonOutput4.find((entry) => filterEntry(entry.data, "a", "lint", "skipped"))).toBeFalsy();
+
+    repo.cleanup();
+  });
 });


### PR DESCRIPTION
In v2, we need to pass the task args to the target hasher to consider as part of the cache key. The feature was implemented, but not hooked up.