### PR TITLE
"affected" command

### DIFF
--- a/change/@lage-run-cli-6c794b34-3c1b-47df-a944-fa130f370a7f.json
+++ b/change/@lage-run-cli-6c794b34-3c1b-47df-a944-fa130f370a7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adding an affected command",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-lage-72fd991b-b7b5-437d-8326-21b2a7a38ddf.json
+++ b/change/@lage-run-lage-72fd991b-b7b5-437d-8326-21b2a7a38ddf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add affected command",
+  "packageName": "@lage-run/lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,11 +3,13 @@ import { Command } from "commander";
 import { runCommand } from "./commands/run/index.js";
 import { cacheCommand } from "./commands/cache/index.js";
 import { NoTargetFoundError } from "./types/errors.js";
+import { affectedCommand } from "./commands/affected/index.js";
 
 async function main() {
   const program = new Command();
   program.addCommand(runCommand, { isDefault: true });
   program.addCommand(cacheCommand);
+  program.addCommand(affectedCommand);
 
   await program.parseAsync(process.argv);
 }

--- a/packages/cli/src/commands/addFilterOptions.ts
+++ b/packages/cli/src/commands/addFilterOptions.ts
@@ -11,6 +11,5 @@ export function addFilterOptions(program: Command) {
       "--ignore <ignore...>",
       "ignores files when calculating the scope with `--since` in addition to the files specified in lage.config",
       []
-    )
-    .option("--allow-no-target-runs");
+    );
 }

--- a/packages/cli/src/commands/affected/action.ts
+++ b/packages/cli/src/commands/affected/action.ts
@@ -1,0 +1,101 @@
+import createLogger from "@lage-run/logger";
+import type { Command } from "commander";
+import { getPackageInfos, getWorkspaceRoot, PackageInfos } from "workspace-tools";
+import { getConfig } from "../../config/getConfig.js";
+import { getFilteredPackages } from "../../filter/getFilteredPackages.js";
+import type { FilterOptions } from "../../types/FilterOptions.js";
+
+interface AffectedOptions extends FilterOptions {
+  outputFormat?: "json" | "graph" | "default";
+}
+
+export async function affectedAction(options: AffectedOptions, command: Command) {
+  const { dependencies, dependents, since, scope, ignore, outputFormat } = options;
+
+  const cwd = process.cwd();
+  const config = await getConfig(cwd);
+  const logger = createLogger();
+
+  const root = getWorkspaceRoot(cwd)!;
+  const packageInfos = getPackageInfos(root);
+
+  const packages = getFilteredPackages({
+    root,
+    logger,
+    packageInfos,
+    includeDependencies: dependencies,
+    includeDependents: dependents,
+    since,
+    scope,
+    repoWideChanges: config.repoWideChanges,
+    sinceIgnoreGlobs: ignore,
+  });
+
+  let output = "";
+  switch (outputFormat) {
+    case "graph":
+      output = renderGraph({ packages, packageInfos });
+      break;
+
+    case "json":
+      output = renderJson({ packages, packageInfos });
+      break;
+
+    default:
+      output = renderDefault({ packages });
+      break;
+  }
+
+  console.log(output);
+}
+
+function renderDefault(props: { packages: string[] }) {
+  const { packages } = props;
+  return `
+All Affected Packages
+---------------------
+
+${packages.join("\n")}
+`;
+}
+
+function renderJson(props: { packages: string[]; packageInfos: PackageInfos }) {
+  const graph = generatePackageGraph(props);
+  return JSON.stringify(graph);
+}
+
+function renderGraph(props: { packages: string[]; packageInfos: PackageInfos }) {
+  const graph = generatePackageGraph(props);
+  const { packages } = graph;
+
+  const adjacencies: [string, string][] = [];
+
+  for (const [pkg, info] of Object.entries(packages)) {
+    for (const dep of info.dependencies) {
+      adjacencies.push([pkg, dep]);
+    }
+  }
+
+  return `
+digraph affected {
+  ${adjacencies.map((entry) => `"${entry[0]}" -> "${entry[1]}"`).join("\n")}
+}  
+`;
+}
+
+function generatePackageGraph(props: { packages: string[]; packageInfos: PackageInfos }) {
+  const { packages, packageInfos } = props;
+  const packageGraph = packages.reduce<{ [pkg: string]: { dependencies: string[]; dependents: string[] } }>((accum, pkg) => {
+    const dependencies = Object.keys(packageInfos[pkg].dependencies ?? {}).filter((dep) => packages.includes(dep));
+    const dependents = Object.keys(packageInfos[pkg].dependents ?? {}).filter((dep) => packages.includes(dep));
+
+    accum[pkg] = {
+      dependencies,
+      dependents,
+    };
+
+    return accum;
+  }, {});
+
+  return { packages: packageGraph, count: packages.length };
+}

--- a/packages/cli/src/commands/affected/action.ts
+++ b/packages/cli/src/commands/affected/action.ts
@@ -1,6 +1,5 @@
 import createLogger from "@lage-run/logger";
-import type { Command } from "commander";
-import { getPackageInfos, getWorkspaceRoot, PackageInfos } from "workspace-tools";
+import { getPackageInfos, getWorkspaceRoot, type PackageInfos } from "workspace-tools";
 import { getConfig } from "../../config/getConfig.js";
 import { getFilteredPackages } from "../../filter/getFilteredPackages.js";
 import type { FilterOptions } from "../../types/FilterOptions.js";
