### PR TITLE
adding parallelism to server command

### DIFF
--- a/change/change-97a756b4-1178-40aa-b243-2f53c2d92403.json
+++ b/change/change-97a756b4-1178-40aa-b243-2f53c2d92403.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "adding parallelism to server",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "adding parallelism to server",
+      "packageName": "@lage-run/config",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "@lage-run/scheduler": "^1.2.10",
     "@lage-run/scheduler-types": "^0.3.14",
     "@lage-run/target-graph": "^0.8.9",
+    "@lage-run/worker-threads-pool": "^0.8.0",
     "chokidar": "3.5.3",
     "commander": "9.5.0",
     "execa": "5.1.1",

--- a/packages/cli/src/commands/server/action.ts
+++ b/packages/cli/src/commands/server/action.ts
@@ -59,7 +59,7 @@ export async function workerAction(options: WorkerOptions, command: Command) {
     packageInfos,
   });
 
-  const lageService = await createLageService(targetGraph, logger, config.npmClient);
+  const lageService = await createLageService(targetGraph, logger, config.npmClient, config.concurrency);
   const server = await rpc.createServer(lageService);
   logger.info(`Server listening on http://${host}:${port}`);
   await server.listen({ host, port });

--- a/packages/cli/src/commands/server/action.ts
+++ b/packages/cli/src/commands/server/action.ts
@@ -59,7 +59,7 @@ export async function workerAction(options: WorkerOptions, command: Command) {
     packageInfos,
   });
 
-  const lageService = await createLageService(targetGraph, logger, config.npmClient, config.concurrency);
+  const lageService = await createLageService(targetGraph, logger, config.npmClient, options.concurrency ?? config.concurrency);
   const server = await rpc.createServer(lageService);
   logger.info(`Server listening on http://${host}:${port}`);
   await server.listen({ host, port });

--- a/packages/cli/src/commands/server/index.ts
+++ b/packages/cli/src/commands/server/index.ts
@@ -1,8 +1,10 @@
+import os from "os";
 import { Command } from "commander";
 import { workerAction } from "./action.js";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 
 const serverCommand = new Command("server");
+serverCommand.option("-c|--concurrency <number>", "max jobs to run at a time", (v) => parseInt(v), os.cpus().length - 1);
 serverCommand.option("-h|--host <host>", "lage server host", "localhost");
 serverCommand.option<number>("-p|--port <port>", "lage worker server port", (v) => parseInt(v), 5332);
 

--- a/packages/cli/src/commands/server/singleTargetWorker.ts
+++ b/packages/cli/src/commands/server/singleTargetWorker.ts
@@ -1,0 +1,28 @@
+import { registerWorker } from "@lage-run/worker-threads-pool";
+import { TargetRunnerPicker } from "@lage-run/runners";
+import type { TargetRunnerPickerOptions } from "@lage-run/runners";
+import type { Target } from "@lage-run/target-graph";
+
+(async () => {
+  async function run(data: { target: Target; runners: TargetRunnerPickerOptions }, abortSignal?: AbortSignal) {
+    let value: unknown = undefined;
+
+    const runnerPicker = new TargetRunnerPicker(data.runners);
+
+    const runner = await runnerPicker.pick(data.target);
+
+    value = await runner.run({
+      target: data.target,
+      weight: 0,
+      abortSignal,
+    });
+
+    return {
+      skipped: false,
+      hash: undefined,
+      value,
+    };
+  }
+
+  registerWorker(run);
+})();

--- a/packages/config/src/getConfig.ts
+++ b/packages/config/src/getConfig.ts
@@ -8,6 +8,7 @@ import type { CacheOptions } from "./types/CacheOptions.js";
  */
 export async function getConfig(cwd: string): Promise<ConfigOptions> {
   const config = (await readConfigFile(cwd)) || ({} as Partial<ConfigOptions>);
+  const availableParallelism = "availableParallelism" in os ? (os as any)["availableParallelism"]() : os.cpus().length - 1;
   return {
     cacheOptions: config?.cacheOptions ?? ({} as CacheOptions),
     ignore: config?.ignore ?? [],
@@ -25,7 +26,7 @@ export async function getConfig(cwd: string): Promise<ConfigOptions> {
     loggerOptions: config?.loggerOptions ?? {},
     runners: config?.runners ?? {},
     workerIdleMemoryLimit: config?.workerIdleMemoryLimit ?? os.totalmem(), // 0 means no limit,
-    concurrency: config?.concurrency ?? os.cpus().length - 1,
+    concurrency: config?.concurrency ?? availableParallelism,
     allowNoTargetRuns: config?.allowNoTargetRuns ?? false,
   };
 }


### PR DESCRIPTION
following the single exeuction model, we are then able to parallelize (without regard to the dependencies) target runner. This lends support for external schedulers (like BuildXL) to run things as a service.