### PR TITLE
Adding file level logging of input file glob hashes (Silly logging)

### DIFF
--- a/change/@lage-run-hasher-0f260ee4-57af-4235-960d-d86ed80e935a.json
+++ b/change/@lage-run-hasher-0f260ee4-57af-4235-960d-d86ed80e935a.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": ""
+  },
+  "packageName": "@lage-run/hasher",
+  "email": "brunoru@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@lage-run-hasher-0f260ee4-57af-4235-960d-d86ed80e935a.json
+++ b/change/@lage-run-hasher-0f260ee4-57af-4235-960d-d86ed80e935a.json
@@ -1,9 +1,0 @@
-{
-  "type": "patch",
-  "comment": {
-    "title": "Adding in file level global input file logging to JSON log file"
-  },
-  "packageName": "@lage-run/hasher",
-  "email": "brunoru@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@lage-run-hasher-0f260ee4-57af-4235-960d-d86ed80e935a.json
+++ b/change/@lage-run-hasher-0f260ee4-57af-4235-960d-d86ed80e935a.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": {
-    "title": ""
+    "title": "Adding in file level global input file logging to JSON log file"
   },
   "packageName": "@lage-run/hasher",
   "email": "brunoru@microsoft.com",

--- a/change/@lage-run-hasher-95dbb6d1-cfd5-403f-8035-7453cbe7dd4b.json
+++ b/change/@lage-run-hasher-95dbb6d1-cfd5-403f-8035-7453cbe7dd4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Log file level input file hashes to silly logs",
+  "packageName": "@lage-run/hasher",
+  "email": "brunoru@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/docs/Reference/cli.md
+++ b/docs/docs/Reference/cli.md
@@ -35,7 +35,6 @@ Usage: `lage [run] <command1> [command2...commandN] [options]  run commands`
   --reset-cache                                     resets the cache, filling it after a run
   --skip-local-cache                                skips caching locally
   --profile [profile]                               writes a run profile into a file that can be processed by Chromium devtool
-  --global-inputs-log-file                          logs global input file hashes (of globbed environmentGlob files) into a JSON file (e.g. --globalInputsLogFile ./logs/globalInputHashes.json)
   --nodearg <nodeArg>                               arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable)
   --continue                                        continues the run even on error
   -h, --help                                        display help for command

--- a/docs/docs/Reference/cli.md
+++ b/docs/docs/Reference/cli.md
@@ -35,7 +35,8 @@ Usage: `lage [run] <command1> [command2...commandN] [options]  run commands`
   --reset-cache                                     resets the cache, filling it after a run
   --skip-local-cache                                skips caching locally
   --profile [profile]                               writes a run profile into a file that can be processed by Chromium devtool
-  --nodearg <nodeArg>                               arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable
+  --global-inputs-log-file                          logs global input file hashes (of globbed environmentGlob files) into a JSON file (e.g. --globalInputsLogFile ./logs/globalInputHashes.json)
+  --nodearg <nodeArg>                               arguments to be passed to node (e.g. --nodearg="--max_old_space_size=1234 --heap-prof" - set via "NODE_OPTIONS" environment variable)
   --continue                                        continues the run even on error
   -h, --help                                        display help for command
 ```

--- a/packages/hasher/src/TargetHasher.ts
+++ b/packages/hasher/src/TargetHasher.ts
@@ -194,13 +194,8 @@ export class TargetHasher {
       const globalInputsHash = hashStrings(Object.values(this.globalInputsHash ?? {}));
       this.logger.verbose(`Global inputs hash: ${globalInputsHash}`);
       // Log global input hashs to log file
-      if (this.options.cliArgs && this.options.cliArgs.includes("--global-inputs-log-file")) {
-        const logFilePathIndex = this.options.cliArgs.indexOf("--global-inputs-log-file") + 1;
-        const logFilePath = this.options.cliArgs[logFilePathIndex];
-        const globalInputsHashJson = JSON.stringify(this.globalInputsHash, null, 2);
-        await fs.promises.writeFile(logFilePath, globalInputsHashJson);
-        this.logger.silly(`\tFile hashes logged to ${logFilePath}`);
-      }
+      const globalInputsHashJson = JSON.stringify(this.globalInputsHash, null, 2);
+      this.logger.silly(globalInputsHashJson);
     }
   }
 

--- a/packages/hasher/src/TargetHasher.ts
+++ b/packages/hasher/src/TargetHasher.ts
@@ -193,6 +193,14 @@ export class TargetHasher {
     if (this.logger !== undefined) {
       const globalInputsHash = hashStrings(Object.values(this.globalInputsHash ?? {}));
       this.logger.verbose(`Global inputs hash: ${globalInputsHash}`);
+      // Log global input hashs to log file
+      if (this.options.cliArgs && this.options.cliArgs.includes("--global-inputs-log-file")) {
+        const logFilePathIndex = this.options.cliArgs.indexOf("--global-inputs-log-file") + 1;
+        const logFilePath = this.options.cliArgs[logFilePathIndex];
+        const globalInputsHashJson = JSON.stringify(this.globalInputsHash, null, 2);
+        await fs.promises.writeFile(logFilePath, globalInputsHashJson);
+        this.logger.silly(`\tFile hashes logged to ${logFilePath}`);
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds the ability to output the file hashes for all files globbed from the `environmentGlob` patterns to the console (Silly log level). 

Example: 

`lage build --log-level=silly--concurrency=7`
Output: 

```
> lage build --log-level=verbose --concurrency=7
Running with 7 workers
Global inputs hash: 1d9559e8dabe5712dc31aa28c5a347d0734d6e82
{
    "repo/src/sourcefile.js" : "8636f28d8d9310adc08b36f111ee8d4664f2c9de",
    "repo/generated/generated.json": "91b945fdef50a2fc32b558afe4a1355f88588941"
}
Workers pools created:  default (7)
Max Worker Memory Usage: 0.00 MB
stats build ➔ start
...
```