### PR TITLE
CI or TF_BUILD should default to the original LogReporter

### DIFF
--- a/change/@lage-run-cli-5eb418d1-4f45-4fd5-bd8b-61ed199e8957.json
+++ b/change/@lage-run-cli-5eb418d1-4f45-4fd5-bd8b-61ed199e8957.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing up some logger options to set up proper conflicts",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/src/commands/addLoggerOptions.ts
+++ b/packages/cli/src/commands/addLoggerOptions.ts
@@ -3,10 +3,11 @@ import { Option } from "commander";
 
 export function addLoggerOptions(program: Command) {
   const isCI = process.env.CI || process.env.TF_BUILD;
+
   return program
-    .option("--reporter <reporter...>", "reporter", "npmLog")
+    .option("--reporter <reporter...>", "reporter")
     .option("--grouped", "groups the logs", false)
-    .addOption(new Option("--progress").conflicts("--reporter").default(!isCI))
-    .addOption(new Option("--log-level <level>", "log level").choices(["info", "warn", "error", "verbose", "silly"]).conflicts("--verbose"))
-    .option("--verbose", "verbose output");
+    .addOption(new Option("--progress").conflicts(["reporter", "grouped", "verbose"]).default(!isCI))
+    .addOption(new Option("--log-level <level>", "log level").choices(["info", "warn", "error", "verbose", "silly"]).conflicts("verbose"))
+    .option("--verbose", "verbose output", false);
 }

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -6,7 +6,7 @@ export function createReporter(reporter: string, options: ReporterInitOptions) {
   const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress } = options;
   const logLevel = LogLevel[logLevelName];
 
-  if (progress && !(verbose || grouped)) {
+  if (progress && !(verbose || grouped || profile)) {
     return new ProgressReporter({ concurrency });
   }
 

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -3,8 +3,12 @@ import { JsonReporter, AdoReporter, LogReporter, ProgressReporter, ChromeTraceEv
 import type { ReporterInitOptions } from "../types/ReporterInitOptions.js";
 
 export function createReporter(reporter: string, options: ReporterInitOptions) {
-  const { verbose, grouped, logLevel: logLevelName, concurrency, profile } = options;
+  const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress } = options;
   const logLevel = LogLevel[logLevelName];
+
+  if (progress && !(verbose || grouped)) {
+    return new ProgressReporter({ concurrency });
+  }
 
   switch (reporter) {
     case "profile":
@@ -17,13 +21,7 @@ export function createReporter(reporter: string, options: ReporterInitOptions) {
     case "azureDevops":
     case "adoLog":
       return new AdoReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });
-    case "old":
-      return new LogReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });
     default:
-      if (verbose || grouped) {
-        return new LogReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });
-      }
-
-      return new ProgressReporter({ concurrency });
+      return new LogReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });
   }
 }

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -6,10 +6,6 @@ export function createReporter(reporter: string, options: ReporterInitOptions) {
   const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress } = options;
   const logLevel = LogLevel[logLevelName];
 
-  if (progress && !(verbose || grouped || profile)) {
-    return new ProgressReporter({ concurrency });
-  }
-
   switch (reporter) {
     case "profile":
       return new ChromeTraceEventsReporter({
@@ -22,6 +18,10 @@ export function createReporter(reporter: string, options: ReporterInitOptions) {
     case "adoLog":
       return new AdoReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });
     default:
+      if (progress && !(verbose || grouped)) {
+        return new ProgressReporter({ concurrency });
+      }
+
       return new LogReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });
   }
 }

--- a/packages/cli/tests/initializeReporters.test.ts
+++ b/packages/cli/tests/initializeReporters.test.ts
@@ -1,15 +1,28 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
 import { Logger } from "@lage-run/logger";
 import { AdoReporter, ChromeTraceEventsReporter, LogReporter, ProgressReporter } from "@lage-run/reporters";
 import { initializeReporters } from "../src/commands/initializeReporters.js";
 
 describe("initializeReporters", () => {
-  it("should initialize progress reporter by default", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lage-"));
+  });
+
+  afterAll(() => {
+    fs.rmdirSync(tmpDir, { recursive: true });
+  });
+
+  it("should initialize progress reporter when param is progress passed as true", () => {
     const logger = new Logger();
     const reporters = initializeReporters(logger, {
       concurrency: 1,
       grouped: false,
       logLevel: "info",
-      progress: false,
+      progress: true,
       reporter: [],
       verbose: false,
     });
@@ -52,14 +65,14 @@ describe("initializeReporters", () => {
       concurrency: 1,
       grouped: false,
       logLevel: "info",
-      progress: false,
+      progress: true,
       reporter: [],
       verbose: false,
-      profile: true,
+      profile: path.join(tmpDir, "profile.json"),
     });
+
     expect(reporters.length).toBe(2);
     expect(reporters).toContainEqual(expect.any(ChromeTraceEventsReporter));
-    expect(reporters).toContainEqual(expect.any(ProgressReporter));
   });
 
   it("should initialize ADO reporter when reporter arg is adoLog", () => {
@@ -71,7 +84,6 @@ describe("initializeReporters", () => {
       progress: false,
       reporter: ["adoLog"],
       verbose: false,
-      profile: false,
     });
     expect(reporters.length).toBe(1);
     expect(reporters).toContainEqual(expect.any(AdoReporter));

--- a/packages/e2e-tests/src/remoteFallback.test.ts
+++ b/packages/e2e-tests/src/remoteFallback.test.ts
@@ -84,7 +84,7 @@ describe("RemoteFallbackCacheProvider", () => {
     });
     repo.install();
 
-    const results = repo.run("test", ["--verbose"]);
+    const results = repo.run("test");
 
     const output = results.stdout + results.stderr;
     const jsonOutput = parseNdJson(output);


### PR DESCRIPTION
At 2.5.35, the lage v2 log reporter defaulted to the more "interactive" output which was not appropriate for the CI systems.