### PR TITLE
Don't add to graph scripts missing from package.json

### DIFF
--- a/change/@lage-run-target-graph-fdec4d4b-405d-4ebe-825a-430305b9ac86.json
+++ b/change/@lage-run-target-graph-fdec4d4b-405d-4ebe-825a-430305b9ac86.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't add to graph scripts missing from package.json",
+  "packageName": "@lage-run/target-graph",
+  "email": "felescoto95@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-tests/src/transitiveTaskDeps.test.ts
+++ b/packages/e2e-tests/src/transitiveTaskDeps.test.ts
@@ -5,7 +5,7 @@ import { filterEntry, parseNdJson } from "./parseNdJson.js";
 describe("transitive task deps test", () => {
   // This test follows the model as documented here:
   // https://microsoft.github.io/lage/guide/levels.html
-  it("produces a build graph even when some scripts are missing in package.json", () => {
+  it("produces a the correct build graph when some scripts are missing in package.json", () => {
     const repo = new Monorepo("transitiveDeps");
 
     repo.init();
@@ -44,7 +44,7 @@ describe("transitive task deps test", () => {
 
     expect(indices[getTargetId("a", "build")]).toBeLessThan(indices[getTargetId("a", "test")]);
 
-    expect(indices[getTargetId("b", "build")]).toBeLessThan(indices[getTargetId("a", "test")]);
+    expect(indices[getTargetId("b", "build")]).toBeUndefined();
 
     repo.cleanup();
   });

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -97,11 +97,19 @@ export class WorkspaceTargetGraphBuilder {
     for (const task of tasks) {
       if (scope) {
         for (const packageName of scope) {
-          subGraphEntries.push(getTargetId(packageName, task));
+          const packageInfo = this.packageInfos[packageName];
+          // Do not add a package to the subgraph if the package does not have the task
+          if (packageInfo.scripts && packageInfo.scripts[task]) {
+            subGraphEntries.push(getTargetId(packageName, task));
+          }
         }
       } else {
         for (const packageName of Object.keys(this.packageInfos)) {
-          subGraphEntries.push(getTargetId(packageName, task));
+          const packageInfo = this.packageInfos[packageName];
+          // Do not add a package to the subgraph if the package does not have the task
+          if (packageInfo.scripts && packageInfo.scripts[task]) {
+            subGraphEntries.push(getTargetId(packageName, task));
+          }
         }
       }
     }


### PR DESCRIPTION
Avoid adding packages to build graph when not specified. This will be highly impactful for our build times of our PR Deployment environment as we'd be able to just bundle packages, we deploy to this environment instead of the full repo. In our build pipelines where we need to build everything, we can add `build` to the Lage tasks. 

## Manual Validation

Within our team's repo, I was able to confirm that running `lage test` ran all test tasks our team has, and avoided building packages without tests and that were not in any dependency path. We went from having to build 117 packages to 108. 

I can share the results with you privately to avoid sharing any private package names here :)

Fixes #592 