### PR TITLE
Expose onMessage handler so that lage's consumers can communicate with the worker threads

### DIFF
--- a/change/@lage-run-scheduler-e50e644e-e7c3-4688-974b-713dfd863269.json
+++ b/change/@lage-run-scheduler-e50e644e-e7c3-4688-974b-713dfd863269.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add onMessage handler for workers",
+  "packageName": "@lage-run/scheduler",
+  "email": "altinokd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -12,6 +12,7 @@ import type { Pool } from "@lage-run/worker-threads-pool";
 import type { TargetRunnerPickerOptions } from "@lage-run/scheduler-types";
 import type { TargetHasher } from "@lage-run/hasher";
 import type { CacheOptions } from "@lage-run/cache";
+import type { MessagePort } from "worker_threads";
 
 export interface SimpleSchedulerOptions {
   logger: Logger;
@@ -30,6 +31,7 @@ export interface SimpleSchedulerOptions {
   pool?: Pool; // for testing
   workerIdleMemoryLimit: number; // in bytes
   hasher: TargetHasher;
+  onMessage?: (message: any, postMessage: MessagePort["postMessage"]) => void;
 }
 
 /**
@@ -129,6 +131,7 @@ export class SimpleScheduler implements TargetScheduler {
           abortController,
           pool,
           hasher: this.options.hasher,
+          onMessage: this.options.onMessage,
         });
       }
 

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -11,6 +11,7 @@ import type { TargetRun, TargetStatus } from "@lage-run/scheduler-types";
 import type { Target } from "@lage-run/target-graph";
 import type { Logger } from "@lage-run/logger";
 import type { TargetHasher } from "@lage-run/hasher";
+import type { MessagePort } from "worker_threads";
 
 export interface WrappedTargetOptions {
   root: string;
@@ -21,6 +22,7 @@ export interface WrappedTargetOptions {
   abortController: AbortController;
   pool: Pool;
   hasher: TargetHasher;
+  onMessage?: (message: any, postMessage: MessagePort["postMessage"]) => void;
 }
 
 interface WorkerResult {
@@ -211,6 +213,8 @@ export class WrappedTarget implements TargetRun {
             this.options.hasher.hash(target).then((hash) => {
               worker.postMessage({ type: "hash", hash });
             });
+          } else if (this.options.onMessage) {
+            this.options.onMessage(data, worker.postMessage);
           }
         };
 


### PR DESCRIPTION
Problem: Currently, there is no way to listen post-messages from worker threads in main thread

Solution: Adding `onMessage` which gives the posted message and a postMessage function to be able to reply back.
