### PR TITLE
Unpin devDependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,7 @@ jobs:
 
       # @see https://www.npmjs.com/package/syncpack
       - name: Check consistent package.json dep versions
-        run: yarn syncpack list-mismatches -w
+        run: yarn syncpack list-mismatches
 
       - name: Dependency checks
         run: yarn lage depcheck

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,16 +1,17 @@
 // @ts-check
 /** @type {import('beachball').BeachballConfig}*/
 module.exports = {
+  groupChanges: true,
   ignorePatterns: [
-    '.*ignore',
-    '.github/**',
-    'beachball.config.js',
-    'decks/**',
-    'docs/**',
-    'jasmine.json',
-    'packages/*/jest.config.js',
-    'packages/*/tests/**',
+    ".*ignore",
+    ".github/**",
+    "beachball.config.js",
+    "decks/**",
+    "docs/**",
+    "jasmine.json",
+    "packages/*/jest.config.js",
+    "packages/*/tests/**",
     // This one is especially important (otherwise dependabot would be blocked by change file requirements)
-    'yarn.lock',
+    "yarn.lock",
   ],
 };

--- a/change/change-16682f44-c91a-4057-b8d5-68ce2deda29f.json
+++ b/change/change-16682f44-c91a-4057-b8d5-68ce2deda29f.json
@@ -1,0 +1,95 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/cache",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "patch",
+      "comment": "Update backfill-config to ^6.4.1",
+      "packageName": "@lage-run/config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/hasher",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/cache-github-actions",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/find-npm-client",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "lage",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/reporters",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/scheduler-types",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/scheduler",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/target-graph",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Use ranges for devDependencies",
+      "packageName": "@lage-run/worker-threads-pool",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -31,24 +31,28 @@
     "postinstall": "patch-package"
   },
   "devDependencies": {
-    "@types/jest": "29.5.1",
-    "@types/node": "16.18.3",
+    "@types/jest": "^29.5.1",
+    "@types/node": "^16.18.3",
     "beachball": "^2.37.0",
     "fast-glob": "^3.2.12",
-    "gh-pages": "4.0.0",
-    "husky": "8.0.3",
+    "gh-pages": "^4.0.0",
+    "husky": "^8.0.3",
     "lage-npm": "npm:lage@2.7.6",
-    "lint-staged": "13.2.0",
-    "patch-package": "6.5.1",
-    "prettier": "2.8.6",
-    "syncpack": "8.5.14",
-    "ts-node": "10.9.1"
-  },
-  "resolutions": {
-    "typescript": "^5.0.3"
+    "lint-staged": "^13.2.0",
+    "patch-package": "^6.5.1",
+    "prettier": "^2.8.6",
+    "syncpack": "^9.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.0.3"
   },
   "lint-staged": {
     "*.ts": "prettier --config .prettierrc --write --ignore-path .gitignore",
     "*.json": "prettier --config .prettierrc --write --ignore-path .gitignore"
+  },
+  "syncpack": {
+    "dependencyTypes": [
+      "dev",
+      "prod"
+    ]
   }
 }

--- a/packages/cache-github-actions/jest.config.js
+++ b/packages/cache-github-actions/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/cache-github-actions/package.json
+++ b/packages/cache-github-actions/package.json
@@ -22,7 +22,7 @@
     "@actions/cache": "^3.0.4"
   },
   "devDependencies": {
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cache/jest.config.js
+++ b/packages/cache/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,7 +20,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "backfill-config": "^6.3.1",
+    "backfill-config": "^6.4.1",
     "@lage-run/logger": "^1.3.0",
     "@lage-run/scheduler-types": "^0.3.12",
     "@lage-run/target-graph": "^0.8.8",
@@ -28,7 +28,7 @@
     "cosmiconfig": "^7.0.0"
   },
   "devDependencies": {
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -19,11 +19,11 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "monorepo-scripts": "*",
     "@lage-run/cli": "^0.16.3",
+    "@lage-run/monorepo-scripts": "*",
     "@lage-run/target-graph": "^0.8.8",
     "@lage-run/scheduler-types": "^0.3.12",
-    "execa": "5.1.1",
+    "execa": "^5.1.1",
     "glob-hasher": "^1.3.0"
   }
 }

