### PR TITLE
New env glob strategy

### DIFF
--- a/change/@lage-run-cache-767afc57-2696-4ef0-9ded-207655f9a94b.json
+++ b/change/@lage-run-cache-767afc57-2696-4ef0-9ded-207655f9a94b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "moving back to fast-glob for globbing, as it was more accurate",
+  "packageName": "@lage-run/cache",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-hasher-8df30fc5-cf62-4461-bbb5-e73de00505fb.json
+++ b/change/@lage-run-hasher-8df30fc5-cf62-4461-bbb5-e73de00505fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "moving back to fast-glob for globbing, as it was more accurate",
+  "packageName": "@lage-run/hasher",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -22,8 +22,7 @@
     "backfill-cache": "^5.6.1",
     "backfill-logger": "^5.1.3",
     "glob-hasher": "1.2.1",
-    "fast-glob": "3.2.12",
-    "p-limit": "^3.0.0"
+    "fast-glob": "3.2.12"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -21,7 +21,9 @@
     "backfill-config": "^6.3.0",
     "backfill-cache": "^5.6.1",
     "backfill-logger": "^5.1.3",
-    "glob-hasher": "1.1.1"
+    "glob-hasher": "1.2.1",
+    "fast-glob": "3.2.12",
+    "p-limit": "^3.0.0"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",

--- a/packages/cache/src/TargetHasher.ts
+++ b/packages/cache/src/TargetHasher.ts
@@ -1,9 +1,8 @@
-import { getRepoInfo, Hasher as LageHasher, RepoInfo } from "@lage-run/hasher";
+import { getRepoInfo, Hasher as LageHasher, type RepoInfo } from "@lage-run/hasher";
 import { salt } from "./salt.js";
 import type { Target } from "@lage-run/target-graph";
 import { hash } from "glob-hasher";
 import fg from "fast-glob";
