### PR TITLE
Update backfill monorepo

### DIFF
--- a/change/change-d0bde26c-13d3-4b9b-a3bb-c5f7c69d02e2.json
+++ b/change/change-d0bde26c-13d3-4b9b-a3bb-c5f7c69d02e2.json
@@ -1,0 +1,32 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update backfill monorepo",
+      "packageName": "@lage-run/cache-github-actions",
+      "email": "brunoru@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Update backfill monorepo",
+      "packageName": "@lage-run/cache",
+      "email": "brunoru@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Update backfill monorepo",
+      "packageName": "@lage-run/config",
+      "email": "brunoru@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Update backfill monorepo",
+      "packageName": "lage",
+      "email": "brunoru@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cache-github-actions/package.json
+++ b/packages/cache-github-actions/package.json
@@ -16,7 +16,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
-    "backfill-config": "6.4.1",
+    "backfill-config": "6.4.2",
     "backfill-logger": "5.2.1",
     "workspace-tools": "0.36.4",
     "@actions/cache": "3.2.4"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@lage-run/target-graph": "^0.8.9",
     "@lage-run/logger": "^1.3.0",
-    "backfill-cache": "5.7.1",
-    "backfill-config": "6.4.1",
+    "backfill-cache": "5.8.0",
+    "backfill-config": "6.4.2",
     "backfill-logger": "5.2.1",
     "glob-hasher": "^1.4.2"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -23,7 +23,7 @@
     "@lage-run/logger": "^1.3.0",
     "@lage-run/scheduler-types": "^0.3.13",
     "@lage-run/target-graph": "^0.8.9",
-    "backfill-config": "6.4.1",
+    "backfill-config": "6.4.2",
     "cosmiconfig": "7.1.0",
     "workspace-tools": "0.36.4"
   },

--- a/packages/lage/dts-bundle.config.js
+++ b/packages/lage/dts-bundle.config.js
@@ -53,7 +53,7 @@ module.exports = {
       libraries: {
         // Note that backfill-config itself must be in this list, or references to files within the
         // package will be treated as external and preserved as imports.
-        inlinedLibraries: ["backfill-config", "backfill-logger"],
+        inlinedLibraries: ["backfill-config", "backfill-logger", "@azure/core-http"],
       },
       output: commonOutputOptions,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,13 +1528,14 @@ babel-preset-jest@^29.5.0:
     babel-plugin-jest-hoist "^29.5.0"
     babel-preset-current-node-syntax "^1.0.0"
 
-backfill-cache@5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/backfill-cache/-/backfill-cache-5.7.1.tgz#09484ed1f963d8d64fbbd7cc0cddd85db5f06143"
-  integrity sha512-+zR2r+A0EmShwhxj3fsGAPmA7EOAs4xc4X0Xr10K+2zsohGWpm4a/L/GmwFi7RfwGeNm/P99nm85Hoexe7V+ag==
+backfill-cache@5.8.0:
+  version "5.8.0"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/backfill-cache/-/backfill-cache-5.8.0.tgz#660ce9df5029ed67beaaa88371b5c907a84d14f8"
+  integrity sha1-Zgzp31Ap7We+qqiDcbXJB6hNFPg=
   dependencies:
+    "@azure/core-http" "^3.0.0"
     "@azure/storage-blob" "^12.15.0"
-    backfill-config "^6.4.1"
+    backfill-config "^6.4.2"
     backfill-logger "^5.2.1"
     execa "^5.0.0"
     fs-extra "^8.1.0"
@@ -1542,11 +1543,21 @@ backfill-cache@5.7.1:
     p-limit "^3.0.0"
     tar-fs "^2.1.0"
 
-backfill-config@6.4.1, backfill-config@^6.4.1:
+backfill-config@6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/backfill-config/-/backfill-config-6.4.1.tgz#b85afd0a8acc0c9f04f4eb177e8d239dc4a2502e"
   integrity sha512-u4394nK6W/GfsAEKSXxdyVhcmQcDb36YztINEKI5mpsd7NjTqnxJVkBgTo5YetbomL/7RU3/ROiwXuv2nkbqyA==
   dependencies:
+    backfill-logger "^5.2.1"
+    find-up "^5.0.0"
+    pkg-dir "^4.2.0"
+
+backfill-config@6.4.2, backfill-config@^6.4.2:
+  version "6.4.2"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/backfill-config/-/backfill-config-6.4.2.tgz#129a0c9916755bdf3d20d3e25cd18a7a79cb7c8d"
+  integrity sha1-EpoMmRZ1W989INPiXNGKennLfI0=
+  dependencies:
+    "@azure/core-http" "^3.0.0"
     backfill-logger "^5.2.1"
     find-up "^5.0.0"
     pkg-dir "^4.2.0"


### PR DESCRIPTION
This pull request primarily involves updates to the backfill monorepo and its dependencies across multiple packages. The most significant changes are the patches made to several packages and the updates to their dependencies in the `package.json` files. Additionally, `@azure/core-http` has been added to the list of inlined libraries in `dts-bundle.config.js`.

Monorepo updates:

* [`change/change-d0bde26c-13d3-4b9b-a3bb-c5f7c69d02e2.json`](diffhunk://#diff-7fdc56455301f1e2f0b36d5952d7afa4a5584ac0d26cf7d4245c309b5b7f3f9aR1-R32): The backfill monorepo has been updated with patches to `@lage-run/cache-github-actions`, `@lage-run/cache`, `@lage-run/config`, and `lage`.

Dependency updates:

* [`packages/cache-github-actions/package.json`](diffhunk://#diff-37cd59b13b3fce369a6fa69e4dba6f5681c32b8b03a9eeb17cafc2a11069a95bL19-R19): The `backfill-config` dependency has been updated from version 6.4.1 to 6.4.2.
* [`packages/cache/package.json`](diffhunk://#diff-d232cbfa8f24cc2cfe7b700df716789ae83147c39b58541db55c5270a9e3c1aaL22-R23): The `backfill-cache` and `backfill-config` dependencies have been updated from versions 5.7.1 and 6.4.1 to 5.8.0 and 6.4.2, respectively.
* [`packages/config/package.json`](diffhunk://#diff-fd956f6d78d80e1989716c00afb66f1ac64847e9b4a3673def6f483cd218e963L26-R26): The `backfill-config` dependency has been updated from version 6.4.1 to 6.4.2.

Inlined libraries:

* [`packages/lage/dts-bundle.config.js`](diffhunk://#diff-b9e1aafbb177b0f165fd497ccc40f0d1f1db249d6a0cde1cd99406fe713ee3bcL56-R56): The `@azure/core-http` library has been added to the list of inlined libraries.