### PR TITLE
docs: fix note admonitions

### DIFF
--- a/docs/docs/Tutorial/remote-cache.md
+++ b/docs/docs/Tutorial/remote-cache.md
@@ -79,7 +79,7 @@ Create a secret named "BACKFILL_CACHE_PROVIDER_OPTIONS":
 {"connectionString":"the **read-write** connection string","container":"CONTAINER NAME"}
 ```
 
-::Note
+:::note
 
 ### Uploading cache to a remote is _not_ the default
 
@@ -91,4 +91,4 @@ Lage picks up your `.env` file contents using [`dotenv`](https://www.npmjs.com/p
 
 Need to access environment variables from the `.env` file in your application? You would need to setup a mechanism to inject them. Try using utilities like `dotenv` (for Node.js) or [`env-cmd`](https://www.npmjs.com/package/env-cmd) (for executing commands).
 
-::
+:::


### PR DESCRIPTION
This PR fixes the admonitions to use the correct docusaurus syntax:
https://docusaurus.io/docs/markdown-features/admonitions

Before:
<img width="1102" alt="image" src="https://github.com/microsoft/lage/assets/12711091/2c130c2f-c9aa-45ee-ad29-71c907b71234">

After:
<img width="1117" alt="image" src="https://github.com/microsoft/lage/assets/12711091/6b0be4d3-1210-4ee2-887a-ecfb4e566c44">