### PR TITLE
Update @ms-cloudpack/task-reporter to fix issue

### DIFF
--- a/change/@lage-run-reporters-16c106e8-41f9-421d-949d-5822ba9e248e.json
+++ b/change/@lage-run-reporters-16c106e8-41f9-421d-949d-5822ba9e248e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @ms-cloudpack/task-reporter to fix \"performance is not defined\" issue",
+  "packageName": "@lage-run/reporters",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -21,7 +21,7 @@
     "@lage-run/scheduler-types": "^0.3.9",
     "@lage-run/target-graph": "^0.8.6",
     "@lage-run/format-hrtime": "^0.1.5",
-    "@ms-cloudpack/task-reporter": "^0.3.2",
+    "@ms-cloudpack/task-reporter": "^0.3.3",
     "chalk": "^4.0.0",
     "ansi-regex": "^5.0.1",
     "gradient-string": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,10 +958,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@ms-cloudpack/task-reporter@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@ms-cloudpack/task-reporter/-/task-reporter-0.3.2.tgz#26bc9129174cc039e819401304134a50e2279e56"
-  integrity sha512-2cP5424WQoCYLcclU49yswI2keMD7yCknfCO+4JmKYWLCQvOVjGs1W2CdjPSF+5AncFzaDJ+hHhFlXeluK65aw==
+"@ms-cloudpack/task-reporter@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@ms-cloudpack/task-reporter/-/task-reporter-0.3.3.tgz#a34fc2c9d249605a05914f4e68bd69c9b3983196"
+  integrity sha512-4Tf9ajafU5cHN11z7c43KL5Fl4bHaIUrg9oxIVdHDwLxwcN5z0om/dO3L+6ZUHwRr+MRvZQPBWmnUNZgaFJRxw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
Pick up microsoft/cloudpack#1047, fixing "performance is not defined" issue on Node 14 (so that it remain semi-supported)