### PR TITLE
Bumps workspace-tools and use the new async API for getPackageInfos to speed things up

### DIFF
--- a/change/@lage-run-cache-github-actions-6eca5216-a78b-418b-ae8e-bef089c9f9ec.json
+++ b/change/@lage-run-cache-github-actions-6eca5216-a78b-418b-ae8e-bef089c9f9ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bumps workspace-tools and use async packageinfos",
+  "packageName": "@lage-run/cache-github-actions",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-cli-09a93b5d-e96b-4e5a-b133-7cc7e29cdb3c.json
+++ b/change/@lage-run-cli-09a93b5d-e96b-4e5a-b133-7cc7e29cdb3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bumps workspace-tools and use async packageinfos",
+  "packageName": "@lage-run/cli",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-config-a666c3fc-f385-42cb-af05-430afefe03c4.json
+++ b/change/@lage-run-config-a666c3fc-f385-42cb-af05-430afefe03c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bumps workspace-tools and use async packageinfos",
+  "packageName": "@lage-run/config",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-target-graph-c75e4272-f0e8-402c-809d-9f8b8e8df0ab.json
+++ b/change/@lage-run-target-graph-c75e4272-f0e8-402c-809d-9f8b8e8df0ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bumps workspace-tools and use async packageinfos",
+  "packageName": "@lage-run/target-graph",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/lage-077e0c75-0904-49bd-8bc6-01a86a997af7.json
+++ b/change/lage-077e0c75-0904-49bd-8bc6-01a86a997af7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bumps workspace-tools and use async packageinfos",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "syncpack": "8.5.14"
   },
   "resolutions": {
-    "workspace-tools": "^0.30.0",
+    "workspace-tools": "^0.31.0",
     "typescript": "^5.0.3"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "syncpack": "8.5.14"
   },
   "resolutions": {
-    "workspace-tools": "^0.31.0",
+    "workspace-tools": "^0.32.0",
     "typescript": "^5.0.3"
   },
   "lint-staged": {

--- a/packages/cache-github-actions/package.json
+++ b/packages/cache-github-actions/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "backfill-config": "^6.3.0",
     "backfill-logger": "^5.1.3",
-    "workspace-tools": "^0.31.0",
+    "workspace-tools": "^0.32.0",
     "@actions/cache": "^3.0.4"
   },
   "devDependencies": {

--- a/packages/cache-github-actions/package.json
+++ b/packages/cache-github-actions/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "backfill-config": "^6.3.0",
     "backfill-logger": "^5.1.3",
-    "workspace-tools": "^0.30.0",
+    "workspace-tools": "^0.31.0",
     "@actions/cache": "^3.0.4"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "@lage-run/cache": "^0.5.1",
     "@lage-run/reporters": "^1.1.0",
     "commander": "^9.4.0",
-    "workspace-tools": "^0.30.0",
+    "workspace-tools": "^0.31.0",
     "chokidar": "3.5.3",
     "fast-glob": "^3.2.11"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "@lage-run/cache": "^0.5.1",
     "@lage-run/reporters": "^1.1.0",
     "commander": "^9.4.0",
-    "workspace-tools": "^0.31.0",
+    "workspace-tools": "^0.32.0",
     "chokidar": "3.5.3",
     "fast-glob": "^3.2.11"
   },

--- a/packages/cli/src/commands/affected/action.ts
+++ b/packages/cli/src/commands/affected/action.ts
@@ -1,5 +1,5 @@
 import createLogger from "@lage-run/logger";
-import { getPackageInfos, getWorkspaceRoot, type PackageInfos } from "workspace-tools";
+import { getPackageInfosAsync, getWorkspaceRoot, type PackageInfos } from "workspace-tools";
 import { getConfig } from "@lage-run/config";
 import { getFilteredPackages } from "../../filter/getFilteredPackages.js";
 import type { FilterOptions } from "../../types/FilterOptions.js";
