### PR TITLE
Worker.on("error") handling (OOM, non memory leak case)

### DIFF
--- a/change/@lage-run-worker-threads-pool-1ae76b06-389e-4005-8883-98d864075dff.json
+++ b/change/@lage-run-worker-threads-pool-1ae76b06-389e-4005-8883-98d864075dff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "crash immediate on OOM in worker (not the memory leak case)",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/worker-threads-pool/src/ThreadWorker.ts
+++ b/packages/worker-threads-pool/src/ThreadWorker.ts
@@ -96,16 +96,18 @@ export class ThreadWorker extends EventEmitter implements IWorker {
     worker.on("message", msgHandler);
 
     const errHandler = (err) => {
-      Promise.all([this.#stdoutInfo.promise, this.#stderrInfo.promise]).then(() => {
-        // In case of an uncaught exception: Call the callback that was passed to
-        // `runTask` with the error.
-        if (this.#taskInfo) {
-          this.#taskInfo.done(err, null);
-        }
+      // We likely have a worker that has crashed - many instances of this is due to out-of-memory errors, we need to fail fast!
+      this.#stdoutInfo.resolve();
+      this.#stderrInfo.resolve();
 
+      // In case of an uncaught exception: Call the callback that was passed to
+      // `runTask` with the error, otherwise, just emit an "error" event (which will crash the process if not handled)
+      if (this.#taskInfo) {
+        this.#taskInfo.abortSignal?.removeEventListener("abort", this.#handleAbort);
+        this.#taskInfo.done(err, null);
+      } else {
         this.emit("error", err);
-        this.restart();
-      });
+      }
     };
 
     // The 'error' event is emitted if the worker thread throws an uncaught exception. In that case, the worker is terminated.
@@ -190,7 +192,9 @@ export class ThreadWorker extends EventEmitter implements IWorker {
   }
 
   #handleAbort() {
-    this.#worker.postMessage({ type: "abort" });
+    if (this.#worker) {
+      this.#worker.postMessage({ type: "abort" });
+    }
   }
 
   start(work: QueueItem, abortSignal?: AbortSignal) {


### PR DESCRIPTION
When a worker is working on a job and it goes over the memory limit, it emits the "error" event. We had been waiting on the "end marker" before stopping the job. This has caused stalling to happen. Rather, we need to simply fail fast and let user know that there is an out-of-memory problem in the worker. No additional work will be done.