### PR TITLE
Remove skiped tasks from profile

### DIFF
--- a/change/@lage-run-reporters-a473d863-0819-49fb-a109-62e398e1cb79.json
+++ b/change/@lage-run-reporters-a473d863-0819-49fb-a109-62e398e1cb79.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ChromeTraceEventsReporter: Hide skipped tasks from the profile",
+  "packageName": "@lage-run/reporters",
+  "email": "felescoto95@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/reporters/src/ChromeTraceEventsReporter.ts
+++ b/packages/reporters/src/ChromeTraceEventsReporter.ts
@@ -69,7 +69,9 @@ export class ChromeTraceEventsReporter implements Reporter {
     const { categorize } = this.options;
 
     for (const targetRun of targetRuns.values()) {
-      if (targetRun.target.hidden) {
+      // Skip hidden targets because those should be hidden by reporters.
+      // Hiding as well skipped targets to avoid polluting the profile.
+      if (targetRun.target.hidden || targetRun.status === "skipped") {
         continue;
       }
 


### PR DESCRIPTION
Our profiles were getting polluted with skipped tasks with 0 duration. On repo's build profiles we are seeing a lot of tasks like the following

![image](https://user-images.githubusercontent.com/10786508/219721881-4b44d0bc-a7fc-4807-b823-1dd7e02fb13f.png)

# Before Change
![image](https://user-images.githubusercontent.com/10786508/219716761-9d7fef2b-c3cc-462b-ae1a-0c8ae9e6c426.png)

# After Change
![image](https://user-images.githubusercontent.com/10786508/219713985-2c390c06-ff84-481b-a20a-704e5c42cf37.png)
