### PR TITLE
Revert "DefaultAzureCredential as fallback with optional in config se…

### DIFF
--- a/change/change-14c1c19a-e952-4120-965a-ad9607b93953.json
+++ b/change/change-14c1c19a-e952-4120-965a-ad9607b93953.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Revert \"DefaultAzureCredential as fallback with optional in config set credential (#760)\"",
+      "packageName": "@lage-run/cache",
+      "email": "brunoru@microsoft.com_msteamsmdb",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cache/src/backfillWrapper.ts
+++ b/packages/cache/src/backfillWrapper.ts
@@ -30,40 +30,22 @@ export function createBackfillLogger() {
 
 export function createBackfillCacheConfig(cwd: string, cacheOptions: Partial<CacheOptions> = {}, backfillLogger: BackfillLogger) {
   const envConfig = getEnvConfig(backfillLogger);
-  // To avoid weakmap issues, we need to store the credential and restore post-merge
-  const credentialStash = getCredentialStash(cacheOptions);
-
   const mergedConfig = {
     ...createDefaultConfig(cwd),
     ...cacheOptions,
     ...envConfig,
   };
 
-  applyCredentialStashToMergedConfig(mergedConfig, credentialStash);
-
-  return mergedConfig;
-}
-
-function getCredentialStash(cacheOptions: Partial<CacheOptions>) {
-  if (
-    cacheOptions.cacheStorageConfig &&
-    cacheOptions.cacheStorageConfig.provider === "azure-blob" &&
-    cacheOptions.cacheStorageConfig.options.credential
-  ) {
-    const stashedCredential = cacheOptions.cacheStorageConfig.options.credential;
-    delete cacheOptions.cacheStorageConfig.options.credential;
-    return stashedCredential;
-  }
-  return null;
-}
-
-function applyCredentialStashToMergedConfig(mergedConfig: any, credentialStash: any) {
   if (mergedConfig.cacheStorageConfig.provider === "azure-blob") {
-    const connectionString = mergedConfig.cacheStorageConfig.options.connectionString;
-    if (connectionString && !isTokenConnectionString(connectionString)) {
-      mergedConfig.cacheStorageConfig.options.credential = credentialStash || CredentialCache.getInstance();
+    if (
+      mergedConfig.cacheStorageConfig.options.connectionString &&
+      !isTokenConnectionString(mergedConfig.cacheStorageConfig.options.connectionString)
+    ) {
+      mergedConfig.cacheStorageConfig.options.credential = CredentialCache.getInstance();
     }
   }
+
+  return mergedConfig;
 }
 
 function isTokenConnectionString(connectionString: string) {


### PR DESCRIPTION
After repeated testing, there seem to be consistent issues with the complexity of the Azure Identity `TokenCredential` derived classes (such as `DefualtAzureCredential` & `AzureCliCredential`) and their handling in the backfillWrapper on the lage side. 
DefaultAzureCredential injection also appears to be enough to support WIF authenticated storage account access as long as the correct env var are set, Mainly AZURE_IDENTITY_TOKEN. 

This reverts commit e937af3a04e0af29a2ad36e57b2f4169d4d5c628.