### PR TITLE
fixing up the lage integrate with buildxl to utilize lage-server

### DIFF
--- a/change/change-51e07348-e1f8-4ab9-9294-e532cc1652eb.json
+++ b/change/change-51e07348-e1f8-4ab9-9294-e532cc1652eb.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "fixing up the lage integrate with buildxl to utilize lage-server",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "fixed the workerpool to raise \"idle\" event only if all workers are freed",
+      "packageName": "@lage-run/worker-threads-pool",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,11 +37,13 @@
     "commander": "9.5.0",
     "execa": "5.1.1",
     "fast-glob": "3.3.2",
+    "proper-lockfile": "^4.1.2",
     "workspace-tools": "0.36.4"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",
-    "@lage-run/monorepo-scripts": "*"
+    "@lage-run/monorepo-scripts": "*",
+    "@types/proper-lockfile": "^4.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/commands/exec/action.ts
+++ b/packages/cli/src/commands/exec/action.ts
@@ -14,6 +14,7 @@ interface ExecOptions extends ReporterInitOptions {
 
 export async function execAction(options: ExecOptions, command: Command) {
   const logger = createLogger();
+  options.cwd = options.cwd ?? process.cwd();
   options.logLevel = options.logLevel ?? "info";
   options.reporter = options.reporter ?? "json";
   initializeReporters(logger, options);

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -132,7 +132,7 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
 }
 
 async function optimizeTargetGraph(graph: TargetGraph, runnerPicker: TargetRunnerPicker) {
-  const targetMinimizedNodes = await removeNodes([...graph.targets.values()] ?? [], async (target) => {
+  const targetMinimizedNodes = await removeNodes([...graph.targets.values()], async (target) => {
     if (target.type === "noop") {
       return true;
     }

--- a/packages/worker-threads-pool/src/WorkerPool.ts
+++ b/packages/worker-threads-pool/src/WorkerPool.ts
@@ -35,7 +35,7 @@ export class WorkerPool extends EventEmitter implements Pool {
     this.on(workerFreedEvent, () => {
       if (this.queue.length > 0) {
         this._exec();
-      } else {
+      } else if (this.workers.every((w) => w.status === "free")) {
         this.emit("idle");
       }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,10 +1715,12 @@ __metadata:
     "@lage-run/scheduler-types": "npm:^0.3.16"
     "@lage-run/target-graph": "npm:^0.9.0"
     "@lage-run/worker-threads-pool": "npm:^0.8.3"
+    "@types/proper-lockfile": "npm:^4.1.4"
     chokidar: "npm:3.5.3"
     commander: "npm:9.5.0"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.2"
+    proper-lockfile: "npm:^4.1.2"
     workspace-tools: "npm:0.36.4"
   bin:
     lage: ./bin/lage.js
@@ -2321,6 +2323,22 @@ __metadata:
   version: 2.7.2
   resolution: "@types/prettier@npm:2.7.2"
   checksum: 10c0/16ffbd1135c10027f118517d3b12aaaf3936be1f3c6e4c6c9c03d26d82077c2d86bf0dcad545417896f29e7d90faf058aae5c9db2e868be64298c644492ea29e
+  languageName: node
+  linkType: hard
+
+"@types/proper-lockfile@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "@types/proper-lockfile@npm:4.1.4"
+  dependencies:
+    "@types/retry": "npm:*"
+  checksum: 10c0/d597846d6f7860da2470623d3f11b6e5b39864719c3c18b5a5e55f783c5e432fe49dcdcf6341b3903428fdf103f2bdc68eba263ce1ce3cbe8070cbcb54bbf230
+  languageName: node
+  linkType: hard
+
+"@types/retry@npm:*":
+  version: 0.12.5
+  resolution: "@types/retry@npm:0.12.5"
+  checksum: 10c0/eaaca483cc62f2f02c0b8486847ee70986ca7f97afd7363037247dbe3e98df8bd56a5b50d58b1e96768a5a1be0307010d86e9991bd458d72e8df88be471bd720
   languageName: node
   linkType: hard
 
@@ -4900,7 +4918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -7196,6 +7214,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    retry: "npm:^0.12.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/2f265dbad15897a43110a02dae55105c04d356ec4ed560723dcb9f0d34bc4fb2f13f79bb930e7561be10278e2314db5aca2527d5d3dcbbdee5e6b331d1571f6d
+  languageName: node
+  linkType: hard
+
 "protocols@npm:^2.0.0, protocols@npm:^2.0.1":
   version: 2.0.1
   resolution: "protocols@npm:2.0.1"
@@ -7651,7 +7680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912


### PR DESCRIPTION
This pull request includes multiple changes to improve the functionality and stability of the `@lage-run/cli` package. The most important changes include fixing the integration with `buildxl`, ensuring proper lockfile handling, improving the worker pool's idle event, and adding new dependencies.

### Enhancements to `@lage-run/cli`:

* Added `proper-lockfile` and its types to `dependencies` and `devDependencies` in `packages/cli/package.json`.
* Added default values for `cwd`, `logLevel`, and `reporter` options in `execAction` function in `packages/cli/src/commands/exec/action.ts`.

### Improvements to remote execution:

* Integrated `proper-lockfile` to ensure that the server lockfile is properly handled in `executeRemotely` function in `packages/cli/src/commands/exec/executeRemotely.ts`. [[1]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR12-R18) [[2]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR78-R115) [[3]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR131-R180) [[4]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR193-R203)
* Added error handling for server connection and task execution in `executeOnServer` function in `packages/cli/src/commands/exec/executeRemotely.ts`.

### Enhancements to worker pool:

* Modified the worker pool to raise the "idle" event only if all workers are free in `packages/worker-threads-pool/src/WorkerPool.ts`.

### Logging improvements:

* Added logging statements to various functions to provide better insights into the initialization and execution process in `packages/cli/src/commands/server/lageService.ts`. [[1]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R36) [[2]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R67) [[3]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R109-R110) [[4]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L117-R135)

### Minor fixes:

* Corrected the condition to remove nodes in `optimizeTargetGraph` function in `packages/cli/src/commands/info/action.ts`.

### JSON change log:

* Updated `change/change-51e07348-e1f8-4ab9-9294-e532cc1652eb.json` to include patch changes for `@lage-run/cli` and `@lage-run/worker-threads-pool`.