### PR TITLE
Fix tag name to fix release

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -2,7 +2,7 @@
 /** @type {import('beachball').BeachballConfig}*/
 module.exports = {
   branch: "v1",
-  tag: "v1",
+  tag: "ver1",
   ignorePatterns: [
     ".*ignore",
     ".github/**",


### PR DESCRIPTION
According to wiki here - https://docs.npmjs.com/cli/v10/commands/npm-dist-tag
The simplest way to avoid semver problems with tags is to use tags that do not begin with a number or the letter v.