### PR TITLE
Update beachball to version that handles yarn.lock updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.1",
     "@types/node": "^16.18.3",
-    "beachball": "^2.37.0",
+    "beachball": "^2.47.1",
     "fast-glob": "3.3.2",
     "gh-pages": "^5.0.0",
     "husky": "^9.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,12 +1681,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/cache@npm:^1.3.1, @lage-run/cache@workspace:packages/cache":
+"@lage-run/cache@npm:^1.3.2, @lage-run/cache@workspace:packages/cache":
   version: 0.0.0-use.local
   resolution: "@lage-run/cache@workspace:packages/cache"
   dependencies:
     "@azure/identity": "npm:^4.0.1"
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/monorepo-fixture": "npm:*"
     "@lage-run/monorepo-scripts": "npm:*"
     "@lage-run/target-graph": "npm:^0.8.9"
@@ -1697,23 +1697,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/cli@npm:^0.19.1, @lage-run/cli@workspace:packages/cli":
+"@lage-run/cli@npm:^0.19.2, @lage-run/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@lage-run/cli@workspace:packages/cli"
   dependencies:
-    "@lage-run/cache": "npm:^1.3.1"
-    "@lage-run/config": "npm:^0.4.0"
-    "@lage-run/hasher": "npm:^1.3.1"
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/cache": "npm:^1.3.2"
+    "@lage-run/config": "npm:^0.4.1"
+    "@lage-run/hasher": "npm:^1.3.2"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/monorepo-fixture": "npm:*"
     "@lage-run/monorepo-scripts": "npm:*"
-    "@lage-run/reporters": "npm:^1.2.8"
+    "@lage-run/reporters": "npm:^1.2.9"
     "@lage-run/rpc": "npm:^1.1.0"
     "@lage-run/runners": "npm:^1.0.1"
-    "@lage-run/scheduler": "npm:^1.2.11"
+    "@lage-run/scheduler": "npm:^1.2.12"
     "@lage-run/scheduler-types": "npm:^0.3.14"
     "@lage-run/target-graph": "npm:^0.8.9"
-    "@lage-run/worker-threads-pool": "npm:^0.8.0"
+    "@lage-run/worker-threads-pool": "npm:^0.8.1"
     chokidar: "npm:3.5.3"
     commander: "npm:9.5.0"
     execa: "npm:5.1.1"
@@ -1724,11 +1724,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/config@npm:^0.4.0, @lage-run/config@workspace:packages/config":
+"@lage-run/config@npm:^0.4.1, @lage-run/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@lage-run/config@workspace:packages/config"
   dependencies:
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/monorepo-scripts": "npm:*"
     "@lage-run/runners": "npm:^1.0.1"
     "@lage-run/target-graph": "npm:^0.8.9"
@@ -1744,7 +1744,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lage-run/e2e-tests@workspace:packages/e2e-tests"
   dependencies:
-    "@lage-run/cli": "npm:^0.19.1"
+    "@lage-run/cli": "npm:^0.19.2"
     "@lage-run/monorepo-scripts": "npm:*"
     "@lage-run/scheduler-types": "npm:^0.3.14"
     "@lage-run/target-graph": "npm:^0.8.9"
@@ -1755,7 +1755,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/format-hrtime@npm:^0.1.5, @lage-run/format-hrtime@workspace:packages/format-hrtime":
+"@lage-run/format-hrtime@npm:^0.1.6, @lage-run/format-hrtime@workspace:packages/format-hrtime":
   version: 0.0.0-use.local
   resolution: "@lage-run/format-hrtime@workspace:packages/format-hrtime"
   languageName: unknown
@@ -1770,11 +1770,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/hasher@npm:^1.3.1, @lage-run/hasher@workspace:packages/hasher":
+"@lage-run/hasher@npm:^1.3.2, @lage-run/hasher@workspace:packages/hasher":
   version: 0.0.0-use.local
   resolution: "@lage-run/hasher@workspace:packages/hasher"
   dependencies:
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/monorepo-fixture": "npm:*"
     "@lage-run/monorepo-scripts": "npm:*"
     "@lage-run/target-graph": "npm:^0.8.9"
