### PR TITLE
After moving caching inside workers, uuid no longer works!

### DIFF
--- a/change/lage-8b517d07-7201-4fdf-896a-edfc3fa035d4.json
+++ b/change/lage-8b517d07-7201-4fdf-896a-edfc3fa035d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed a bundling issue where cache was no longer working due to exportConditions problem in rollup's node plugin",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/rollup.config.js
+++ b/packages/lage/rollup.config.js
@@ -53,6 +53,7 @@ export default [
         // Since we are produce CJS, let's resolve main first!
         mainFields: ["main", "module"],
         preferBuiltins: true,
+        exportConditions: ["node"],
       }),
       commonjs({
         ignoreDynamicRequires: true,
@@ -75,6 +76,7 @@ export default [
         // Since we are produce CJS, let's resolve main first!
         mainFields: ["main", "module"],
         preferBuiltins: true,
+        exportConditions: ["node"],
       }),
       commonjs({
         ignoreDynamicRequires: true,


### PR DESCRIPTION
rollup pays attention the export maps. But by default the nodeResolve plugin doesn't know to also use the "node" export condition. We need to add this to accommodate the `uuid` package bundling. We had this fix early on for lage when doing caching in the main thread. However, we also bundle the targetWorker - and this issue resurfaced!