### PR TITLE
Add back the init command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+// This is only used to enable eslint in the editor
+module.exports = {
+  ...require("./scripts/config/eslintrc"),
+  parserOptions: {
+    project: "./scripts/config/tsconfig.eslint.json",
+  },
+  ignorePatterns: ["**/*.js", "**/__fixtures__", "**/hasher/src/__tests__"],
+};

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
           git config user.email "kchau@microsoft.com"
           git config user.name "Ken Chau"
 
-      - run: |
+      - name: Publish
+        run: |
           # Get the existing remote URL without creds, and use a trap (like try/finally)
           # to restore it after this step finishes
           trap "git remote set-url origin '$(git remote get-url origin)'" EXIT

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "eslint.workingDirectories": ["src", "tests"],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/change/@lage-run-cli-a1accf2e-f4eb-4c51-9cca-b038b9b23617.json
+++ b/change/@lage-run-cli-a1accf2e-f4eb-4c51-9cca-b038b9b23617.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add back the init command",
+  "packageName": "@lage-run/cli",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-config-0c3f9ffd-61af-46f8-9bfc-d561e06ffa36.json
+++ b/change/@lage-run-config-0c3f9ffd-61af-46f8-9bfc-d561e06ffa36.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add readConfigFile API to read the file without defaults",
+  "packageName": "@lage-run/config",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/lage-c7f0f1ed-81a0-460a-865e-b320c75a3b4d.json
+++ b/change/lage-c7f0f1ed-81a0-460a-865e-b320c75a3b4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update readme",
+  "packageName": "lage",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,22 +20,23 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
+    "@lage-run/cache": "^0.5.4",
     "@lage-run/config": "^0.1.4",
     "@lage-run/find-npm-client": "^0.1.4",
     "@lage-run/logger": "^1.3.0",
+    "@lage-run/reporters": "^1.2.0",
     "@lage-run/scheduler": "^0.11.3",
     "@lage-run/scheduler-types": "^0.3.8",
     "@lage-run/target-graph": "^0.8.4",
-    "@lage-run/cache": "^0.5.4",
-    "@lage-run/reporters": "^1.2.0",
-    "commander": "^9.4.0",
-    "workspace-tools": "^0.34.0",
     "chokidar": "3.5.3",