-import path from "path";
 import { hashStrings } from "./hashStrings.js";
 
 export interface TargetHasherOptions {

--- a/packages/hasher/src/__tests__/index.test.ts
+++ b/packages/hasher/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 import { WorkspaceInfo } from "workspace-tools";
 import { PackageHashInfo } from "../hashOfPackage";
-import { Hasher, addToQueue } from "../index";
+import { Hasher, addToQueue, getRepoInfo } from "../index";
 
 import { Monorepo } from "@lage-run/monorepo-fixture";
 const fixturesPath = path.join(__dirname, "..", "__fixtures__");
@@ -89,7 +89,8 @@ describe("The main Hasher class", () => {
 
     const buildSignature = "yarn build";
 
-    const hasher = new Hasher(packageRoot);
+    const repoInfo = await getRepoInfo(monorepo.root);
+    const hasher = new Hasher(packageRoot, repoInfo);
     const hash = await hasher.createPackageHash(buildSignature);
 
     return hash;

--- a/packages/hasher/src/index.ts
+++ b/packages/hasher/src/index.ts
@@ -31,13 +31,10 @@ export function addToQueue(dependencyNames: string[], queue: string[], done: Pac
 }
 
 export class Hasher implements IHasher {
-  private repoInfo?: RepoInfo;
-
-  constructor(private packageRoot: string) {}
+  constructor(private packageRoot: string, private repoInfo: RepoInfo) {}
 
   public async createPackageHash(salt: string): Promise<string> {
-    const packageRoot = await getPackageRoot(this.packageRoot);
-    this.repoInfo = await getRepoInfo(packageRoot);
+    const packageRoot = this.packageRoot;
 
     const { workspaceInfo } = this.repoInfo;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2642,25 +2642,50 @@ glob-hasher-darwin-arm64@1.1.1:
   resolved "https://registry.yarnpkg.com/glob-hasher-darwin-arm64/-/glob-hasher-darwin-arm64-1.1.1.tgz#625f6bf445b441ef3d733298869a7620d32c38bb"
   integrity sha512-Zx2WB81BZ+5TDemdM5l8UjW94Css8YQmSBQfnvG2lqdmnfWZ8upaaK1uHrUyQ9XbQotDpjais7xC92GU+PzOpw==
 
+glob-hasher-darwin-arm64@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/glob-hasher-darwin-arm64/-/glob-hasher-darwin-arm64-1.2.1.tgz#642de0fc1f8fc92c3d6b5dd54bf0a95c219ff188"
+  integrity sha512-zm9bcLTmrN4WrLn60T6PVs3s3Wp4ebp8nAdtenF5UZ7mWo1V/d/BSVGbp/4HNXZz8oH8FoNNRDfA4irj7O7sYg==
+
 glob-hasher-darwin-x64@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/glob-hasher-darwin-x64/-/glob-hasher-darwin-x64-1.1.1.tgz#0126f3bc153db7a708c0c58a4103c3c0064b20fe"
   integrity sha512-U8xVbnPnOIL7nyiUnnOiyz9hpZS7UEsZbBn8F2705QmtOPazoe9zcvJnzcLp5G9OUQ4lMQoZsBVPIXrVtsxHUA==
+
+glob-hasher-darwin-x64@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/glob-hasher-darwin-x64/-/glob-hasher-darwin-x64-1.2.1.tgz#85fff7adede9a7b51fec6ebbcbdc01e399dbf4b0"
+  integrity sha512-5/ywPOZaMWHuk6L8SDd5Ndi0cAZTbbrYyTyZsjGAiY7Lo7qsAxtMV5DY19+z1NlO2vhTKbRVnqdS/r7vlhjvjQ==
 
 glob-hasher-linux-x64-gnu@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/glob-hasher-linux-x64-gnu/-/glob-hasher-linux-x64-gnu-1.1.1.tgz#1fd5d8501e5636953778ad3ab206378d2438488f"
   integrity sha512-u/IkNXy4OruR9eukkNTKnY3E+QgCIpVUAKi41dMjFfRH6OPisWNWPy8yb4ouKR6xPyRT9kTzbtJoYb72CcZOBw==
 
+glob-hasher-linux-x64-gnu@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/glob-hasher-linux-x64-gnu/-/glob-hasher-linux-x64-gnu-1.2.1.tgz#3ce5ee596f2610843865edf9290c48230b8059f2"
+  integrity sha512-QBuGYH1av9rPaOKHid0EWwruuEhEaI9T04oM66Q7LpJVFdkmSVaBj/8GJgBnA4UjraBpr7PMM5+5nvxZ/a8u4Q==
+
 glob-hasher-win32-arm64-msvc@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/glob-hasher-win32-arm64-msvc/-/glob-hasher-win32-arm64-msvc-1.1.1.tgz#867fcec657d57e0709360d12b47594ba334c9b5c"
   integrity sha512-4GCuvDDoMwdbYl83T/cJM8sYjrP2dY1IPqFOTEMBiOAoFuoLuk9vMvUF5GqYqa/gPUU9q2lhZorrxH+NZZBiaw==
 
+glob-hasher-win32-arm64-msvc@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/glob-hasher-win32-arm64-msvc/-/glob-hasher-win32-arm64-msvc-1.2.1.tgz#a40ba3676e914e9f6e28c1b1ac557fa09191221d"
+  integrity sha512-8ISCz8cpA33yt5TH3DMEVTsZBxozpHuDAg7JOf8zlXElEvLJ6TLkdJyubvG/VRmIzd4S0qtUeLNl9fDh5LHM7Q==
+
 glob-hasher-win32-x64-msvc@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/glob-hasher-win32-x64-msvc/-/glob-hasher-win32-x64-msvc-1.1.1.tgz#c79bec37c3038cd8c87be33930a2c0648ed3d087"
   integrity sha512-qJCm1Zfr8I5eNRuYK32oDshiuybJCSqQ95Spharv9Ns0yl8BPzh6VmXUHSPV2RZnUmzZr6KzAvAceQJ6n6pXfg==
+
+glob-hasher-win32-x64-msvc@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/glob-hasher-win32-x64-msvc/-/glob-hasher-win32-x64-msvc-1.2.1.tgz#99c66196f330c9da4f054f405283727bb8715cf0"
+  integrity sha512-sM+7R9/gmhAQ/TjndTqsOLPjCmmxN5jhY42ROvlOoRMgY76dsUn7Hshm1U1ctE/n+4nPEUTD4eEpVERCDaV55A==
 
 glob-hasher@1.1.1:
   version "1.1.1"
@@ -2672,6 +2697,17 @@ glob-hasher@1.1.1:
     glob-hasher-linux-x64-gnu "1.1.1"
     glob-hasher-win32-arm64-msvc "1.1.1"
     glob-hasher-win32-x64-msvc "1.1.1"
+
+glob-hasher@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/glob-hasher/-/glob-hasher-1.2.1.tgz#7b2fd2e11f9053cc4a53f3de6ea934c8ad4d83e4"
+  integrity sha512-Z2d2NN/CYaoJf2Sbsee2thKO2yzc8HfSawFtdJqh9LbvZETRCBquwyAVUFpBSd1g84KUd7rkWI6kFrQt3CmNSg==
+  optionalDependencies:
+    glob-hasher-darwin-arm64 "1.2.1"
+    glob-hasher-darwin-x64 "1.2.1"
+    glob-hasher-linux-x64-gnu "1.2.1"
+    glob-hasher-win32-arm64-msvc "1.2.1"
+    glob-hasher-win32-x64-msvc "1.2.1"
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"


### PR DESCRIPTION
In this PR, we revert back to using fast-glob for our globbing utility. It was proving to be faster and more in line with what users were expecting to get from an envglob input. We also applied `fast-glob` in the `inputs` option for tasks.