### PR TITLE
fixing publish of lage to enable lage-server to work

### DIFF
--- a/change/change-317eebd0-82d7-4d9d-9a4e-c0caeb96090b.json
+++ b/change/change-317eebd0-82d7-4d9d-9a4e-c0caeb96090b.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "fixing the lage-server by publishing the correct files",
+      "packageName": "lage",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/lage/package.json
+++ b/packages/lage/package.json
@@ -36,7 +36,9 @@
     "dist/lage.js",
     "dist/lage.js.map",
     "dist/runners/**",
-    "dist/workers/**"
+    "dist/workers/**",
+    "dist/singleTargetWorker.js",
+    "dist/singleTargetWorker.js.map"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This pull request includes changes to fix the `lage-server` by ensuring the correct files are published. The most important changes involve updating the `package.json` file and adding a change record.

Fixes and improvements:

* [`packages/lage/package.json`](diffhunk://#diff-7a4d71e6f5905437297f47cd241f9fbc330f8c2fb8320118a0eb4a787fff0723L39-R41): Added `dist/singleTargetWorker.js` and `dist/singleTargetWorker.js.map` to the files array to ensure they are included in the published package.
* [`change/change-317eebd0-82d7-4d9d-9a4e-c0caeb96090b.json`](diffhunk://#diff-553855dcb45171db393a2849972281bab36cba20d87bd8d270cc7d876360aa0aR1-R11): Added a change record to document the patch fixing the `lage-server` by publishing the correct files.