### PR TITLE
Task name in chrome reporter category

### DIFF
--- a/change/@lage-run-reporters-bd3f32e1-92f5-4a3f-b9c8-7a6df0a77f0a.json
+++ b/change/@lage-run-reporters-bd3f32e1-92f5-4a3f-b9c8-7a6df0a77f0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChromeTraceEventsReporter: Add task name to category",
+  "packageName": "@lage-run/reporters",
+  "email": "felescoto95@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/reporters/src/ChromeTraceEventsReporter.ts
+++ b/packages/reporters/src/ChromeTraceEventsReporter.ts
@@ -12,7 +12,7 @@ interface TraceEventsObject {
 
 interface CompleteEvent {
   name: string;
-  cat: string;
+  cat: string; // status#task
   ph: "X";
   ts: number; // in microseconds
   pid: number;
@@ -75,7 +75,7 @@ export class ChromeTraceEventsReporter implements Reporter {
 
       const event = {
         name: targetRun.target.id,
-        cat: targetRun.status,
+        cat: `${targetRun.status}#${targetRun.target.task}`,
         ph: "X",
         ts: hrTimeToMicroseconds(targetRun.startTime) - hrTimeToMicroseconds(startTime), // in microseconds
         dur: hrTimeToMicroseconds(targetRun.duration ?? [0, 1000]), // in microseconds

--- a/packages/reporters/tests/ChromeTraceEventsReporter.test.ts
+++ b/packages/reporters/tests/ChromeTraceEventsReporter.test.ts
@@ -62,7 +62,7 @@ describe("ChromeTraceEventsReporter", () => {
         "traceEvents": [
           {
             "name": "a#build",
-            "cat": "failed",
+            "cat": "failed#build",
             "ph": "X",
             "ts": 0,
             "dur": 60000000,
@@ -71,7 +71,7 @@ describe("ChromeTraceEventsReporter", () => {
           },
           {
             "name": "a#test",
-            "cat": "success",
+            "cat": "success#test",
             "ph": "X",
             "ts": 1000000,
             "dur": 10000000,
@@ -80,7 +80,7 @@ describe("ChromeTraceEventsReporter", () => {
           },
           {
             "name": "b#build",
-            "cat": "success",
+            "cat": "success#build",
             "ph": "X",
             "ts": 2000000,
             "dur": 30000000,


### PR DESCRIPTION
Adds the task-name to the task's category within the Profiler's output. This allows you to get a visual distinction between the types of tasks within the pipeline when opening the profile within the Chrome dev-tools performance tab.

## Before Change

![image](https://user-images.githubusercontent.com/10786508/219713985-2c390c06-ff84-481b-a20a-704e5c42cf37.png)


## After Change

![image](https://user-images.githubusercontent.com/10786508/219713870-9aa778a9-aadd-4e54-bad2-8879a5d3ceea.png)
