### PR TITLE
Fix lage info dependencies by resolving transitive task dependencies behind noop tasks

### DIFF
--- a/change/change-8494e0e5-609a-448e-9279-dfbef8446b26.json
+++ b/change/change-8494e0e5-609a-448e-9279-dfbef8446b26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix undefined dependencies in info output",
+      "packageName": "@lage-run/cli",
+      "email": "sverre.johansen@gmail.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/e2e-tests/src/info.test.ts
+++ b/packages/e2e-tests/src/info.test.ts
@@ -37,4 +37,34 @@ describe("info command", () => {
 
     repo.cleanup();
   });
+
+  it("dependencies are resolved via noop tasks", () => {
+    const repo = new Monorepo("noop-task-info");
+    repo.init();
+    repo.addPackage("a", ["b"], { build: "echo 'building a'" });
+    // This task does not have a `build` script.
+    repo.addPackage("b", ["c"], {});
+    repo.addPackage("c", [], { build: "echo 'building c'" });
+    repo.install();
+
+    const results = repo.run("lage", ["info", "build", "prepare"]);
+
+    const output = results.stdout + results.stderr;
+    const infoJsonOutput: any = parseNdJson(output)[0];
+    const { packageTasks } = infoJsonOutput.data;
+
+    // Check if task `a#build` depends on `c#build`, because package `b` doesn't
+    // have a `build` task so dependencies are hoisted up.
+    const task = packageTasks.find(({ id }) => id === "a#build");
+    expect(task.dependencies).toEqual(["c#build"]);
+
+    // Make sure all dependencies points to an existing task.
+    for (const task of packageTasks) {
+      for (const dependency of task.dependencies) {
+        expect(packageTasks.some(({ id }) => id === dependency)).toBeTruthy();
+      }
+    }
+
+    repo.cleanup();
+  });
 });


### PR DESCRIPTION
Lage info doesn't print information about tasks that doesn't have a `package.json` script, but other tasks can still depend on it. This results in missing information, and dangling dependencies.

This fixes that by hoisting up all dependencies from these tasks, so that tasks still depends on all package-topological dependencies.

This is a fix for #722.