### PR TITLE
Add note about Node 16 requirement to release notes

### DIFF
--- a/change/lage-b1571b5c-f13b-46f0-9733-0bdeb91261d7.json
+++ b/change/lage-b1571b5c-f13b-46f0-9733-0bdeb91261d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add note about Node 16 requirement to release notes",
+  "packageName": "lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/docs/docs/Cookbook/migration.mdx
+++ b/docs/docs/Cookbook/migration.mdx
@@ -16,16 +16,38 @@ Lage has many changes from 1.x to 2.x. This migration guide will go over major c
 
 ### New Features
 
-1. Revamped Website! You're reading it now!
-2. New non-`npmlog` based default logger
-3. The reporter _name_ `adoLog` has been renamed to `azureDevops` (old name is still useable, just deprecating in the next major version!)
-4. `WorkerRunner` to help make tools like lint or TypeScript run super fast by reusing context in a [dedicated worker](./make-lint-fast.mdx) (e.g. ESLint instance, TypeScript program)
+- Revamped Website! You're reading it now!
+- New non-`npmlog`-based default logger
+- The reporter `adoLog` has been renamed to `azureDevops` (old name is still useable, just deprecating in the next major version!)
+- `WorkerRunner` to help make tools like lint or TypeScript run super fast by reusing context (e.g. ESLint instance, TypeScript program) in a dedicated worker. This must be configured per tool; see examples for [TypeScript](./make-ts-fast.mdx), [ESLint](./make-lint-fast.mdx), and [Jest](./make-jest-fast.mdx).
 
 ### Breaking Changes
 
-1. `lage` now will automatically write remote cache if the typical environment variable is set (e.g. CI or TF_BUILD)
-2. `info` command is currently not implemented yet
-3. `graph` command is current not implemented yet
+- `lage` requires **Node 16**, or using the `--experimental-abortcontroller` flag in Node 14
+- `lage` now will automatically write remote cache if the typical environment variable is set (e.g. `CI` or `TF_BUILD`)
+- `info` command is not implemented yet
+- `graph` command is not implemented yet
+
+#### Using `lage` v2 with Node 14
+
+If you're still on Node 14, you can use Lage v2 by wrapping it with a script which passes the `--experimental-abortcontroller` flag, and using that wrapper in your other scripts.
+
+Relevant parts of `package.json` (omit the comments):
+
+```jsonc
+{
+  "scripts": {
+    // cross-env sets environment variables on any platform
+    "lage": "cross-env NODE_OPTIONS=\"--experimental-abortcontroller\" lage",
+    // Be sure to use `yarn lage` rather than only `lage` in your other scripts!
+    "build": "yarn lage build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0",
+    "lage": "^2.0.0"
+  }
+}
+```
 
 ## v0.x -> v1.x
 

--- a/packages/lage/CHANGELOG.md
+++ b/packages/lage/CHANGELOG.md
@@ -71,8 +71,13 @@ Wed, 15 Feb 2023 16:47:12 GMT
 
 Tue, 07 Feb 2023 23:52:48 GMT
 
-### Major changes
+### Breaking changes
 
-- Promoting v2 to be the @latest tag for npmjs, see [RELEASE.md] (kchau@microsoft.com)
-- Bump @lage-run/cli to v0.8.2
-- Bump @lage-run/scheduler to v0.8.3
+- Lage v2 requires **Node 16** or passing the `--experimental-abortcontroller` flag in Node 14.
+- `lage` now will automatically write remote cache if the typical environment variable is set (e.g. `CI` or `TF_BUILD`)
+- `info` command is not implemented yet
+- `graph` command is not implemented yet
+
+### Features
+
+See the [release notes](./RELEASE.md) and [migration guide](https://microsoft.github.io/lage/docs/Cookbook/migration) for more information about what's new in v2.

--- a/packages/lage/RELEASE.md
+++ b/packages/lage/RELEASE.md
@@ -10,24 +10,19 @@ Lage version 2 is now available at dist-tag `@latest`, featuring significant upd
 * Weighted targets to allow better utilization of resources for tasks that spawn multiple processes like Jest
 * Smaller installation, faster startup times thanks to distributing a pre-made bundle rather than individual scripts
 * Featured in v1, but expanded in v2: the configuration syntax of pipelines is improved to allow for more [configuration options](https://microsoft.github.io/lage/docs/Reference/config#a-complete-tour-of-the-config)
-* Remote fall back cache to speed up local development experience
+* Remote fallback cache to speed up local development experience
 * `@lage-run` scoped packages are now available to integrate as a set of Node.js API such as target graphs, scheduling, worker pool, logging, caching, etc.
 
-## Get started today
+## Breaking changes
 
-Installing `lage` has always been a single package dependency and one installation away. Add `lage` to your `package.json` as one of your `devDependencies`:
+* `lage` requires **Node 16**, or using the `--experimental-abortcontroller` flag in Node 14
+* `lage` now will automatically write remote cache if the typical environment variable is set (e.g. `CI` or `TF_BUILD`)
+* `info` command is not implemented yet
+* `graph` command is not implemented yet
 
-```
-npm install --save-dev lage
-```
+## Other features and migration
 
-or 
-
-```
-yarn add -D lage
-```
-
-Read up on how to [get started quickly](https://microsoft.github.io/lage/docs/Quick%20Start) in the docs!
+[See the migration guide on the website.](https://microsoft.github.io/lage/docs/Cookbook/migration)
 
 ## New Node.js API @lage-run scoped packages
 
@@ -40,4 +35,3 @@ Read up on how to [get started quickly](https://microsoft.github.io/lage/docs/Qu
 * `@lage-run/scheduler`: a typed work scheduler that understands how to schedule work according to a `target-graph`
 * `@lage-run/target-graph`: a graph representation between of packages and their tasks; with utilities to caculate subgraphs
 * `@lage-run/worker-threads-pool`: a typed `worker_threads` pool implementation that includes the ability to associate stdout of each task given to workers
-


### PR DESCRIPTION
Lage v2 uses AbortController which requires either Node 16 or the `--experimental-abortcontroller` flag in Node 14. This should be mentioned in the changelog and release info.

Other updates:
- Mention all breaking changes in the changelog, release notes, and migration page
- Link to the release notes and migration guide from the changelog
- Add info about how to semi-automatically pass the flag in Node 14
- I don't think it's necessary to have release notes include getting started info (presumably someone reading the notes is already using lage), so I replaced that section with breaking change info and a link to the migration guide