### PR TITLE
Optimize subgraph build

### DIFF
--- a/change/change-c0b34a9b-c47c-412a-8769-770f448ba103.json
+++ b/change/change-c0b34a9b-c47c-412a-8769-770f448ba103.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Optimize subgraph build",
+      "packageName": "@lage-run/target-graph",
+      "email": "ronakjain.public@gmail.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -106,7 +106,7 @@ export class TargetGraphBuilder {
 
   subgraph(entriesTargetIds: string[]) {
     const subgraphBuilder = new TargetGraphBuilder();
-    const visited: string[] = [];
+    const visited: Set<string> = new Set();
     const queue: string[] = [];
 
     for (const targetId of entriesTargetIds) {
@@ -119,11 +119,11 @@ export class TargetGraphBuilder {
 
     while (queue.length > 0) {
       const targetId = queue.shift()!;
-      if (visited.includes(targetId)) {
+      if (visited.has(targetId)) {
         continue;
       }
 
-      visited.push(targetId);
+      visited.add(targetId);
 
       const target = this.targets.get(targetId);
 
@@ -140,7 +140,9 @@ export class TargetGraphBuilder {
           subgraphBuilder.addDependency(dependency, targetId);
         }
 
-        queue.push(dependency);
+        if (!visited.has(dependency)) {
+          queue.push(dependency);
+        }
       }
     }
 


### PR DESCRIPTION
When trying out the transitive dependency operator in 1JS/midgard (`build: [^^transpile]`) it turned out to be really slow - taking anywhere from 1 minute to 6-7 minutes. Looking into it the primary culprit responsible for this was the `subgraph` method in `TargetGraphBuilder` - which lacked a few simple optimizations. 

After this change `info` command in 1JS/midgard with transitive takes 30 seconds consistently - with < 3 seconds spent building the subgraph. 20 seconds are spent in `transitiveReduction` - might be a good target for optimization later.