### PR TITLE
avoids re-creating target picker

### DIFF
--- a/change/change-29b3990d-29e4-4773-9893-0b16c9c7f4b9.json
+++ b/change/change-29b3990d-29e4-4773-9893-0b16c9c7f4b9.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "adding a mkdirp before writing to the log file",
+      "packageName": "@lage-run/reporters",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-76f74c5e-9500-4e6f-beb6-c5a0066b4a4e.json
+++ b/change/change-76f74c5e-9500-4e6f-beb6-c5a0066b4a4e.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "moved the picker creation to be just once to be reused in a singletargetworker",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/server/action.ts
+++ b/packages/cli/src/commands/server/action.ts
@@ -17,7 +17,8 @@ export async function serverAction(options: WorkerOptions) {
 
   const logger = createLogger();
   options.logLevel = options.logLevel ?? "info";
-  options.reporter = options.reporter ?? "json";
+  options.logFile = options.logFile ?? "node_modules/.cache/lage/server.log";
+  options.reporter = options.reporter ?? "verboseFileLog";
   initializeReporters(logger, options);
 
   logger.info(`Starting server on http://${host}:${port}`);

--- a/packages/cli/src/commands/server/singleTargetWorker.ts
+++ b/packages/cli/src/commands/server/singleTargetWorker.ts
@@ -2,13 +2,26 @@ import { registerWorker } from "@lage-run/worker-threads-pool";
 import { TargetRunnerPicker } from "@lage-run/runners";
 import type { TargetRunnerPickerOptions } from "@lage-run/runners";
 import type { Target } from "@lage-run/target-graph";
+import { workerData } from "worker_threads";
+
+interface SimpleTargetWorkerDataOptions {
+  runners: TargetRunnerPickerOptions;
+}
+
+async function setup(options: SimpleTargetWorkerDataOptions) {
+  const { runners } = options;
+  const runnerPicker = new TargetRunnerPicker(runners);
+
+  return {
+    options,
+    runnerPicker,
+  };
+}
 
 (async () => {
-  async function run(data: { target: Target; runners: TargetRunnerPickerOptions }, abortSignal?: AbortSignal) {
+  const { runnerPicker } = await setup(workerData);
+  async function run(data: { target: Target }, abortSignal?: AbortSignal) {
     let value: unknown = undefined;
-
-    const runnerPicker = new TargetRunnerPicker(data.runners);
-
     const runner = await runnerPicker.pick(data.target);
 
     value = await runner.run({

--- a/packages/reporters/src/VerboseFileLogReporter.ts
+++ b/packages/reporters/src/VerboseFileLogReporter.ts
@@ -3,10 +3,10 @@ import { isTargetStatusLogEntry } from "./isTargetStatusLogEntry.js";
 import { LogLevel } from "@lage-run/logger";
 import ansiRegex from "ansi-regex";
 import type { Reporter, LogEntry } from "@lage-run/logger";
-import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
 import type { TargetMessageEntry, TargetStatusEntry } from "./types/TargetLogEntry.js";
 import { Writable } from "stream";
 import fs from "fs";
+import path from "path";
 
 const stripAnsiRegex = ansiRegex();
 
@@ -18,6 +18,13 @@ export class VerboseFileLogReporter implements Reporter {
   fileStream: Writable;
   constructor(logFile?: string) {
     // if logFile is falsy (not specified on cli args), this.fileStream just become a "nowhere" stream and this reporter effectively does nothing
+    if (logFile) {
+      const logFilePath = path.dirname(path.resolve(logFile));
+      if (!fs.existsSync(logFilePath)) {
+        fs.mkdirSync(logFilePath, { recursive: true });
+      }
+    }
+
     this.fileStream = logFile ? fs.createWriteStream(logFile) : new Writable({ write() {} });
   }
 


### PR DESCRIPTION
This pull request includes several changes to improve the logging and worker management in the `@lage-run` project. The key updates involve adding directory creation before logging, reusing picker creation in single target workers, and refactoring worker pool initialization and management.

### Logging Improvements:
* **Directory Creation for Log Files**: Added a check to create the directory if it does not exist before writing to the log file in `VerboseFileLogReporter`. (`packages/reporters/src/VerboseFileLogReporter.ts`)
* **Default Log File Path**: Updated the default log file path and reporter type in the `serverAction` function. (`packages/cli/src/commands/server/action.ts`)

### Worker Management Enhancements:
* **Picker Creation Reuse**: Moved the picker creation to be reused in a `singleTargetWorker`. (`change/change-76f74c5e-9500-4e6f-beb6-c5a0066b4a4e.json`)
* **Worker Pool Initialization**: Refactored the `initialize` function to include worker pool initialization and management using the new `ServiceControls` interface. (`packages/cli/src/commands/server/lageService.ts`) [[1]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R36-R59) [[2]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L86-L126) [[3]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L135-R162) [[4]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L166-R193)
* **Worker Data Handling**: Added handling of `workerData` in `singleTargetWorker` to initialize the runner picker. (`packages/cli/src/commands/server/singleTargetWorker.ts`)