### PR TITLE
More resilience in dealing with rerun requests to scheduler

### DIFF
--- a/change/@lage-run-scheduler-655c120c-696b-44b2-9954-542f99ebcdf1.json
+++ b/change/@lage-run-scheduler-655c120c-696b-44b2-9954-542f99ebcdf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Making SimpleScheduler more resilient to re-run requests that maybe come from target-graphs that are changing",
+  "packageName": "@lage-run/scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -183,14 +183,17 @@ export class SimpleScheduler implements TargetScheduler {
     const queue = [targetId];
     while (queue.length > 0) {
       const current = queue.shift()!;
-      const targetRun = this.targetRuns.get(current)!;
 
-      if (targetRun.status !== "pending") {
-        targetRun.status = "pending";
-        this.rerunTargets.add(targetRun.target.id);
-        const dependents = targetRun.target.dependents;
-        for (const dependent of dependents) {
-          queue.push(dependent);
+      if (this.targetRuns.has(current)) {
+        const targetRun = this.targetRuns.get(current)!;
+
+        if (targetRun.status !== "pending") {
+          targetRun.status = "pending";
+          this.rerunTargets.add(targetRun.target.id);
+          const dependents = targetRun.target.dependents;
+          for (const dependent of dependents) {
+            queue.push(dependent);
+          }
         }
       }
     }


### PR DESCRIPTION
If many different `run()` requests are coming through to the SimpleScheduler, there exists some race conditions in which the targetRuns have less entries than the graph being called. We are fixing assumptions of an order in which these are called by safeguarding the mark pending fn.