### PR TITLE
Shell script launching with BIN scripts rather than directly using node to call the .js 

### DIFF
--- a/change/change-edbf711d-509f-497e-a50a-247a2b2f9f6a.json
+++ b/change/change-edbf711d-509f-497e-a50a-247a2b2f9f6a.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "uses the shell scripts to have a different executable name",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -102,10 +102,10 @@ export async function executeRemotely(options: ExecRemotelyOptions, command) {
 
     const binPaths = getBinPaths();
     const lageServerBinPath = binPaths["lage-server"];
-    const lageServerArgs = [lageServerBinPath, "--host", host, "--port", port, "--timeout", timeout, ...args];
+    const lageServerArgs = ["--host", host, "--port", port, "--timeout", timeout, ...args];
 
-    logger.info(`Launching lage-server with these parameters: "${process.execPath}" ${lageServerArgs.join(" ")}`);
-    const child = execa(process.execPath, lageServerArgs, {
+    logger.info(`Launching lage-server with these parameters: ${lageServerArgs.join(" ")}`);
+    const child = execa(lageServerBinPath, lageServerArgs, {
       detached: true,
       stdio: "ignore",
     });

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -186,7 +186,7 @@ function generateCommand(
     return command;
   } else if (target.type === "worker" && shouldRunWorkersAsService) {
     const { host, port } = parseServerOption(options.server);
-    const command = [process.execPath, binPaths["lage"], "exec", "--server", `${host}:${port}`];
+    const command = [binPaths["lage"], "exec", "--server", `${host}:${port}`];
     if (options.concurrency) {
       command.push("--concurrency", options.concurrency.toString());
     }
@@ -202,7 +202,7 @@ function generateCommand(
     command.push(...taskArgs);
     return command;
   } else if (target.type === "worker") {
-    const command = [process.execPath, binPaths.lage, "exec"];
+    const command = [binPaths.lage, "exec"];
     command.push(target.packageName ?? "");
     command.push(target.task);
     command.push(...taskArgs);

--- a/packages/cli/src/getBinPaths.ts
+++ b/packages/cli/src/getBinPaths.ts
@@ -1,16 +1,26 @@
 import path from "path";
 import fs from "fs";
+import os from "os";
+
+function findUp(name: string, dir: string) {
+  let currentDir = dir;
+  while (currentDir !== "/") {
+    const fullPath = path.join(currentDir, name);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+  return undefined;
+}
 
 export function getBinPaths() {
-  let dir = __dirname;
-  let packageJsonPath = "";
-  while (dir !== "/") {
-    packageJsonPath = path.join(dir, "package.json");
-    if (fs.existsSync(packageJsonPath)) {
-      break;
-    }
-    dir = path.dirname(dir);
+  const bins = os.platform() === "win32" ? ["lage.cmd", "lage-server.cmd"] : ["lage", "lage-server"];
+  const binPaths = bins.map((bin) => findUp("node_modules/.bin/" + bin, __dirname));
+
+  if (binPaths.some((binPath) => binPath === undefined)) {
+    throw new Error("Could not find bin paths for lage or lage-server");
   }
-  const packageJson = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
-  return { lage: path.join(dir, packageJson.bin.lage), "lage-server": path.join(dir, packageJson.bin["lage-server"]) };
+
+  return { lage: binPaths[0]!, "lage-server": binPaths[1]! };
 }


### PR DESCRIPTION
this way, the buildxl sandbox can utilize the executable name as a "breakaway" process for background pips