@@ -1794,7 +1794,7 @@ __metadata:
   dependencies:
     "@types/jest": "npm:^29.5.1"
     "@types/node": "npm:^16.18.3"
-    beachball: "npm:^2.37.0"
+    beachball: "npm:^2.47.1"
     fast-glob: "npm:3.3.2"
     gh-pages: "npm:^5.0.0"
     husky: "npm:^9.1.5"
@@ -1808,7 +1808,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/logger@npm:^1.3.0, @lage-run/logger@workspace:packages/logger":
+"@lage-run/logger@npm:^1.3.1, @lage-run/logger@workspace:packages/logger":
   version: 0.0.0-use.local
   resolution: "@lage-run/logger@workspace:packages/logger"
   languageName: unknown
@@ -1841,12 +1841,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/reporters@npm:^1.2.8, @lage-run/reporters@workspace:packages/reporters":
+"@lage-run/reporters@npm:^1.2.9, @lage-run/reporters@workspace:packages/reporters":
   version: 0.0.0-use.local
   resolution: "@lage-run/reporters@workspace:packages/reporters"
   dependencies:
-    "@lage-run/format-hrtime": "npm:^0.1.5"
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/format-hrtime": "npm:^0.1.6"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/scheduler-types": "npm:^0.3.14"
     "@lage-run/target-graph": "npm:^0.8.9"
     "@ms-cloudpack/task-reporter": "npm:0.5.3"
@@ -1891,19 +1891,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/scheduler@npm:^1.2.11, @lage-run/scheduler@workspace:packages/scheduler":
+"@lage-run/scheduler@npm:^1.2.12, @lage-run/scheduler@workspace:packages/scheduler":
   version: 0.0.0-use.local
   resolution: "@lage-run/scheduler@workspace:packages/scheduler"
   dependencies:
-    "@lage-run/cache": "npm:^1.3.1"
-    "@lage-run/config": "npm:^0.4.0"
-    "@lage-run/hasher": "npm:^1.3.1"
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/cache": "npm:^1.3.2"
+    "@lage-run/config": "npm:^0.4.1"
+    "@lage-run/hasher": "npm:^1.3.2"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/monorepo-scripts": "npm:*"
     "@lage-run/runners": "npm:^1.0.1"
     "@lage-run/scheduler-types": "npm:^0.3.14"
     "@lage-run/target-graph": "npm:^0.8.9"
-    "@lage-run/worker-threads-pool": "npm:^0.8.0"
+    "@lage-run/worker-threads-pool": "npm:^0.8.1"
   languageName: unknown
   linkType: soft
 
@@ -1916,11 +1916,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lage-run/worker-threads-pool@npm:^0.8.0, @lage-run/worker-threads-pool@workspace:packages/worker-threads-pool":
+"@lage-run/worker-threads-pool@npm:^0.8.1, @lage-run/worker-threads-pool@workspace:packages/worker-threads-pool":
   version: 0.0.0-use.local
   resolution: "@lage-run/worker-threads-pool@workspace:packages/worker-threads-pool"
   dependencies:
-    "@lage-run/logger": "npm:^1.3.0"
+    "@lage-run/logger": "npm:^1.3.1"
     "@lage-run/monorepo-scripts": "npm:*"
   languageName: unknown
   linkType: soft
@@ -2982,13 +2982,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"beachball@npm:^2.37.0":
-  version: 2.37.0
-  resolution: "beachball@npm:2.37.0"
+"beachball@npm:^2.47.1":
+  version: 2.47.1
+  resolution: "beachball@npm:2.47.1"
   dependencies:
-    cosmiconfig: "npm:^7.0.0"
+    cosmiconfig: "npm:^8.3.6"
     execa: "npm:^5.0.0"
-    fs-extra: "npm:^10.0.0"
+    fs-extra: "npm:^11.1.1"
     lodash: "npm:^4.17.15"
     minimatch: "npm:^3.0.4"
     p-limit: "npm:^3.0.2"
@@ -2996,11 +2996,11 @@ __metadata:
     semver: "npm:^7.0.0"
     toposort: "npm:^2.0.2"
     uuid: "npm:^9.0.0"