-    "fast-glob": "^3.2.11"
+    "commander": "^9.4.0",
+    "execa": "5.1.1",
+    "fast-glob": "^3.2.11",
+    "workspace-tools": "^0.34.0"
   },
   "devDependencies": {
-    "monorepo-scripts": "*",
-    "@lage-run/monorepo-fixture": "*"
+    "@lage-run/monorepo-fixture": "*",
+    "monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,12 +4,14 @@ import { runCommand } from "./commands/run/index.js";
 import { cacheCommand } from "./commands/cache/index.js";
 import { NoTargetFoundError } from "./types/errors.js";
 import { affectedCommand } from "./commands/affected/index.js";
+import { initCommand } from "./commands/init/index.js";
 
 async function main() {
   const program = new Command();
   program.addCommand(runCommand, { isDefault: true });
   program.addCommand(cacheCommand);
   program.addCommand(affectedCommand);
+  program.addCommand(initCommand);
 
   await program.parseAsync(process.argv);
 }

--- a/packages/cli/src/commands/init/action.ts
+++ b/packages/cli/src/commands/init/action.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console -- logger doesn't work in this context */
 import { readConfigFile } from "@lage-run/config";
 import fs from "fs";
 import path from "path";

--- a/packages/cli/src/commands/init/action.ts
+++ b/packages/cli/src/commands/init/action.ts
@@ -1,0 +1,128 @@
+import { readConfigFile } from "@lage-run/config";
+import fs from "fs";
+import path from "path";
+import execa from "execa";
+
+type WorkspaceManager = "rush" | "pnpm" | "yarn" | "npm";
+
+export async function initAction() {
+  const cwd = process.cwd();
+
+  const config = await readConfigFile(cwd);
+  if (config) {
+    console.error("lage is already initialized in this workspace");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.info("Installing lage and creating a default configuration file");
+
+  let workspaceManager: WorkspaceManager = "yarn";
+
+  try {
+    workspaceManager = whichWorkspaceManager(cwd);
+  } catch (e) {
+    console.error(
+      "lage requires you to be using a workspace - make sure you are using yarn workspaces, npm workspaces, pnpm workspaces, or rush"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const pipeline = {
+    build: ["^build"],
+    test: ["build"],
+    lint: [],
+  };
+
+  const lageConfig = {
+    pipeline,
+    npmClient: workspaceManager === "yarn" ? "yarn" : "npm",
+  };
+
+  const lageConfigFile = path.join(cwd, "lage.config.js");
+  fs.writeFileSync(lageConfigFile, "module.exports = " + JSON.stringify(lageConfig, null, 2) + ";");
+
+  installLage(cwd, workspaceManager, pipeline);
+
+  console.info(`Lage is initialized! You can now run: ${getBuildCommand(workspaceManager)}`);
+}
+
+function getBuildCommand(workspaceManager: WorkspaceManager) {
+  switch (workspaceManager) {
+    case "yarn":
+      return "yarn lage build";
+
+    case "pnpm":
+      return "pnpm run lage build";
+
+    case "rush":
+    case "npm":
+      return "npm run lage build";
+  }
+}
+
+function whichWorkspaceManager(cwd: string) {
+  const packageJson = readPackageJson(cwd);
+
+  if (fs.existsSync(path.join(cwd, "rush.json"))) {
+    return "rush";
+  }
+
+  if (fs.existsSync(path.join(cwd, "yarn.lock")) && packageJson.workspaces) {
+    return "yarn";
+  }
+
+  if (fs.existsSync(path.join(cwd, "pnpm-workspace.yaml"))) {
+    return "pnpm";
+  }
+
+  if (fs.existsSync(path.join(cwd, "package-lock.json")) && packageJson.workspaces) {
+    return "npm";
+  }
+
+  throw new Error("not a workspace");
+}
+
+async function installLage(cwd: string, workspaceManager: WorkspaceManager, pipeline: Record<string, string[]>) {
+  const lageVersion = getLageVersion();
+  const packageJson = readPackageJson(cwd);
+  packageJson.scripts ??= {};
+  for (const script of Object.keys(pipeline)) {
+    packageJson.scripts[script] = `lage ${script}`;
+  }
+
+  if (workspaceManager === "rush") {
+    packageJson.scripts.lage = `node common/scripts/install-run.js lage@${lageVersion} lage`;
+    writePackageJson(cwd, packageJson);
+  } else {
+    packageJson.scripts.lage = "lage";
+    packageJson.devDependencies ??= {};
+    packageJson.devDependencies.lage = lageVersion;
+    writePackageJson(cwd, packageJson);
+
+    await execa(workspaceManager, ["install"], { stdio: "inherit" });
+  }
+}
+
+function getLageVersion() {
+  const lagePackageJsonFile = require.resolve("../../package.json", {
+    paths: [__dirname],
+  });
+  const lagePackageJson = JSON.parse(fs.readFileSync(lagePackageJsonFile, "utf-8"));
+  return lagePackageJson.version;
+}
+
+function writePackageJson(cwd: string, packageJson: any) {
+  const packageJsonFile = path.join(cwd, "package.json");
+  fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, null, 2));
+}
+
+function readPackageJson(cwd: string): {
+  scripts?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  workspaces?: any;
+} {
+  const packageJsonFile = path.join(cwd, "package.json");
+  return JSON.parse(fs.readFileSync(packageJsonFile, "utf-8"));
+}

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+import { addFilterOptions } from "../addFilterOptions.js";
+import { initAction } from "./action.js";
+
+const initCommand = new Command("init");
+
+addFilterOptions(initCommand).description("Install lage in a workspace and create a config file").action(initAction);
+
+export { initCommand };

--- a/packages/config/src/getConfig.ts
+++ b/packages/config/src/getConfig.ts
@@ -1,22 +1,15 @@
 import os from "os";
-import { cosmiconfig } from "cosmiconfig";
-import { getWorkspaceRoot } from "workspace-tools";
+import { readConfigFile } from "./readConfigFile.js";
 import type { ConfigOptions } from "./types/ConfigOptions.js";
+import type { CacheOptions } from "./types/CacheOptions.js";
 
+/**
+ * Get the lage config with defaults.
+ */
 export async function getConfig(cwd: string): Promise<ConfigOptions> {
-  // Verify presence of git
-  const root = getWorkspaceRoot(cwd);
-  if (!root) {
-    throw new Error("This must be called inside a codebase that is part of a JavaScript workspace.");
-  }
-
-  // Search for lage.config.js file
-  const ConfigModuleName = "lage";
-  const configExplorer = await cosmiconfig(ConfigModuleName);
-  const results = await configExplorer.search(root ?? cwd);
-  const config = results?.config;
+  const config = (await readConfigFile(cwd)) || ({} as Partial<ConfigOptions>);
   return {
-    cacheOptions: config?.cacheOptions ?? {},
+    cacheOptions: config?.cacheOptions ?? ({} as CacheOptions),
     ignore: config?.ignore ?? [],
     npmClient: config?.npmClient ?? "npm",
     pipeline: config?.pipeline ?? {},

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 export { getConfig } from "./getConfig.js";
 export { getConcurrency } from "./getConcurrency.js";
 export { getMaxWorkersPerTask, getMaxWorkersPerTaskFromOptions } from "./getMaxWorkersPerTask.js";
+export { readConfigFile } from "./readConfigFile.js";
 export type { PipelineDefinition } from "./types/PipelineDefinition.js";
 export type { ConfigOptions } from "./types/ConfigOptions.js";
 export type { CacheOptions } from "./types/CacheOptions.js";

--- a/packages/config/src/readConfigFile.ts
+++ b/packages/config/src/readConfigFile.ts
@@ -1,0 +1,21 @@
+import { cosmiconfig } from "cosmiconfig";
+import { getWorkspaceRoot } from "workspace-tools";
+import type { ConfigOptions } from "./types/ConfigOptions.js";
+
+const ConfigModuleName = "lage";
+
+/**
+ * Read the lage config file if it exists, without filling in defaults.
+ */
+export async function readConfigFile(cwd: string): Promise<ConfigOptions | undefined> {
+  // Verify presence of git
+  const root = getWorkspaceRoot(cwd);
+  if (!root) {
+    throw new Error("This must be called inside a codebase that is part of a JavaScript workspace.");
+  }
+
+  // Search for lage.config.js file
+  const configExplorer = await cosmiconfig(ConfigModuleName);
+  const results = await configExplorer.search(root ?? cwd);
+  return results?.config || undefined;
+}

--- a/packages/lage/README.md
+++ b/packages/lage/README.md
@@ -2,7 +2,7 @@
 
 Documentation: https://microsoft.github.io/lage/
 
-See the [release notes](https://github.com/microsoft/lage/blob/master/packages/lage/RELEASE.md) for more details of new features!
+**Lage v2 is here!** See the [release notes](https://github.com/microsoft/lage/blob/master/packages/lage/RELEASE.md) for details about new features and breaking changes.
 
 ## Overview
 
@@ -14,17 +14,31 @@ This usually means that there are wasted CPU cycles in between `build` and `test
 
 `lage` (Norwegian for "make", pronounced law-geh) solves this by providing a terse pipelining syntax. It has many features geared towards speeding up the task runner that we'll explore later.
 
-## Quick Start
+## Quick start
 
-`lage` gives you this capability with very little configuration. First, let's install the `lage` utility. You can place this in your workspace's root `package.json` by running `yarn add`:
+`lage` gives you this capability with very little configuration.
 
-```
-yarn add -D lage
-```
+### Automatic installation
 
-Confirm with `yarn` that you are sure to add a package at the root level, you then place a root level script inside the `package.json` to run `lage`:
+You can automatically install lage and create a basic config file by running:
 
 ```
+npx lage init
+```
+
+### Manual installation
+
+You can also install and configure `lage` manually.
+
+First, install `lage` at your workspace's root. For example, if you're using `yarn`:
+
+```
+yarn add -D -W lage
+```
+
+Next, add scripts inside the workspace root `package.json` to run `lage`. For example:
+
+```json
 {
   "scripts": {
     "build": "lage build",
@@ -33,7 +47,7 @@ Confirm with `yarn` that you are sure to add a package at the root level, you th
 }
 ```
 
-Add a configuration file in the root to get started. Create this file at the root `lage.config.js`:
+To specify that `test` depends on `build`, create a file `lage.config.js` at the repo root and add the following:
 
 ```js
 module.exports = {
@@ -44,10 +58,22 @@ module.exports = {
 };
 ```
 
-Do not worry about the syntax for now. We will go over the configuration file in a coming section. You can now run this command:
+(You can find more details about this syntax in the [pipelines tutorial](https://microsoft.github.io/lage/docs/Tutorial/pipeline).)
+
+You can now run this command:
 
 ```
-$ lage test
+lage test
 ```
 
 `lage` will detect that you need to run `build` steps before `test`s are run.
+
+## Next steps
+
+Take a look at some of the other resources on the website:
+
+- [Introduction and overview](https://microsoft.github.io/lage/docs/Introduction) of how `lage` works
+- [Tutorial](https://microsoft.github.io/lage/docs/Tutorial/pipeline) about the `pipeline` syntax and other `lage` concepts
+- [CLI reference](https://microsoft.github.io/lage/docs/Reference/cli)
+- [Config reference](https://microsoft.github.io/lage/docs/Reference/config)
+- [Recipes](https://microsoft.github.io/lage/docs/Cookbook/make-jest-fast) for integrating with Jest, ESLint, and more

--- a/scripts/config/eslintrc.js
+++ b/scripts/config/eslintrc.js
@@ -11,11 +11,10 @@ module.exports = {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-require-imports": "error",
     "no-console": "error",
-    "file-extension-in-import-ts/file-extension-in-import-ts": "error"
+    "file-extension-in-import-ts/file-extension-in-import-ts": "error",
   },
   parserOptions: {
     project: "./tsconfig.json",
   },
   root: true,
-  
 };

--- a/scripts/config/tsconfig.eslint.json
+++ b/scripts/config/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  // tsconfig used only for eslint in the editor
+  "extends": "../../packages/tsconfig.lage2.json",
+  "include": ["../../packages/*/src"]
+}


### PR DESCRIPTION
The docs still reference the `init` command from v1, but it's gone in v2. It's pretty simple, so I copied the code from v1 and modified it to fit v2 patterns.

Also updated the lage readme to include the `init` command and made some other improvements.

And I fixed the eslint setup for the editor so it actually shows errors while editing files.