### PR TITLE
Return value from workers

### DIFF
--- a/change/@lage-run-scheduler-8c9ad317-d85f-4682-ae83-c74d381f51b3.json
+++ b/change/@lage-run-scheduler-8c9ad317-d85f-4682-ae83-c74d381f51b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Return value from worker run functions as part of TargetRun.result object. Encapsulated status and result fields. Added a way to reset WrappedTarget",
+  "packageName": "@lage-run/scheduler",
+  "email": "altinokd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-scheduler-types-ba399186-2327-433c-a346-650ef5a60067.json
+++ b/change/@lage-run-scheduler-types-ba399186-2327-433c-a346-650ef5a60067.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added result to TargetRun. Made TargetRun, TargetRunner, SchedulerRunSummary, TargetScheduler generic to support type safe results",
+  "packageName": "@lage-run/scheduler-types",
+  "email": "altinokd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/scheduler-types/src/types/SchedulerRunSummary.ts
+++ b/packages/scheduler-types/src/types/SchedulerRunSummary.ts
@@ -7,9 +7,9 @@ export type TargetRunSummary = { [key in TargetStatus]-?: string[] };
 
 export type SchedulerRunResults = "success" | "failed";
 
-export interface SchedulerRunSummary {
+export interface SchedulerRunSummary<TTargetRunResult = unknown> {
   targetRunByStatus: TargetRunSummary;
-  targetRuns: Map<string, TargetRun>;
+  targetRuns: Map<string, TargetRun<TTargetRunResult>>;
   startTime: [number, number];
   duration: [number, number];
   results: SchedulerRunResults;

--- a/packages/scheduler-types/src/types/TargetRun.ts
+++ b/packages/scheduler-types/src/types/TargetRun.ts
@@ -1,11 +1,12 @@
 import type { Target } from "@lage-run/target-graph";
 import type { TargetStatus } from "./TargetStatus.js";
 
-export interface TargetRun {
+export interface TargetRun<TResult = unknown> {
   queueTime: [number, number];
   startTime: [number, number];
   duration: [number, number];
   target: Target;
   status: TargetStatus;
   threadId: number;
+  result?: TResult;
 }

--- a/packages/scheduler-types/src/types/TargetRunner.ts
+++ b/packages/scheduler-types/src/types/TargetRunner.ts
@@ -8,6 +8,6 @@ export interface TargetRunnerOptions {
 
 export interface TargetRunner {
   shouldRun(target: Target): Promise<boolean>;
-  run(options: TargetRunnerOptions): Promise<void>;
+  run(options: TargetRunnerOptions): Promise<unknown>;
   cleanup?(): Promise<void> | void;
 }

--- a/packages/scheduler-types/src/types/TargetScheduler.ts
+++ b/packages/scheduler-types/src/types/TargetScheduler.ts
@@ -1,9 +1,9 @@
 import type { TargetGraph } from "@lage-run/target-graph";
 import type { SchedulerRunSummary } from "./SchedulerRunSummary.js";
 
-export interface TargetScheduler {
+export interface TargetScheduler<TTargetRunResult> {
   abort(): void;
-  run(root: string, targetGraph: TargetGraph, shouldRerun: boolean): Promise<SchedulerRunSummary>;
+  run(root: string, targetGraph: TargetGraph, shouldRerun: boolean): Promise<SchedulerRunSummary<TTargetRunResult>>;
   onTargetChange?(targetId: string): void;
   cleanup(): void;
 }

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -75,6 +75,11 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
 
   constructor(public options: WrappedTargetOptions) {
     this.target = options.target;
+
+    if (this.target.id === getStartTargetId()) {
+      this.#status = "success";
+      return;
+    }
   }
 
   onQueued() {
@@ -143,10 +148,6 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
 
   async run() {
     const { target, logger, shouldCache, abortController, root } = this.options;
-    if (target.id === getStartTargetId()) {
-      this.onComplete();
-      return;
-    }
 
     const abortSignal = abortController.signal;
 

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -8,7 +8,7 @@ import { mkdir, writeFile } from "fs/promises";
 
 import type { Pool } from "@lage-run/worker-threads-pool";
 import type { TargetRun, TargetStatus } from "@lage-run/scheduler-types";
-import type { Target } from "@lage-run/target-graph";
+import { getStartTargetId, type Target } from "@lage-run/target-graph";
 import type { Logger } from "@lage-run/logger";
 import type { TargetHasher } from "@lage-run/hasher";
 import type { MessagePort } from "worker_threads";
@@ -25,11 +25,12 @@ export interface WrappedTargetOptions {
   onMessage?: (message: any, postMessage: MessagePort["postMessage"]) => void;
 }
 
-interface WorkerResult {
+export interface WorkerResult {
   stdoutBuffer: string;
   stderrBuffer: string;
   skipped: boolean;
   hash: string;
+  value: unknown;
 }
 
 /**
@@ -39,15 +40,22 @@ interface WorkerResult {
  * 3. Abort signal
  * 4. Continue on error
  */
-export class WrappedTarget implements TargetRun {
+export class WrappedTarget implements TargetRun<WorkerResult> {
+  #status: TargetStatus = "pending";
+  #result: WorkerResult | undefined;
   queueTime: [number, number] = [0, 0];
   startTime: [number, number] = [0, 0];
   duration: [number, number] = [0, 0];
   target: Target;
-  status: TargetStatus;
   threadId = 0;
 
-  result: Promise<WorkerResult> | undefined;
+  get result() {
+    return this.#result;
+  }
+
+  get status() {
+    return this.#status;
+  }
 
   get abortController() {
     return this.options.abortController;
@@ -58,25 +66,24 @@ export class WrappedTarget implements TargetRun {
   }
 
   get successful() {
-    return this.status === "skipped" || this.status === "success";
+    return this.#status === "skipped" || this.#status === "success";
   }
 
   get waiting() {
-    return this.status === "pending" || this.status === "queued";
+    return this.#status === "pending" || this.#status === "queued";
   }
 
   constructor(public options: WrappedTargetOptions) {
-    this.status = "pending";
     this.target = options.target;
   }
 
   onQueued() {
-    this.status = "queued";
+    this.#status = "queued";
     this.queueTime = process.hrtime();
   }
 
   onAbort() {
-    this.status = "aborted";
+    this.#status = "aborted";
     this.duration = process.hrtime(this.startTime);
     this.options.logger.info("", { target: this.target, status: "aborted", threadId: this.threadId });
   }
@@ -84,14 +91,14 @@ export class WrappedTarget implements TargetRun {
   onStart(threadId: number) {
     if (this.status !== "running") {
       this.threadId = threadId;
-      this.status = "running";
+      this.#status = "running";
       this.startTime = process.hrtime();
       this.options.logger.info("", { target: this.target, status: "running", threadId });
     }
   }
 
   onComplete() {
-    this.status = "success";
+    this.#status = "success";
     this.duration = process.hrtime(this.startTime);
     this.options.logger.info("", {
       target: this.target,
@@ -102,7 +109,7 @@ export class WrappedTarget implements TargetRun {
   }
 
   onFail() {
-    this.status = "failed";
+    this.#status = "failed";
     this.duration = process.hrtime(this.startTime);
     this.options.logger.info("", {
       target: this.target,
@@ -121,7 +128,7 @@ export class WrappedTarget implements TargetRun {
       this.duration = process.hrtime(this.startTime);
     }
 
-    this.status = "skipped";
+    this.#status = "skipped";
 
     if (hash) {
       this.options.logger.info("", {
@@ -136,6 +143,10 @@ export class WrappedTarget implements TargetRun {
 
   async run() {
     const { target, logger, shouldCache, abortController, root } = this.options;
+    if (target.id === getStartTargetId()) {
+      this.onComplete();
+      return;
+    }
 
     const abortSignal = abortController.signal;
 
@@ -146,23 +157,24 @@ export class WrappedTarget implements TargetRun {
     }
 
     try {
-      const result = await this.runInPool();
-      const cacheEnabled = target.cache && shouldCache && result.hash;
+      this.#result = await this.runInPool();
+
+      const cacheEnabled = target.cache && shouldCache && this.#result.hash;
       // Save output if cache is enabled & cache is hit
-      if (!result.skipped && cacheEnabled) {
-        const outputLocation = getLageOutputCacheLocation(root, result.hash);
+      if (!this.#result.skipped && cacheEnabled) {
+        const outputLocation = getLageOutputCacheLocation(root, this.#result.hash);
         const outputPath = path.dirname(outputLocation);
         await mkdir(outputPath, { recursive: true });
 
-        const output = `${result.stdoutBuffer}\n${result.stderrBuffer}`;
+        const output = `${this.#result.stdoutBuffer}\n${this.#result.stderrBuffer}`;
 
         await writeFile(outputLocation, output);
 
-        logger.verbose(`>> Saved cache - ${result.hash}`, { target });
+        logger.verbose(`>> Saved cache - ${this.#result.hash}`, { target });
       }
 
-      if (result.skipped) {
-        const { hash } = result;
+      if (this.#result.skipped) {
+        const { hash } = this.#result;
 
         const cachedOutputFile = getLageOutputCacheLocation(root, hash ?? "");
 
@@ -190,7 +202,7 @@ export class WrappedTarget implements TargetRun {
     }
   }
 
-  private async runInPool() {
+  private async runInPool(): Promise<WorkerResult> {
     const { target, logger, abortController, pool } = this.options;
     const abortSignal = abortController.signal;
 
@@ -202,7 +214,7 @@ export class WrappedTarget implements TargetRun {
 
     let msgHandler: (data: LogEntry<any> & { type: string }) => void;
 
-    this.result = pool.exec(
+    const result = await (pool.exec(
       { target },
       target.weight ?? 1,
       (worker, stdout, stderr) => {
@@ -249,11 +261,15 @@ export class WrappedTarget implements TargetRun {
         releaseStderr();
       },
       abortSignal
-    ) as Promise<WorkerResult>;
+    ) as Promise<{ value?: unknown; skipped: boolean; hash: string }>);
 
-    const result = await this.result;
-
-    return { stdoutBuffer: bufferStdout.buffer, stderrBuffer: bufferStderr.buffer, skipped: result?.skipped, hash: result?.hash };
+    return {
+      stdoutBuffer: bufferStdout.buffer,
+      stderrBuffer: bufferStderr.buffer,
+      skipped: result?.skipped,
+      hash: result?.hash,
+      value: result?.value,
+    };
   }
 
   /**
@@ -268,5 +284,13 @@ export class WrappedTarget implements TargetRun {
       target: this.target.id,
       status: this.status,
     };
+  }
+
+  /**
+   * Reset the state of this wrapped target.
+   */
+  reset() {
+    this.#result = undefined;
+    this.#status = "pending";
   }
 }

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -78,7 +78,6 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
 
     if (this.target.id === getStartTargetId()) {
       this.#status = "success";
-      return;
     }
   }
 

--- a/packages/scheduler/src/runners/WorkerRunner.ts
+++ b/packages/scheduler/src/runners/WorkerRunner.ts
@@ -72,7 +72,7 @@ export class WorkerRunner implements TargetRunner {
       throw new Error("WorkerRunner: worker script must export a function; you likely need to use `module.exports = function() {...}`");
     }
 
-    await runFn({ target, weight, taskArgs, abortSignal });
+    return await runFn({ target, weight, taskArgs, abortSignal });
   }
 
   async getScriptModule(target: Target) {

--- a/packages/scheduler/src/workers/targetWorker.ts
+++ b/packages/scheduler/src/workers/targetWorker.ts
@@ -93,9 +93,10 @@ async function setup(options: TargetWorkerDataOptions) {
 
     const cacheEnabled = data.target.cache && options.shouldCache && hash;
 
+    let value: unknown = undefined;
     if (!cacheHit || !cacheEnabled) {
       const runner = await runnerPicker.pick(data.target);
-      await runner.run({
+      value = await runner.run({
         ...data,
         abortSignal,
       });
@@ -106,6 +107,7 @@ async function setup(options: TargetWorkerDataOptions) {
     return {
       skipped: cacheHit,
       hash,
+      value,
     };
   }
 


### PR DESCRIPTION
- Added result to TargetRun
- Return value from worker run functions as part of TargetRun.result object. 
- Encapsulated status and result fields. 
- Added a way to reset WrappedTarget
- Made TargetRun, TargetRunner, SchedulerRunSummary, TargetScheduler generic to support type safe results

## Consuming result.value
```ts
const target = createBundleTarget(scripts, bundleRequest);

const targetGraphBuilder = new targetGraph.TargetGraphBuilder();
targetGraphBuilder.addTarget(target);
const graph = targetGraphBuilder.build();

const { targetRuns } = await this.#scheduler.run(target.cwd, graph, options.rerun);
const value = targetRuns.get(target.id)?.result?.value;
if (value) {
   console.log(value);
}


```
