### PR TITLE
Log globalInputHash in TargetHasher init

### DIFF
--- a/packages/cli/src/cache/createCacheProvider.ts
+++ b/packages/cli/src/cache/createCacheProvider.ts
@@ -11,13 +11,14 @@ interface CreateCacheOptions {
 }
 
 export async function createCache(options: CreateCacheOptions) {
-  const { cacheOptions, root, cliArgs } = options;
+  const { cacheOptions, root, cliArgs, logger } = options;
 
   const hasher = new TargetHasher({
     root,
     environmentGlob: cacheOptions?.environmentGlob ?? [],
     cacheKey: cacheOptions?.cacheKey,
     cliArgs,
+    logger,
   });
 
   await hasher.initialize();

--- a/packages/hasher/src/TargetHasher.ts
+++ b/packages/hasher/src/TargetHasher.ts
@@ -19,6 +19,7 @@ import { hashStrings } from "./hashStrings.js";
 import { resolveInternalDependencies } from "./resolveInternalDependencies.js";
 import { resolveExternalDependencies } from "./resolveExternalDependencies.js";
 import { FileHasher } from "./FileHasher.js";
+import { Logger } from "@lage-run/logger";
 import { PackageTree } from "./PackageTree.js";
 
 export interface TargetHasherOptions {
@@ -26,6 +27,7 @@ export interface TargetHasherOptions {
   environmentGlob: string[];
   cacheKey?: string;
   cliArgs?: string[];
+  logger?: Logger;
 }
 
 export interface TargetManifest {
@@ -50,6 +52,7 @@ export interface TargetManifest {
  * Currently, it encapsulates the use of `backfill-hasher` to generate a hash.
  */
 export class TargetHasher {
+  logger: Logger | undefined;
   fileHasher: FileHasher;
   packageTree: PackageTree | undefined;
 
@@ -136,8 +139,8 @@ export class TargetHasher {
   }
 
   constructor(private options: TargetHasherOptions) {
-    const { root } = options;
-
+    const { root, logger } = options;
+    this.logger = logger;
     this.fileHasher = new FileHasher({
       root,
     });
@@ -185,6 +188,11 @@ export class TargetHasher {
     ]);
 
     await this.initializedPromise;
+
+    if (this.logger !== undefined) {
+      const globalInputsHash = hashStrings(Object.values(this.globalInputsHash ?? {}));
+      this.logger.silly(`Global inputs hash: ${globalInputsHash}`);
+    }
   }
 
   async hash(target: Target): Promise<string> {


### PR DESCRIPTION
Simple addition of a logger call in TargetHasher to log a hash of the environmentGlob file hashes. 

I would like to add this to help debug environmentalGlob differences and remote cache misses when using remote cache uploaded in CI-pipelines on a local machine build (Assuming environmental differences between CI agents and dev machine)

Output: 
`> yarn lage build --log-level=silly --concurrency=7 --reporter=npmLog`
`Running with 7 workers`
`Global inputs hash: 5409e2bb9a9f6a8c0a5823c42b176e328dbbf92c`
`Workers pools created:  default (7)`
`Max Worker Memory Usage: 0.00 MB`