### PR TITLE
Enabled reporter param for lage.config.js

### DIFF
--- a/change/lage-6d5a8bd5-9b73-4d12-a1b4-3835d9043749.json
+++ b/change/lage-6d5a8bd5-9b73-4d12-a1b4-3835d9043749.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enabled reporter param for lage.config.js",
+  "packageName": "lage",
+  "email": "argoy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lage/src/config/getConfig.ts
+++ b/packages/lage/src/config/getConfig.ts
@@ -37,9 +37,10 @@ export async function getConfig(cwd: string): Promise<Config> {
 
   const dist = parsedArgs.experimentDist || false;
   const concurrency = parsedArgs.concurrency || configResults?.config.concurrency || os.cpus().length - 1;
+  const reporter = parsedArgs.reporter || configResults?.config.reporter || ["npmLog"];
 
   return {
-    reporter: parsedArgs.reporter || ["npmLog"],
+    reporter: reporter,
     grouped: parsedArgs.grouped || false,
     args: getPassThroughArgs(command, parsedArgs),
     cache: parsedArgs.cache === false ? false : true,


### PR DESCRIPTION
Before this PR, reporter param is only read from cli args. With this PR, reporter param can be read from cli args as well as lage.config.js file.