### PR TITLE
Use node script for command instead of npm client

### DIFF
--- a/change/change-4d82b1bc-9d6f-46db-ae51-cc398b53d9c0.json
+++ b/change/change-4d82b1bc-9d6f-46db-ae51-cc398b53d9c0.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "added a fix so that the \"shell\" command is only applied on windows",
+      "packageName": "@lage-run/runners",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-8c5869c9-d00b-4272-8533-2fd7e3b5d985.json
+++ b/change/change-8c5869c9-d00b-4272-8533-2fd7e3b5d985.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "skip using npm client if running a node script",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,12 +38,14 @@
     "execa": "5.1.1",
     "fast-glob": "3.3.2",
     "proper-lockfile": "^4.1.2",
+    "shell-quote": "^1.8.1",
     "workspace-tools": "0.37.0"
   },
   "devDependencies": {
     "@lage-run/monorepo-fixture": "*",
     "@lage-run/monorepo-scripts": "*",
-    "@types/proper-lockfile": "^4.1.4"
+    "@types/proper-lockfile": "^4.1.4",
+    "@types/shell-quote": "^1.7.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -191,7 +191,7 @@ function generateCommand(
     if (script && script.startsWith("node")) {
       const parsed = parse(script);
       if (parsed.length > 0 && parsed.every((entry) => typeof entry === "string")) {
-        return parsed as string[];
+        return [...(parsed as string[]), ...taskArgs];
       }
     }
 

--- a/packages/e2e-tests/src/__snapshots__/info.test.ts.snap
+++ b/packages/e2e-tests/src/__snapshots__/info.test.ts.snap
@@ -18,9 +18,8 @@ exports[`info command basic info test case 1`] = `
         },
         {
           "command": [
-            "yarn",
-            "run",
-            "test",
+            "node",
+            "./test.js",
           ],
           "dependencies": [
             "a#build",
@@ -32,9 +31,8 @@ exports[`info command basic info test case 1`] = `
         },
         {
           "command": [
-            "yarn",
-            "run",
-            "test",
+            "node",
+            "./test.js",
           ],
           "dependencies": [
             "b#build",
@@ -46,9 +44,8 @@ exports[`info command basic info test case 1`] = `
         },
         {
           "command": [
-            "yarn",
-            "run",
-            "build",
+            "node",
+            "./build.js",
           ],
           "dependencies": [
             "b#build",
@@ -60,9 +57,8 @@ exports[`info command basic info test case 1`] = `
         },
         {
           "command": [
-            "yarn",
-            "run",
-            "build",
+            "node",
+            "./build.js",
           ],
           "dependencies": [
             "__start",
@@ -102,9 +98,8 @@ exports[`info command scoped info test case 1`] = `
         },
         {
           "command": [
-            "yarn",
-            "run",
-            "test",
+            "node",
+            "./test.js",
           ],
           "dependencies": [
             "b#build",
@@ -116,9 +111,8 @@ exports[`info command scoped info test case 1`] = `
         },
         {
           "command": [
-            "yarn",
-            "run",
-            "build",
+            "node",
+            "./build.js",
           ],
           "dependencies": [
             "__start",

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import { readFile } from "fs/promises";
 import { spawn, type ChildProcess } from "child_process";
+import os from "os";
 import type { TargetRunner, TargetRunnerOptions } from "./types/TargetRunner.js";
 import type { Target } from "@lage-run/target-graph";
 
@@ -103,7 +104,7 @@ export class NpmScriptRunner implements TargetRunner {
         cwd: target.cwd,
         stdio: ["inherit", "pipe", "pipe"],
         // This is required for Windows due to https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-        shell: true,
+        ...(os.platform() === "win32" && { shell: true }),
         env: {
           ...(process.stdout.isTTY && { FORCE_COLOR: "1" }), // allow user env to override this
           ...process.env,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,11 +1716,13 @@ __metadata:
     "@lage-run/target-graph": "npm:^0.9.3"
     "@lage-run/worker-threads-pool": "npm:^0.8.4"
     "@types/proper-lockfile": "npm:^4.1.4"
+    "@types/shell-quote": "npm:^1.7.5"
     chokidar: "npm:3.5.3"
     commander: "npm:9.5.0"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.2"
     proper-lockfile: "npm:^4.1.2"
+    shell-quote: "npm:^1.8.1"
     workspace-tools: "npm:0.37.0"
   bin:
     lage: ./bin/lage.js
@@ -2347,6 +2349,13 @@ __metadata:
   version: 7.3.13
   resolution: "@types/semver@npm:7.3.13"
   checksum: 10c0/73295bb1fee46f8c76c7a759feeae5a3022f5bedfdc17d16982092e4b33af17560234fb94861560c20992a702a1e1b9a173bb623a96f95f80892105f5e7d25e3
+  languageName: node
+  linkType: hard
+
+"@types/shell-quote@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@types/shell-quote@npm:1.7.5"
+  checksum: 10c0/ddcf225e85e5520e3f44411d7d79eee0e56477fab705d0d93e293b61b9f8de2a57db6e859d492a24bc9e0d071c0490271efeae832756e2ac0d4d255922ac281d
   languageName: node
   linkType: hard
 
@@ -7678,6 +7687,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "shell-quote@npm:1.8.1"
+  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In some circumstances, it might be advantageous to skip using the npm client at all to launch a script. This can shave time and take advantage of underlying schedulers' ability to launch processes. Currently, if the "script" section has a definition of a "node" script:

`node xyz.js` 

then `lage info` will generate a command that directly uses it without passing an additional layer of the npm client. For example, buildxl can receive this and launch the `node xyz.js` command directly.
