### PR TITLE
Fix progress reporter

### DIFF
--- a/change/@lage-run-reporters-b797d93e-6677-4f3c-97cc-452aec9ecc3a.json
+++ b/change/@lage-run-reporters-b797d93e-6677-4f3c-97cc-452aec9ecc3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "reporting \"abort\" status for \"queued\" or \"running\" tasks when abortSignal is received",
+  "packageName": "@lage-run/reporters",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/reporters/src/ProgressReporter.ts
+++ b/packages/reporters/src/ProgressReporter.ts
@@ -128,7 +128,15 @@ export class ProgressReporter implements Reporter {
 
   summarize(schedulerRunSummary: SchedulerRunSummary) {
     const { targetRuns, targetRunByStatus, duration } = schedulerRunSummary;
-    const { failed, aborted, skipped, success, pending } = targetRunByStatus;
+    const { failed, aborted, skipped, success, pending, running, queued } = targetRunByStatus;
+
+    // If we are printing summary, and there are still some running / queued tasks - report them as aborted
+    for (const wrappedTarget of running.concat(queued)) {
+      const reporterTask = this.tasks.get(wrappedTarget);
+      if (reporterTask) {
+        reporterTask.complete({ status: "abort" });
+      }
+    }
 
     const statusColorFn: {
       [status in TargetStatus]: chalk.Chalk;


### PR DESCRIPTION
Progress reporter currently hangs because aborts are not being reported to the underlying TaskReporter