-    workspace-tools: "npm:^0.35.0"
+    workspace-tools: "npm:^0.36.3"
     yargs-parser: "npm:^21.0.0"
   bin:
     beachball: bin/beachball.js
-  checksum: 10c0/6f62250065804eff804abf1520d8bd870edb66dd9a71608927453acd9e8764c0a594f4773ff7c5787f3274304006342bc3f437374d9247169ba42ce15bb1ebf9
+  checksum: 10c0/87d35286c185402527f3082cc259347cc1673ad592cfdc03c8dda493e375c8bc62b31c2707f5862d032a84d1af1754a7faa7c192af09c20b957985000b0d62d7
   languageName: node
   linkType: hard
 
@@ -3440,7 +3440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:7.1.0, cosmiconfig@npm:^7.0.0, cosmiconfig@npm:^7.1.0":
+"cosmiconfig@npm:7.1.0, cosmiconfig@npm:^7.1.0":
   version: 7.1.0
   resolution: "cosmiconfig@npm:7.1.0"
   dependencies:
@@ -3462,6 +3462,23 @@ __metadata:
     parse-json: "npm:^5.0.0"
     path-type: "npm:^4.0.0"
   checksum: 10c0/80144be230b89857e7c4cafd59ba8feb3f5f7e6dae90faa324629fdecf9a6fc3f5b4106c3623f69a1a3d77cb11ef90e5ab65a67f21d73ffda3d76b18f8e4e6c2
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^8.3.6":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
+  dependencies:
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+    path-type: "npm:^4.0.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/0382a9ed13208f8bfc22ca2f62b364855207dffdb73dc26e150ade78c3093f1cf56172df2dd460c8caf2afa91c0ed4ec8a88c62f8f9cd1cf423d26506aa8797a
   languageName: node
   linkType: hard
 
@@ -4499,14 +4516,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
+"fs-extra@npm:^11.1.1":
+  version: 11.2.0
+  resolution: "fs-extra@npm:11.2.0"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
-  checksum: 10c0/5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
+  checksum: 10c0/d77a9a9efe60532d2e790e938c81a02c1b24904ef7a3efb3990b835514465ba720e99a6ea56fd5e2db53b4695319b644d76d5a0e9988a2beef80aa7b1da63398
   languageName: node
   linkType: hard
 
@@ -5033,7 +5050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -6038,7 +6055,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "lage@workspace:packages/lage"
   dependencies:
-    "@lage-run/cli": "npm:^0.19.1"
+    "@lage-run/cli": "npm:^0.19.2"
     "@lage-run/runners": "npm:^1.0.1"
     backfill-config: "npm:6.4.2"
     dts-bundle-generator: "npm:^9.5.1"
@@ -8498,7 +8515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workspace-tools@npm:0.36.4":
+"workspace-tools@npm:0.36.4, workspace-tools@npm:^0.36.3":
   version: 0.36.4
   resolution: "workspace-tools@npm:0.36.4"
   dependencies:
@@ -8510,21 +8527,6 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     micromatch: "npm:^4.0.0"
   checksum: 10c0/39aa445637921b5e5a1786ea6ac8ef23fbede6a8f6c41eb75c2a4d69caa19fc49f5707f9b37cc8ce5f7f3f8c58558316450159424fc931068efbf7656b926c52
-  languageName: node
-  linkType: hard
-
-"workspace-tools@npm:^0.35.0":
-  version: 0.35.2
-  resolution: "workspace-tools@npm:0.35.2"
-  dependencies:
-    "@yarnpkg/lockfile": "npm:^1.1.0"
-    fast-glob: "npm:^3.3.1"
-    git-url-parse: "npm:^13.0.0"
-    globby: "npm:^11.0.0"
-    jju: "npm:^1.4.0"
-    js-yaml: "npm:^4.1.0"
-    micromatch: "npm:^4.0.0"
-  checksum: 10c0/f86fd85cd63d072c5da01419d1679171104d0915bfa2cf2691c0f20cb235bd43e61fed8a5ee75908738cefcf2f18e4659d45e0490c69f2b2f7986d65c1856252
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
lage was on an older beachball version that didn't handle the required updates to yarn.lock after bumping packages with yarn v4. This is fixed in the latest beachball version.