### PR TITLE
Dynamically creating workers when work comes in

### DIFF
--- a/change/@lage-run-worker-threads-pool-d94bb7f8-ed27-444b-b502-26119c403074.json
+++ b/change/@lage-run-worker-threads-pool-d94bb7f8-ed27-444b-b502-26119c403074.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Dynamic pooling by firing up 2 workers as a start, then adding new workers as work comes in",
+  "packageName": "@lage-run/worker-threads-pool",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/lage-d38f6b96-2ca7-4aa6-aaa8-17d51604ed1b.json
+++ b/change/lage-d38f6b96-2ca7-4aa6-aaa8-17d51604ed1b.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Dynamic pooling by firing up 2 workers as a start, then adding new workers as work comes in",
+  "type": "minor",
+  "packageName": "lage",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/worker-threads-pool/src/types/WorkerPoolOptions.ts
+++ b/packages/worker-threads-pool/src/types/WorkerPoolOptions.ts
@@ -1,6 +1,7 @@
 import type { WorkerOptions } from "worker_threads";
 
 export interface WorkerPoolOptions {
+  minWorkers?: number;
   maxWorkers?: number;
   script: string;
   workerIdleMemoryLimit?: number; // in bytes

--- a/packages/worker-threads-pool/tests/AggregatedPool.test.ts
+++ b/packages/worker-threads-pool/tests/AggregatedPool.test.ts
@@ -22,8 +22,8 @@ describe("AggregatedPool", () => {
     expect(group1Pool).toBeTruthy();
     expect(group2Pool).toBeTruthy();
     expect(group1Pool).not.toBe(group2Pool);
-    expect(group1Pool?.workers.length).toBe(5);
-    expect(group2Pool?.workers.length).toBe(5);
+    expect(group1Pool?.maxWorkers).toBe(5);
+    expect(group2Pool?.maxWorkers).toBe(5);
 
     expect(pool.defaultPool).toBeUndefined();
 
@@ -49,11 +49,12 @@ describe("AggregatedPool", () => {
     expect(group1Pool).toBeTruthy();
     expect(group2Pool).toBeTruthy();
     expect(group1Pool).not.toBe(group2Pool);
-    expect(group1Pool?.workers.length).toBe(2);
-    expect(group2Pool?.workers.length).toBe(3);
+
+    expect(group1Pool?.maxWorkers).toBe(2);
+    expect(group2Pool?.maxWorkers).toBe(3);
 
     expect(pool.defaultPool).toBeTruthy();
-    expect(pool.defaultPool?.workers.length).toBe(5);
+    expect(pool.defaultPool?.maxWorkers).toBe(5);
 
     await pool.close();
   });


### PR DESCRIPTION
It takes time to create workers. So, rather than creating all workers up front, we will start with 2 workers. Then new workers are created as the work pool is about to execute code.

Note that we are not current exposing a "minWorker" option for the end users yet. This capability isn't difficult to be exposed, but presents a bit of complexity that isn't truly needed (yet?)