### PR TITLE
Exec command: executes a target regardless of the graph.

### DIFF
--- a/change/change-583fcfc6-c527-46d3-b6ee-5bbc9251bcbd.json
+++ b/change/change-583fcfc6-c527-46d3-b6ee-5bbc9251bcbd.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "adds an exec command that skips building a target graph.",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { NoTargetFoundError } from "./types/errors.js";
 import { affectedCommand } from "./commands/affected/index.js";
 import { initCommand } from "./commands/init/index.js";
 import { infoCommand } from "./commands/info/index.js";
+import { execCommand } from "./commands/exec/index.js";
 
 async function main() {
   const program = new Command();
@@ -14,6 +15,7 @@ async function main() {
   program.addCommand(affectedCommand);
   program.addCommand(initCommand);
   program.addCommand(infoCommand);
+  program.addCommand(execCommand);
 
   await program.parseAsync(process.argv);
 }

--- a/packages/cli/src/commands/exec/action.ts
+++ b/packages/cli/src/commands/exec/action.ts
@@ -1,0 +1,73 @@
+import type { Command } from "commander";
+import { filterArgsForTasks } from "../run/filterArgsForTasks.js";
+import { getConfig } from "@lage-run/config";
+import { getPackageInfos, getWorkspaceRoot } from "workspace-tools";
+import createLogger from "@lage-run/logger";
+import path from "path";
+
+import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
+import { TargetFactory } from "@lage-run/target-graph";
+import { initializeReporters } from "../initializeReporters.js";
+import { TargetRunnerPicker } from "@lage-run/runners";
+import { getPackageAndTask } from "@lage-run/target-graph/lib/targetId.js";
+
+interface ExecOptions extends ReporterInitOptions {
+  cwd?: string;
+  nodeArg?: string[];
+}
+
+export async function execAction(options: ExecOptions, command: Command) {
+  const cwd = process.cwd();
+  const config = await getConfig(cwd);
+
+  const logger = createLogger();
+  options.logLevel = options.logLevel ?? "info";
+  options.reporter = options.reporter ?? "json";
+  initializeReporters(logger, options);
+
+  const root = getWorkspaceRoot(cwd)!;
+
+  const packageInfos = getPackageInfos(root);
+
+  const resolve = (packageName: string) => {
+    return path.relative(root, path.dirname(packageInfos[packageName]?.packageJsonPath)).replace(/\\/g, "/");
+  };
+
+  const { taskArgs } = filterArgsForTasks(command.args);
+
+  const { packageName, task } = getPackageAndTask(command.args[0]);
+
+  const factory = new TargetFactory({ root, resolve, packageInfos });
+
+  const target = packageName ? factory.createPackageTarget(packageName, task, {}) : factory.createGlobalTarget(task, {});
+
+  const pickerOptions = {
+    npmScript: {
+      script: require.resolve("../run/runners/NpmScriptRunner.js"),
+      options: {
+        nodeArg: options.nodeArg,
+        taskArgs,
+        npmCmd: config.npmClient,
+      },
+    },
+    worker: {
+      script: require.resolve("../run/runners/WorkerRunner.js"),
+      options: {
+        taskArgs,
+      },
+    },
+    noop: {
+      script: require.resolve("../run/runners/NoOpRunner.js"),
+      options: {},
+    },
+  };
+  const runnerPicker = new TargetRunnerPicker(pickerOptions);
+  const runner = await runnerPicker.pick(target);
+  if (await runner.shouldRun(target)) {
+    await runner.run({
+      target,
+      weight: 1,
+      abortSignal: new AbortController().signal,
+    });
+  }
+}

--- a/packages/cli/src/commands/exec/index.ts
+++ b/packages/cli/src/commands/exec/index.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+import { execAction } from "./action.js";
+import { addLoggerOptions } from "../addLoggerOptions.js";
+
+const execCommand = new Command("exec");
+
+addLoggerOptions(execCommand).action(execAction);
+export { execCommand };


### PR DESCRIPTION
This paves the way for any external scheduler to execute a single lage command without having to calculate a graph.