--- a/packages/find-npm-client/jest.config.js
+++ b/packages/find-npm-client/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/find-npm-client/package.json
+++ b/packages/find-npm-client/package.json
@@ -14,7 +14,7 @@
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/format-hrtime/jest.config.js
+++ b/packages/format-hrtime/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/hasher/jest.config.js
+++ b/packages/hasher/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -25,9 +25,9 @@
     "micromatch": "^4.0.5"
   },
   "devDependencies": {
-    "@types/graceful-fs": "^4.1.6",
-    "@lage-run/monorepo-fixture": "^0.1.0",
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-fixture": "*",
+    "@lage-run/monorepo-scripts": "*",
+    "@types/graceful-fs": "^4.1.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lage/package.json
+++ b/packages/lage/package.json
@@ -26,7 +26,7 @@
     "@lage-run/cli": "^0.16.3",
     "@lage-run/scheduler": "^1.1.10",
     "backfill-config": "^6.4.1",
-    "dts-bundle-generator": "7.2.0",
+    "dts-bundle-generator": "^7.2.0",
     "workspace-tools": "^0.36.4",
     "esbuild": "^0.17.18"
   },

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/monorepo-fixture/jest.config.js
+++ b/packages/monorepo-fixture/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/monorepo-fixture/package.json
+++ b/packages/monorepo-fixture/package.json
@@ -15,7 +15,7 @@
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {
-    "execa": "5.1.1",
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*",
+    "execa": "^5.1.1"
   }
 }

