### PR TITLE
Fix: Bind postMessage

### DIFF
--- a/change/@lage-run-scheduler-5d05a85f-ab8d-4a75-af7d-c329304d03bc.json
+++ b/change/@lage-run-scheduler-5d05a85f-ab8d-4a75-af7d-c329304d03bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bind postMessage when passing into onMessage",
+  "packageName": "@lage-run/scheduler",
+  "email": "altinokd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -214,7 +214,7 @@ export class WrappedTarget implements TargetRun {
               worker.postMessage({ type: "hash", hash });
             });
           } else if (this.options.onMessage) {
-            this.options.onMessage(data, worker.postMessage);
+            this.options.onMessage(data, worker.postMessage.bind(worker));
           }
         };
 

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -206,6 +206,8 @@ export class WrappedTarget implements TargetRun {
       { target },
       target.weight ?? 1,
       (worker, stdout, stderr) => {
+        const postMessage = worker.postMessage.bind(worker);
+
         msgHandler = (data) => {
           if (data.type === "log") {
             logger.log(data.level, data.msg, { target, threadId: worker.threadId });
@@ -214,7 +216,7 @@ export class WrappedTarget implements TargetRun {
               worker.postMessage({ type: "hash", hash });
             });
           } else if (this.options.onMessage) {
-            this.options.onMessage(data, worker.postMessage.bind(worker));
+            this.options.onMessage(data, postMessage);
           }
         };
 


### PR DESCRIPTION
## Issue
I'm getting the below error when I try to call `postMessage` parameter

```
/Users/altinokdarici/Repo/mscloudpack/node_modules/@lage-run/worker-threads-pool/lib/ThreadWorker.js:43
        throw new TypeError("attempted to " + action + " private field on non-instance");
              ^

TypeError: attempted to get private field on non-instance
    at _class_extract_field_descriptor (/Users/altinokdarici/Repo/mscloudpack/node_modules/@lage-run/worker-threads-pool/lib/ThreadWorker.js:43:15)
    at _class_private_field_get (/Users/altinokdarici/Repo/mscloudpack/node_modules/@lage-run/worker-threads-pool/lib/ThreadWorker.js:48:22)
    at postMessage (/Users/altinokdarici/Repo/mscloudpack/node_modules/@lage-run/worker-threads-pool/lib/ThreadWorker.js:156:9)
```

## Solution
We needed to bind it before passing it into it.