### PR TITLE
Converting getConfig to async

### DIFF
--- a/change/lage-f48c750f-4347-4465-8dba-227bdbde4be5.json
+++ b/change/lage-f48c750f-4347-4465-8dba-227bdbde4be5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Converting getConfig to async",
+  "packageName": "lage",
+  "email": "71752651+unpervertedkid@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/src/cli.ts
+++ b/packages/lage/src/cli.ts
@@ -9,38 +9,41 @@ import { version } from "./command/version";
 import { cache } from "./command/cache";
 import { graph } from "./command/graph";
 
-// Parse CLI args
-const cwd = process.cwd();
-try {
-  const config = getConfig(cwd);
-  const reporters = initReporters(config);
+async function runTaskRunner() {
+  const cwd = process.cwd();
+  try {
+    const config = await getConfig(cwd);
+    const reporters = initReporters(config);
 
-  switch (config.command[0]) {
-    case "cache":
-      cache(cwd, config);
-      break;
+    switch (config.command[0]) {
+      case "cache":
+        cache(cwd, config);
+        break;
 
-    case "init":
-      init(cwd);
-      break;
+      case "init":
+        init(cwd);
+        break;
 
-    case "info":
-      info(cwd, config);
-      break;
+      case "info":
+        info(cwd, config);
+        break;
 
-    case "graph":
-      graph(cwd);
-      break;
+      case "graph":
+        graph(cwd);
+        break;
 
-    case "version":
-      version();
-      break;
+      case "version":
+        version();
+        break;
 
-    default:
-      logger.info(`Lage task runner - let's make it`);
-      run(cwd, config, reporters);
-      break;
+      default:
+        logger.info(`Lage task runner - let's make it`);
+        run(cwd, config, reporters);
+        break;
+    }
+  } catch (e) {
+    showHelp(e && (e as any).message);
   }
-} catch (e) {
-  showHelp(e && (e as any).message);
 }
+
+runTaskRunner();

--- a/packages/lage/src/config/getConfig.ts
+++ b/packages/lage/src/config/getConfig.ts
@@ -1,10 +1,10 @@
 import { Config } from "../types/Config";
-import { cosmiconfigSync } from "cosmiconfig";
+import { cosmiconfig } from "cosmiconfig";
 import { getWorkspaceRoot } from "workspace-tools";
 import { parseArgs, arrifyArgs, getPassThroughArgs, validateInput } from "../args";
 import os from "os";
 
-export function getConfig(cwd: string): Config {
+export async function getConfig(cwd: string): Promise<Config> {
   // Verify presence of git
   const root = getWorkspaceRoot(cwd);
   if (!root) {
@@ -13,7 +13,7 @@ export function getConfig(cwd: string): Config {
 
   // Search for lage.config.js file
   const ConfigModuleName = "lage";
-  const configResults = cosmiconfigSync(ConfigModuleName).search(root || cwd);
+  const configResults = await cosmiconfig(ConfigModuleName).search(root || cwd);
 
   // Parse CLI args
   const parsedArgs = parseArgs();


### PR DESCRIPTION
## Problem
In lage v1, getConfig reads lage configs synchronously using cosmiconfigSync.
This means that you can't pass in a config asyncronously in lageConfig ie :
```js
async function getConfig() {
 let someConfig = await someAsyncFunction();
 const config = {
.....
...someConfig
};
return config;
}

const config = getConfig();
module.exports = config;
```
## Solution
Using cosmiconfig instead of cosmiconfigSync to get the config.