@@ -9,7 +8,7 @@ interface AffectedOptions extends FilterOptions {
   outputFormat?: "json" | "graph" | "default";
 }
 
-export async function affectedAction(options: AffectedOptions, command: Command) {
+export async function affectedAction(options: AffectedOptions) {
   const { dependencies, dependents, since, scope, ignore, outputFormat } = options;
 
   const cwd = process.cwd();
@@ -46,6 +45,7 @@ export async function affectedAction(options: AffectedOptions, command: Command)
       break;
   }
 
+  // eslint-disable-next-line no-console
   console.log(output);
 }
 

--- a/packages/cli/src/commands/affected/action.ts
+++ b/packages/cli/src/commands/affected/action.ts
@@ -78,7 +78,7 @@ function renderGraph(props: { packages: string[]; packageInfos: PackageInfos }) 
 
   return `
 digraph affected {
-  ${adjacencies.map((entry) => `"${entry[0]}" -> "${entry[1]}"`).join("\n")}
+${adjacencies.map((entry) => `  "${entry[0]}" -> "${entry[1]}"`).join("\n")}
 }  
 `;
 }

--- a/packages/cli/src/commands/affected/index.ts
+++ b/packages/cli/src/commands/affected/index.ts
@@ -1,4 +1,4 @@
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import { addFilterOptions } from "../addFilterOptions.js";
 import { affectedAction } from "./action.js";
 

--- a/packages/cli/src/commands/affected/index.ts
+++ b/packages/cli/src/commands/affected/index.ts
@@ -1,0 +1,16 @@
+import { Command, Option } from "commander";
+import { addFilterOptions } from "../addFilterOptions.js";
+import { affectedAction } from "./action.js";
+
+const affectedCommand = new Command("affected");
+
+addFilterOptions(affectedCommand)
+  .action(affectedAction)
+  .option(
+    "--output-format <graph|json|default>",
+    `Generate a report about what packages are affected by the current change (defaults to human readable format) ` +
+      `"graph" will generate a GraphViz .dot file format`
+  )
+  .option("--since <branch>", "Calculate changes since this branch (defaults to origin/master)", "origin/master");
+
+export { affectedCommand };

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -21,6 +21,7 @@ addFilterOptions(addLoggerOptions(runCommand))
     'arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable'
   )
   .option("--continue", "continues the run even on error")
+  .option("--allow-no-target-runs")
   .addOption(
     new Option(
       "--info",

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -14,26 +14,21 @@ import type { Reporter } from "@lage-run/logger";
 import createLogger from "@lage-run/logger";
 
 import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
+import type { FilterOptions } from "../../types/FilterOptions.js";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
 import { getConcurrency } from "../../config/getConcurrency.js";
 import type { TargetGraph } from "@lage-run/target-graph";
 import { NoTargetFoundError } from "../../types/errors.js";
 
-interface RunOptions extends ReporterInitOptions {
+interface RunOptions extends ReporterInitOptions, FilterOptions {
   concurrency: number;
   maxWorkersPerTask: string[];
   profile: string | boolean | undefined;
-  dependencies: boolean;
-  dependents: boolean;
-  since: string;
-  scope: string[];
-  to: string[];
   skipLocalCache: boolean;
   continue: boolean;
   cache: boolean;
   resetCache: boolean;
   nodeArg: string;
-  ignore: string[];
   allowNoTargetRuns: boolean;
 }
 

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -18,7 +18,7 @@ import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
 import type { Target } from "@lage-run/target-graph";
 import { getConcurrency } from "../../config/getConcurrency.js";
-import { FilterOptions } from "../../types/FilterOptions.js";
+import type { FilterOptions } from "../../types/FilterOptions.js";
 
 interface RunOptions extends ReporterInitOptions, FilterOptions {
   concurrency: number;

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -18,22 +18,18 @@ import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
 import type { Target } from "@lage-run/target-graph";
 import { getConcurrency } from "../../config/getConcurrency.js";
+import { FilterOptions } from "../../types/FilterOptions.js";
 
-interface RunOptions extends ReporterInitOptions {
+interface RunOptions extends ReporterInitOptions, FilterOptions {
   concurrency: number;
   maxWorkersPerTask: string[];
   profile: string | boolean | undefined;
-  dependencies: boolean;
-  dependents: boolean;
-  since: string;
-  scope: string[];
-  to: string[];
   skipLocalCache: boolean;
   continue: boolean;
   cache: boolean;
   resetCache: boolean;
   nodeArg: string;
-  ignore: string[];
+  allowNoTargetRuns: boolean;
 }
 
 export async function watchAction(options: RunOptions, command: Command) {

--- a/packages/cli/src/types/FilterOptions.ts
+++ b/packages/cli/src/types/FilterOptions.ts
@@ -1,0 +1,9 @@
+export interface FilterOptions {
+  dependencies: boolean;
+  dependents: boolean;
+  since: string;
+  scope: string[];
+  to: string[];
+  ignore: string[];
+  allowNoTargetRuns: boolean;
+}


### PR DESCRIPTION
In this PR, we create the beginnings of a `affected` command. The command takes in the filtering command arguments such as `--since`, `--ignore`, `--scope`, etc.

It'll print out a list of affected packages. There are other --output-format like `json`, `graph`.

Example:
`lage affected --output-format json`