### PR TITLE
Fix glob patterns in the package tree find files function

### DIFF
--- a/change/change-ea92a0ef-c19c-4ad1-9230-83e9d4d1af28.json
+++ b/change/change-ea92a0ef-c19c-4ad1-9230-83e9d4d1af28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "matching correct glob and exclude patterns",
+      "packageName": "@lage-run/hasher",
+      "email": "kchau@microsoft.com_msteamsmdb",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/hasher/src/PackageTree.ts
+++ b/packages/hasher/src/PackageTree.ts
@@ -42,8 +42,8 @@ export class PackageTree {
       [
         "ls-files",
         "-z",
-        ...patterns.filter((p) => !p.startsWith("!")),
-        ...patterns.filter((p) => p.startsWith("!")).map((p) => `:!:${p.slice(1)}`),
+        ...patterns.filter((p) => !p.startsWith("!")).map((p) => `:(glob)${p}`),
+        ...patterns.filter((p) => p.startsWith("!")).map((p) => `:(exclude,glob)${p.slice(1)}`),
       ],
       { cwd }
     ).then((lsFilesResults) => {
@@ -61,8 +61,8 @@ export class PackageTree {
             "-z",
             "-o",
             "--exclude-standard",
-            ...patterns.filter((p) => !p.startsWith("!")),
-            ...patterns.filter((p) => p.startsWith("!")).map((p) => `:!:${p.slice(1)}`),
+            ...patterns.filter((p) => !p.startsWith("!")).map((p) => `:(glob)${p}`),
+            ...patterns.filter((p) => p.startsWith("!")).map((p) => `:(exclude,glob)${p.slice(1)}`),
           ],
           { cwd }
         ).then((lsOtherResults) => {


### PR DESCRIPTION
https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec

has this detail about using `:(glob)PATTERN` - it uses a glob pattern that is more familiar to what people expect inside lage config