### PR TITLE
Adding gitignore flag back for calculating envGlob 

### DIFF
--- a/change/@lage-run-cache-09657421-696e-4c66-810e-0a7fcf5d19e6.json
+++ b/change/@lage-run-cache-09657421-696e-4c66-810e-0a7fcf5d19e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "gitignore to be respected again in the envglob - this causes major perf regression otherwise",
+  "packageName": "@lage-run/cache",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cache/src/salt.ts
+++ b/packages/cache/src/salt.ts
@@ -47,7 +47,7 @@ function getEnvHashOneAtTime(environmentGlobFiles: string[], repoRoot: string) {
     return envHashes[key];
   }
 
-  const hashes = hashGlobGit(environmentGlobFiles, { cwd: repoRoot, gitignore: false })!;
+  const hashes = hashGlobGit(environmentGlobFiles, { cwd: repoRoot, gitignore: true })!;
 
   envHashes[key] = Object.values(hashes);
 


### PR DESCRIPTION
For example, if a rule like 'lib' is in the gitignore, and someone wants to add this into the envglob: 'packages/foo/lib', it used to be that glob-hasher would be told to disregard ALL of gitignore to glob. This would be slow! The solution is to turn gitignore on by default again + do the following workaround:

```json
{
  environmentGlob: ['lib', 'packages/foo/lib/**']
}
```
That first "lib" tells glob-hasher to NOT disregard the lib folder when traversing.