--- a/packages/reporters/jest.config.js
+++ b/packages/reporters/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -27,7 +27,7 @@
     "gradient-string": "^2.0.1"
   },
   "devDependencies": {
-    "memory-streams": "0.1.3"
+    "memory-streams": "^0.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scheduler-types/jest.config.js
+++ b/packages/scheduler-types/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/scheduler-types/package.json
+++ b/packages/scheduler-types/package.json
@@ -19,7 +19,7 @@
     "@lage-run/target-graph": "^0.8.8"
   },
   "devDependencies": {
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scheduler/jest.config.js
+++ b/packages/scheduler/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@lage-run/scheduler-types": "^0.3.12",
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/target-graph/jest.config.js
+++ b/packages/target-graph/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -20,7 +20,7 @@
     "workspace-tools": "^0.36.4"
   },
   "devDependencies": {
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/worker-threads-pool/jest.config.js
+++ b/packages/worker-threads-pool/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require("monorepo-scripts/config/jest.config.js");
+module.exports = require("@lage-run/monorepo-scripts/config/jest.config.js");

--- a/packages/worker-threads-pool/package.json
+++ b/packages/worker-threads-pool/package.json
@@ -20,7 +20,7 @@
     "@lage-run/logger": "^1.3.0"
   },
   "devDependencies": {
-    "monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "monorepo-scripts",
+  "name": "@lage-run/monorepo-scripts",
   "version": "1.0.0",
   "private": true,
   "bin": {
@@ -7,11 +7,9 @@
   },
   "dependencies": {
     "@swc/core": "^1.3.14",
-    "@swc/jest": "^0.2.23",
     "depcheck": "^1.4.3",
     "jest": "^29.0.0",
     "ts-jest": "^29.0.0",
-    "typescript": "^5.0.3",
     "eslint": "^8.20.0",
     "eslint-plugin-file-extension-in-import-ts": "^1.0.1",
     "workspace-tools": "^0.36.4",

--- a/scripts/worker/depcheck.js
+++ b/scripts/worker/depcheck.js
@@ -5,7 +5,7 @@ const path = require("path");
 const depcheck = require("depcheck");
 
 module.exports = async function depcheckWorker({ target }) {
-  const ignored = ["monorepo-scripts", "@lage-run/docs"];
+  const ignored = ["@lage-run/monorepo-scripts", "@lage-run/docs"];
 
   // ignore the tooling package: monorepo-scripts
   if (ignored.includes(target.packageName)) {
@@ -15,7 +15,7 @@ module.exports = async function depcheckWorker({ target }) {
   const results = await depcheck(target.cwd, {
     ignoreBinPackage: true,
     ignorePatterns: ["node_modules", "dist", "lib", "build"],
-    ignoreMatches: ["yoga-layout-prebuilt", "glob-hasher"]
+    ignoreMatches: ["yoga-layout-prebuilt", "glob-hasher"],
   });
 
   let hasErrors = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,13 +676,6 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^27.4.2":
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz#7448fae15602ea95c828f5eceed35c202a820b31"
-  integrity sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==
-  dependencies:
-    "@jest/types" "^27.5.1"
-
 "@jest/environment@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.5.0.tgz#9152d56317c1fdb1af389c46640ba74ef0bb4c65"
@@ -816,17 +809,6 @@
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
-
-"@jest/types@^27.5.1":
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
-  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
 
 "@jest/types@^29.5.0":
   version "29.5.0"
@@ -1004,14 +986,6 @@
     "@swc/core-win32-ia32-msvc" "1.3.56"
     "@swc/core-win32-x64-msvc" "1.3.56"
 
-"@swc/jest@^0.2.23":
-  version "0.2.26"
-  resolved "https://registry.yarnpkg.com/@swc/jest/-/jest-0.2.26.tgz#6ef2d6d31869e3aaddc132603bc21f2e4c57cc5d"
-  integrity sha512-7lAi7q7ShTO3E5Gt1Xqf3pIhRbERxR1DUxvtVa9WKzIB+HGQ7wZP5sYx86zqnaEoKKGhmOoZ7gyW0IRu8Br5+A==
-  dependencies:
-    "@jest/create-cache-key-function" "^27.4.2"
-    jsonc-parser "^3.2.0"
-
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -1091,10 +1065,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@29.5.1":
-  version "29.5.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.1.tgz#83c818aa9a87da27d6da85d3378e5a34d2f31a47"
-  integrity sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==
+"@types/jest@^29.5.1":
+  version "29.5.4"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.4.tgz#9d0a16edaa009a71e6a71a999acd582514dab566"
+  integrity sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -1117,10 +1091,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@16.18.3":
-  version "16.18.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.3.tgz#d7f7ba828ad9e540270f01ce00d391c54e6e0abc"
-  integrity sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==
+"@types/node@*", "@types/node@^16.18.3":
+  version "16.18.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.25.tgz#8863940fefa1234d3fcac7a4b7a48a6c992d67af"
+  integrity sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1158,13 +1132,6 @@
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
-
-"@types/yargs@^16.0.0":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.5.tgz#12cc86393985735a283e387936398c2f9e5f88e3"
-  integrity sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.22"
@@ -1549,7 +1516,7 @@ backfill-cache@^5.7.1:
     p-limit "^3.0.0"
     tar-fs "^2.1.0"
 
-backfill-config@^6.3.1, backfill-config@^6.4.1:
+backfill-config@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/backfill-config/-/backfill-config-6.4.1.tgz#b85afd0a8acc0c9f04f4eb177e8d239dc4a2502e"
   integrity sha512-u4394nK6W/GfsAEKSXxdyVhcmQcDb36YztINEKI5mpsd7NjTqnxJVkBgTo5YetbomL/7RU3/ROiwXuv2nkbqyA==
@@ -1842,10 +1809,10 @@ combined-stream@^1.0.6, combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@10.0.0, commander@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
-  integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
+commander@10.0.1, commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@^2.18.0:
   version "2.20.3"
@@ -1882,10 +1849,10 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.0.0.tgz#e9feae014eab580f858f8a0288f38997a7bebe97"
-  integrity sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==
+cosmiconfig@8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
+  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
   dependencies:
     import-fresh "^3.2.1"
     js-yaml "^4.1.0"
@@ -2018,7 +1985,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dts-bundle-generator@7.2.0:
+dts-bundle-generator@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/dts-bundle-generator/-/dts-bundle-generator-7.2.0.tgz#1a06f621e33399e38c8968bbd71d65ab577e5327"
   integrity sha512-pHjRo52hvvLDRijzIYRTS9eJR7vAOs3gd/7jx+7YVnLU8ay3yPUWGtHXPtuMBSlJYk/s4nq1SvXObDCZVguYMg==
@@ -2263,7 +2230,7 @@ events@^3.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@5.1.1, execa@^5.0.0, execa@^5.1.1:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -2297,11 +2264,6 @@ exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
-
-expect-more@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/expect-more/-/expect-more-1.3.0.tgz#fcc6e7477e36d91194d550684bf733a88228aaff"
-  integrity sha512-HnXT5nJb9V3DMnr5RgA1TiKbu5kRaJ0GD1JkuhZvnr1Qe3HJq+ESnrcl/jmVUZ8Ycnl3Sp0OTYUhmO36d2+zow==
 
 expect@^29.0.0, expect@^29.5.0:
   version "29.5.0"
@@ -2454,20 +2416,15 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fp-ts@2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.13.1.tgz#1bf2b24136cca154846af16752dc29e8fa506f2a"
-  integrity sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ==
-
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
-  integrity sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==
+fs-extra@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -2536,7 +2493,7 @@ get-stream@^6.0.0, get-stream@^6.0.1:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-gh-pages@4.0.0:
+gh-pages@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-4.0.0.tgz#bd7447bab7eef008f677ac8cc4f6049ab978f4a6"
   integrity sha512-p8S0T3aGJc68MtwOcZusul5qPSNZCalap3NWbhRUZYu1YOdp+EjZ+4kPmRM8h3NNRdqw00yuevRjlkuSzCn7iQ==
@@ -2722,7 +2679,7 @@ human-signals@^4.3.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.0.tgz#2095c3cd5afae40049403d4b811235b03879db50"
   integrity sha512-zyzVyMjpGBX2+6cDVZeFPCdtOtdsxOeseRhB9tkQ6xXmGUNrcnBzdEKPy3VPNYz+4gy1oukVOXcrJCunSyc6QQ==
 
-husky@8.0.3:
+husky@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
@@ -3353,11 +3310,6 @@ json5@^2.1.3, json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
-  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
-
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -3418,10 +3370,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lint-staged@13.2.0:
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.0.tgz#b7abaf79c91cd36d824f17b23a4ce5209206126a"
-  integrity sha512-GbyK5iWinax5Dfw5obm2g2ccUiZXNGtAS4mCbJ0Lv4rq6iEtfBSjOYdcbOtAIFtM114t0vdpViDDetjVTSd8Vw==
+lint-staged@^13.2.0:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.2.tgz#5e711d3139c234f73402177be2f8dd312e6508ca"
+  integrity sha512-71gSwXKy649VrSU09s10uAT0rWCcY3aewhMaHyl2N84oBk4Xs9HgxvUp3AYu+bNsK4NrOYYxvSgg7FyGJ+jGcA==
   dependencies:
     chalk "5.2.0"
     cli-truncate "^3.1.0"
@@ -3435,7 +3387,7 @@ lint-staged@13.2.0:
     object-inspect "^1.12.3"
     pidtree "^0.6.0"
     string-argv "^0.3.1"
-    yaml "^2.2.1"
+    yaml "^2.2.2"
 
 listr2@^5.0.7:
   version "5.0.8"
@@ -3537,7 +3489,7 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-memory-streams@0.1.3:
+memory-streams@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/memory-streams/-/memory-streams-0.1.3.tgz#d9b0017b4b87f1d92f55f2745c9caacb1dc93ceb"
   integrity sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==
@@ -3584,10 +3536,10 @@ mimic-fn@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
-minimatch@6.1.6:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-6.1.6.tgz#5384bb324be5b5dae12a567c03d22908febd0ddd"
-  integrity sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==
+minimatch@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-6.2.0.tgz#2b70fd13294178c69c04dfc05aebdb97a4e79e42"
+  integrity sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -3814,7 +3766,7 @@ parse-url@^8.1.0:
   dependencies:
     parse-path "^7.0.0"
 
-patch-package@6.5.1:
+patch-package@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.5.1.tgz#3e5d00c16997e6160291fee06a521c42ac99b621"
   integrity sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==
@@ -3934,10 +3886,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@2.8.6:
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.6.tgz#5c174b29befd507f14b83e3c19f83fdc0e974b71"
-  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
+prettier@^2.8.6:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^29.0.0, pretty-format@^29.5.0:
   version "29.5.0"
@@ -4165,10 +4117,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
-semver@7.3.8, semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@7.5.0, semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
+  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -4397,21 +4349,21 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-syncpack@8.5.14:
-  version "8.5.14"
-  resolved "https://registry.yarnpkg.com/syncpack/-/syncpack-8.5.14.tgz#f820ab59b68dfc624ea984a180d331752e02a01f"
-  integrity sha512-+ESXgFXgLEievTVui2TQ/ejdPSX1hb+EXZYSrZfNOoFT2IvaAzGT9OQfiXYjka7ao3fRru9pRtsFoWTy1vyXCQ==
+syncpack@^9.0.0:
+  version "9.8.6"
+  resolved "https://registry.yarnpkg.com/syncpack/-/syncpack-9.8.6.tgz#edc06ea03295773165fb5086bb2655be03e5f094"
+  integrity sha512-4S4cUoKK9WenA/Wdk9GvlekzPR9PxC7sqcsUIsK4ypsa/pIYv8Ju1vxGNvp6Y1yI2S9EdCk0QJsB3/wRB8XYVw==
   dependencies:
     chalk "4.1.2"
-    commander "10.0.0"
-    cosmiconfig "8.0.0"
-    expect-more "1.3.0"
-    fp-ts "2.13.1"
-    fs-extra "11.1.0"
+    commander "10.0.1"
+    cosmiconfig "8.1.3"
+    fs-extra "11.1.1"
     glob "8.1.0"
-    minimatch "6.1.6"
+    minimatch "6.2.0"
     read-yaml-file "2.1.0"
-    semver "7.3.8"
+    semver "7.5.0"
+    tightrope "0.1.0"
+    zod "3.21.4"
 
 tar-fs@^2.1.0:
   version "2.1.1"
@@ -4452,6 +4404,11 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+tightrope@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tightrope/-/tightrope-0.1.0.tgz#f734fba76bd3472cc88884e4bd4bf109e5f0b051"
+  integrity sha512-HHHNYdCAIYwl1jOslQBT455zQpdeSo8/A346xpIb/uuqhSg+tCvYNsP5f11QW+z9VZ3vSX8YIfzTApjjuGH63w==
 
 tinycolor2@^1.0.0:
   version "1.6.0"
@@ -4530,7 +4487,7 @@ ts-jest@^29.0.0:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-node@10.9.1:
+ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -4593,10 +4550,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@>=4.5.2, typescript@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
-  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
+typescript@>=4.5.2, typescript@~5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -4786,10 +4743,10 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
-  integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
+yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^20.2.2:
   version "20.2.9"
@@ -4836,3 +4793,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
Due to [Renovate config changes](https://github.com/microsoft/m365-renovate-config#dependency-version-update-strategy), we can use ranges for `devDependencies` again.

Also:
- Fix the syncpack setup
- Rename the `monorepo-scripts` package to be scoped (there have been false-positive security reports about unscoped local package names in the past)
- Enable grouped change files