### PR TITLE
DefaultAzureCredential as fallback with optional in config set credential

### DIFF
--- a/change/change-a891e1b5-dee0-4dd6-9bda-b797277daeed.json
+++ b/change/change-a891e1b5-dee0-4dd6-9bda-b797277daeed.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Default fallback with optional pre-set credentials",
+      "packageName": "@lage-run/cache",
+      "email": "brunoru@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Extending the flexibility of `lage` `azure-blob` remote cache credential configuration by allowing `TokenCredential`'s passed in via the `cachStorageConfig` to be merged in with environmental remote cache configurations. This will allow any `TokenCredential` to be supplied in the project side `lage.config.js` and then be used to authenticate backfill access to the Azure Blob Storage.