@@ -16,7 +16,7 @@ export async function affectedAction(options: AffectedOptions) {
   const logger = createLogger();
 
   const root = getWorkspaceRoot(cwd)!;
-  const packageInfos = getPackageInfos(root);
+  const packageInfos = await getPackageInfosAsync(root);
 
   const packages = getFilteredPackages({
     root,

--- a/packages/cli/src/commands/run/infoAction.ts
+++ b/packages/cli/src/commands/run/infoAction.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import { createTargetGraph } from "./createTargetGraph.js";
 import { filterArgsForTasks } from "./filterArgsForTasks.js";
 import { getConfig } from "@lage-run/config";
-import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import { getPackageInfosAsync, getWorkspaceRoot } from "workspace-tools";
 import createLogger from "@lage-run/logger";
 
 import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
@@ -27,7 +27,7 @@ export async function infoAction(options: RunOptions, command: Command) {
 
   // Build Target Graph
   const root = getWorkspaceRoot(process.cwd())!;
-  const packageInfos = getPackageInfos(root);
+  const packageInfos = await getPackageInfosAsync(root);
 
   const { tasks } = filterArgsForTasks(command.args);
 

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -4,7 +4,7 @@ import { filterArgsForTasks } from "./filterArgsForTasks.js";
 import { filterPipelineDefinitions } from "./filterPipelineDefinitions.js";
 import { findNpmClient } from "@lage-run/find-npm-client";
 import { getConfig, getMaxWorkersPerTask, getMaxWorkersPerTaskFromOptions, getConcurrency } from "@lage-run/config";
-import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import { getPackageInfosAsync, getWorkspaceRoot } from "workspace-tools";
 import { initializeReporters } from "../initializeReporters.js";
 import { SimpleScheduler } from "@lage-run/scheduler";
 
@@ -44,7 +44,7 @@ export async function runAction(options: RunOptions, command: Command) {
 
   // Build Target Graph
   const root = getWorkspaceRoot(process.cwd())!;
-  const packageInfos = getPackageInfos(root);
+  const packageInfos = await getPackageInfosAsync(root);
 
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -3,7 +3,7 @@ import { createTargetGraph } from "./createTargetGraph.js";
 import { filterArgsForTasks } from "./filterArgsForTasks.js";
 import { findNpmClient } from "@lage-run/find-npm-client";
 import { getConfig, getMaxWorkersPerTask, getMaxWorkersPerTaskFromOptions, getConcurrency } from "@lage-run/config";
-import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import { getPackageInfosAsync, getWorkspaceRoot } from "workspace-tools";
 import { filterPipelineDefinitions } from "./filterPipelineDefinitions.js";
 import { LogReporter } from "@lage-run/reporters";
 import { SimpleScheduler } from "@lage-run/scheduler";
@@ -43,7 +43,7 @@ export async function watchAction(options: RunOptions, command: Command) {
 
   // Build Target Graph
   const root = getWorkspaceRoot(process.cwd())!;
-  const packageInfos = getPackageInfos(root);
+  const packageInfos = await getPackageInfosAsync(root);
 
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 
@@ -119,7 +119,7 @@ export async function watchAction(options: RunOptions, command: Command) {
   }
 
   // When initial run is done, disable fetching of caches on all targets, keep writing to the cache
-  const watcher = watch(root);
+  const watcher = await watch(root, packageInfos);
   watcher.on("change", async (packageName) => {
     reporter.resetLogEntries();
     const targets = new Map<string, Target>();

--- a/packages/cli/src/commands/run/watcher.ts
+++ b/packages/cli/src/commands/run/watcher.ts
@@ -1,7 +1,7 @@
 import chokidar from "chokidar";
 
 import path from "path";
-import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import { getWorkspaceRoot } from "workspace-tools";
 import type { PackageInfos } from "workspace-tools";
 import EventEmitter from "events";
 
@@ -13,10 +13,9 @@ interface PathIndex {
   [pathPart: string]: PathIndexItem;
 }
 
-export function watch(cwd: string): EventEmitter {
+export function watch(cwd: string, packageInfos: PackageInfos): EventEmitter {
   const events = new EventEmitter();
   const root = getWorkspaceRoot(cwd);
-  const packageInfos = getPackageInfos(cwd);
 
   // generate a tree index of all the packages
   const packageIndex = createPackageIndex(root!, packageInfos);

--- a/packages/cli/tests/getFilteredPackages.test.ts
+++ b/packages/cli/tests/getFilteredPackages.test.ts
@@ -1,6 +1,6 @@
 import createLogger from "@lage-run/logger";
 import { Monorepo } from "@lage-run/monorepo-fixture";
-import { getPackageInfos } from "workspace-tools";
+import { getPackageInfosAsync } from "workspace-tools";
 import { getFilteredPackages } from "../src/filter/getFilteredPackages";
 
 describe("getFilteredPackages", () => {
@@ -24,7 +24,7 @@ describe("getFilteredPackages", () => {
 
     const filteredPackages = getFilteredPackages({
       root: monorepo.root,
-      packageInfos: getPackageInfos(monorepo.root),
+      packageInfos: await getPackageInfosAsync(monorepo.root),
       includeDependents: false,
       includeDependencies: false,
       since: "HEAD~1",
@@ -59,7 +59,7 @@ describe("getFilteredPackages", () => {
 
     const filteredPackages = getFilteredPackages({
       root: monorepo.root,
-      packageInfos: getPackageInfos(monorepo.root),
+      packageInfos: await getPackageInfosAsync(monorepo.root),
       includeDependents: false,
       includeDependencies: false,
       since: "HEAD~1",
@@ -96,7 +96,7 @@ describe("getFilteredPackages", () => {
 
     const filteredPackages = getFilteredPackages({
       root: monorepo.root,
-      packageInfos: getPackageInfos(monorepo.root),
+      packageInfos: await getPackageInfosAsync(monorepo.root),
       includeDependents: false,
       includeDependencies: false,
       since: "HEAD~1",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,7 +21,7 @@
     "@lage-run/logger": "^1.2.2",
     "@lage-run/scheduler-types": "^0.3.5",
     "@lage-run/target-graph": "^0.8.1",
-    "workspace-tools": "^0.31.0",
+    "workspace-tools": "^0.32.0",
     "cosmiconfig": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,7 +21,7 @@
     "@lage-run/logger": "^1.2.2",
     "@lage-run/scheduler-types": "^0.3.5",
     "@lage-run/target-graph": "^0.8.1",
-    "workspace-tools": "^0.30.0",
+    "workspace-tools": "^0.31.0",
     "cosmiconfig": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/lage/package.json
+++ b/packages/lage/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-terser": "7.0.2",
     "backfill-config": "^6.3.0",
     "dts-bundle-generator": "7.2.0",
-    "workspace-tools": "^0.30.0"
+    "workspace-tools": "^0.31.0"
   },
   "files": [
     "dist/*.d.ts",

--- a/packages/lage/package.json
+++ b/packages/lage/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-terser": "7.0.2",
     "backfill-config": "^6.3.0",
     "dts-bundle-generator": "7.2.0",
-    "workspace-tools": "^0.31.0"
+    "workspace-tools": "^0.32.0"
   },
   "files": [
     "dist/*.d.ts",

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -15,7 +15,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "workspace-tools": "^0.30.0"
+    "workspace-tools": "^0.31.0"
   },
   "devDependencies": {
     "monorepo-scripts": "*"

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -15,7 +15,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "workspace-tools": "^0.31.0"
+    "workspace-tools": "^0.32.0"
   },
   "devDependencies": {
     "monorepo-scripts": "*"

--- a/scripts/config/jest.config.js
+++ b/scripts/config/jest.config.js
@@ -2,7 +2,7 @@
 const { getWorkspaceRoot, getPackageInfos } = require("workspace-tools");
 const path = require("path");
 
-const root = getWorkspaceRoot(process.cwd());
+const root = getWorkspaceRoot(process.cwd()) ?? process.cwd();
 const packages = getPackageInfos(root);
 const moduleNameMapper = Object.values(packages).reduce((acc, { packageJsonPath, name }) => {
   const packagePath = path.dirname(packageJsonPath);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,7 @@
     "typescript": "^5.0.3",
     "eslint": "^8.20.0",
     "eslint-plugin-file-extension-in-import-ts": "^1.0.1",
-    "workspace-tools": "^0.30.0",
+    "workspace-tools": "^0.31.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7"
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,7 @@
     "typescript": "^5.0.3",
     "eslint": "^8.20.0",
     "eslint-plugin-file-extension-in-import-ts": "^1.0.1",
-    "workspace-tools": "^0.31.0",
+    "workspace-tools": "^0.32.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,10 +4836,10 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workspace-tools@0.30.0, workspace-tools@^0.30.0, workspace-tools@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.31.0.tgz#2ded1e1e0b4aecef70bc7f4ab6dd63bc2a6118c5"
-  integrity sha512-iXCZDyR2l779K98XuDNW+Vb06016FRcZ9wKElT6/35UbiWKZo582J9uJjMs7KiGF79GpVpFGKqq8HeJD4T8mdg==
+workspace-tools@0.30.0, workspace-tools@^0.30.0, workspace-tools@^0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.32.0.tgz#ffc07ae42377aad774b294168afad1b69d7db379"
+  integrity sha512-A61/L7jpHLAvGVgjtT5tJypOP7FVuI3iLwJYlyxJSrZpY5NQ/lCzW1fQZiXi7gNJDnJXuXjQM5cSLvIANH3X4Q==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     git-url-parse "^13.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,10 +4836,10 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workspace-tools@0.30.0, workspace-tools@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.30.0.tgz#93103df09a66d5a4260bf65005b8f9924e439cf1"
-  integrity sha512-vQrzjAFvQYI2Zg9kFAo43aIgQNX5VSTtWLvOxCKhgjKnPdyLMXcPNxPTCKu3v+tjDW+YJNXUAigVv+pykrwOsQ==
+workspace-tools@0.30.0, workspace-tools@^0.30.0, workspace-tools@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.31.0.tgz#2ded1e1e0b4aecef70bc7f4ab6dd63bc2a6118c5"
+  integrity sha512-iXCZDyR2l779K98XuDNW+Vb06016FRcZ9wKElT6/35UbiWKZo582J9uJjMs7KiGF79GpVpFGKqq8HeJD4T8mdg==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     git-url-parse "^13.0.0"


### PR DESCRIPTION
using the async api will speed up the reading of all the package.json for all the workspaces.