### PR TITLE
Log globalInputHash in TargetHasher init

### DIFF
--- a/change/@lage-run-cli-eb1ddb83-c353-44ad-b596-bd377c4d6b63.json
+++ b/change/@lage-run-cli-eb1ddb83-c353-44ad-b596-bd377c4d6b63.json
@@ -1,8 +1,6 @@
 {
   "type": "patch",
-  "comment": {
-    "title": ""
-  },
+  "comment": "Passing logger object to TargetHasher for hasher init logging",
   "packageName": "@lage-run/cli",
   "email": "brunoru@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@lage-run-cli-eb1ddb83-c353-44ad-b596-bd377c4d6b63.json
+++ b/change/@lage-run-cli-eb1ddb83-c353-44ad-b596-bd377c4d6b63.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": ""
+  },
+  "packageName": "@lage-run/cli",
+  "email": "brunoru@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-hasher-76184c0c-d5ca-4cdf-bd11-c487e84d3b4e.json
+++ b/change/@lage-run-hasher-76184c0c-d5ca-4cdf-bd11-c487e84d3b4e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": ""
+  },
+  "packageName": "@lage-run/hasher",
+  "email": "brunoru@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-hasher-76184c0c-d5ca-4cdf-bd11-c487e84d3b4e.json
+++ b/change/@lage-run-hasher-76184c0c-d5ca-4cdf-bd11-c487e84d3b4e.json
@@ -1,8 +1,6 @@
 {
   "type": "patch",
-  "comment": {
-    "title": ""
-  },
+  "comment": "Added logging in TargetHasher, now logs hash of glob-hashed files for global input hash comparison",
   "packageName": "@lage-run/hasher",
   "email": "brunoru@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/cli/src/cache/createCacheProvider.ts
+++ b/packages/cli/src/cache/createCacheProvider.ts
@@ -11,13 +11,14 @@ interface CreateCacheOptions {
 }
 
 export async function createCache(options: CreateCacheOptions) {
-  const { cacheOptions, root, cliArgs } = options;
+  const { cacheOptions, root, cliArgs, logger } = options;
 
   const hasher = new TargetHasher({
     root,
     environmentGlob: cacheOptions?.environmentGlob ?? [],
     cacheKey: cacheOptions?.cacheKey,
     cliArgs,
+    logger,
   });
 
   await hasher.initialize();

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@lage-run/target-graph": "^0.8.6",
+    "@lage-run/logger": "^1.3.0",
     "execa": "5.1.1",
     "workspace-tools": "0.30.0",
     "fast-glob": "3.2.12",

--- a/packages/hasher/src/TargetHasher.ts
+++ b/packages/hasher/src/TargetHasher.ts
@@ -19,6 +19,7 @@ import { hashStrings } from "./hashStrings.js";
 import { resolveInternalDependencies } from "./resolveInternalDependencies.js";
 import { resolveExternalDependencies } from "./resolveExternalDependencies.js";
 import { FileHasher } from "./FileHasher.js";
+import type { Logger } from "@lage-run/logger";
 import { PackageTree } from "./PackageTree.js";
 
 export interface TargetHasherOptions {
@@ -26,6 +27,7 @@ export interface TargetHasherOptions {
   environmentGlob: string[];
   cacheKey?: string;
   cliArgs?: string[];
+  logger?: Logger;
 }
 
 export interface TargetManifest {
@@ -50,6 +52,7 @@ export interface TargetManifest {
  * Currently, it encapsulates the use of `backfill-hasher` to generate a hash.
  */
 export class TargetHasher {
+  logger: Logger | undefined;
   fileHasher: FileHasher;
   packageTree: PackageTree | undefined;
 
@@ -136,7 +139,8 @@ export class TargetHasher {
   }
 
   constructor(private options: TargetHasherOptions) {
-    const { root } = options;
+    const { root, logger } = options;
+    this.logger = logger;
 
     this.fileHasher = new FileHasher({
       root,
@@ -185,6 +189,11 @@ export class TargetHasher {
     ]);
 
     await this.initializedPromise;
+
+    if (this.logger !== undefined) {
+      const globalInputsHash = hashStrings(Object.values(this.globalInputsHash ?? {}));
+      this.logger.verbose(`Global inputs hash: ${globalInputsHash}`);
+    }
   }
 
   async hash(target: Target): Promise<string> {


### PR DESCRIPTION
Simple addition of a logger call in TargetHasher to log a hash of the environmentGlob file hashes.

I would like to add this to help debug environmentalGlob differences and remote cache misses when using remote cache uploaded in CI-pipelines on a local machine build (Assuming environmental differences between CI agents and dev machine)

Output:
> yarn lage build --log-level=silly --concurrency=7
Running with 7 workers
Global inputs hash: 5409e2bb9a9f6a8c0a5823c42b176e328dbbf92c
Workers pools created:  default (7)
Max Worker Memory Usage: 0.00 MB