### PR TITLE
Add task error summary to ADO reporter

### DIFF
--- a/change/@lage-run-reporters-f4b8e4c6-3712-410e-a50a-b8cece1cd2ab.json
+++ b/change/@lage-run-reporters-f4b8e4c6-3712-410e-a50a-b8cece1cd2ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add task error summary to ADO reporter",
+  "packageName": "@lage-run/reporters",
+  "email": "felescoto95@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/reporters/src/AdoReporter.ts
+++ b/packages/reporters/src/AdoReporter.ts
@@ -203,12 +203,16 @@ export class AdoReporter implements Reporter {
     }
 
     if (failed && failed.length > 0) {
+      let packagesMessage = `##vso[task.logissue type=error]Your build failed on the following packages => `;
+
       for (const targetId of failed) {
         const target = targetRuns.get(targetId)?.target;
 
         if (target) {
           const { packageName, task } = target;
           const taskLogs = this.logEntries.get(targetId);
+
+          packagesMessage += `[${packageName} ${task}], `;
 
           this.logStream.write(`##[error] [${chalk.magenta(packageName)} ${chalk.cyan(task)}] ${chalk.redBright("ERROR DETECTED")}\n`);
 
@@ -220,6 +224,9 @@ export class AdoReporter implements Reporter {
           }
         }
       }
+
+      packagesMessage += "find the error logs above with the prefix '##[error]!'\n";
+      this.logStream.write(packagesMessage);
     }
 
     this.logStream.write(format(LogLevel.info, "", `Took a total of ${formatDuration(hrToSeconds(duration))} to complete`));

--- a/packages/reporters/tests/AdoReporter.test.ts
+++ b/packages/reporters/tests/AdoReporter.test.ts
@@ -313,6 +313,7 @@ describe("AdoReporter", () => {
       ##[error] test message for a#build
       ##[error] test message for a#build again, but look there is an error!
       ##[error] 
+      ##vso[task.logissue type=error]Your build failed on the following packages => [a build], find the error logs above with the prefix '##[error]!'
       INFO:  Took a total of 1m 40.00s to complete
       "
     `);


### PR DESCRIPTION
After switching to Lage v2, I noticed that our PR summaries by the ado reporter were no longer listing the packages that failed on the PR page. I've added back the code and message from the Lage v1 reporter to bring back feature parity.  

## Expected 

![image](https://user-images.githubusercontent.com/10786508/215172249-9d27a077-6735-4e38-868f-003d95aee952.png)

## Current behavior

![image](https://user-images.githubusercontent.com/10786508/215172893-9ccb81d8-bcc3-45a7-ad5b-07c50425b851.png)
