### PR TITLE
adding sourcemaps when doing compile; adds shouldRun() capability on a per-target basis

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://swc.rs/schema.json",
   "jsc": {
     "parser": {
       "syntax": "typescript",
@@ -10,5 +11,6 @@
   "module": {
     "type": "commonjs",
     "ignoreDynamic": true
-  }
+  },
+  "sourceMaps": true
 }

--- a/change/change-63e56fb2-e6c8-4e28-bfeb-5c8af37dbccd.json
+++ b/change/change-63e56fb2-e6c8-4e28-bfeb-5c8af37dbccd.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "add \"shouldRun()\" config to the target config",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "add \"shouldRun()\" config to the target config",
+      "packageName": "@lage-run/runners",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "add \"shouldRun()\" config to the target config",
+      "packageName": "@lage-run/target-graph",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/exec/executeInProcess.ts
+++ b/packages/cli/src/commands/exec/executeInProcess.ts
@@ -106,7 +106,9 @@ export async function executeInProcess({ cwd, args, nodeArg, logger }: ExecuteIn
 
   const definition = expandTargetDefinition(isGlobal ? undefined : info.name, task, pipeline, config.cacheOptions.outputGlob ?? []);
 
-  const target = isGlobal ? factory.createGlobalTarget(task, definition) : factory.createPackageTarget(info.name, task, definition);
+  const target = isGlobal
+    ? await factory.createGlobalTarget(task, definition)
+    : await factory.createPackageTarget(info.name, task, definition);
   const pickerOptions = runnerPickerOptions(nodeArg, config.npmClient, taskArgs);
 
   const runnerPicker = new TargetRunnerPicker(pickerOptions);

--- a/packages/cli/src/commands/exec/executeInProcess.ts
+++ b/packages/cli/src/commands/exec/executeInProcess.ts
@@ -106,9 +106,7 @@ export async function executeInProcess({ cwd, args, nodeArg, logger }: ExecuteIn
 
   const definition = expandTargetDefinition(isGlobal ? undefined : info.name, task, pipeline, config.cacheOptions.outputGlob ?? []);
 
-  const target = isGlobal
-    ? await factory.createGlobalTarget(task, definition)
-    : await factory.createPackageTarget(info.name, task, definition);
+  const target = isGlobal ? factory.createGlobalTarget(task, definition) : factory.createPackageTarget(info.name, task, definition);
   const pickerOptions = runnerPickerOptions(nodeArg, config.npmClient, taskArgs);
 
   const runnerPicker = new TargetRunnerPicker(pickerOptions);

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -90,7 +90,7 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
 
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 
-  const targetGraph = createTargetGraph({
+  const targetGraph = await createTargetGraph({
     logger,
     root,
     dependencies: options.dependencies,

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -38,16 +38,16 @@ export async function createTargetGraph(options: CreateTargetGraphOptions) {
 
   for (const [id, definition] of Object.entries(pipeline)) {
     if (Array.isArray(definition)) {
-      await builder.addTargetConfig(id, {
+      builder.addTargetConfig(id, {
         cache: true,
         dependsOn: definition,
         options: {},
         outputs,
       });
     } else {
-      await builder.addTargetConfig(id, definition);
+      builder.addTargetConfig(id, definition);
     }
   }
 
-  return builder.build(tasks, packages);
+  return await builder.build(tasks, packages);
 }

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -19,7 +19,7 @@ interface CreateTargetGraphOptions {
   packageInfos: PackageInfos;
 }
 
-export function createTargetGraph(options: CreateTargetGraphOptions) {
+export async function createTargetGraph(options: CreateTargetGraphOptions) {
   const { logger, root, dependencies, dependents, since, scope, repoWideChanges, ignore, pipeline, outputs, tasks, packageInfos } = options;
 
   const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
@@ -38,14 +38,14 @@ export function createTargetGraph(options: CreateTargetGraphOptions) {
 
   for (const [id, definition] of Object.entries(pipeline)) {
     if (Array.isArray(definition)) {
-      builder.addTargetConfig(id, {
+      await builder.addTargetConfig(id, {
         cache: true,
         dependsOn: definition,
         options: {},
         outputs,
       });
     } else {
-      builder.addTargetConfig(id, definition);
+      await builder.addTargetConfig(id, definition);
     }
   }
 

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -49,7 +49,7 @@ export async function runAction(options: RunOptions, command: Command) {
 
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 
-  const targetGraph = createTargetGraph({
+  const targetGraph = await createTargetGraph({
     logger,
     root,
     dependencies: options.dependencies,

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -48,7 +48,7 @@ export async function watchAction(options: RunOptions, command: Command) {
 
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 
-  const targetGraph = createTargetGraph({
+  const targetGraph = await createTargetGraph({
     logger,
     root,
     dependencies: options.dependencies,

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -71,7 +71,7 @@ async function initialize({ cwd, logger, serverControls, nodeArg, taskArgs, maxW
     const packageInfos = getPackageInfos(root);
     const tasks = findAllTasks(pipeline);
 
-    const targetGraph = createTargetGraph({
+    const targetGraph = await createTargetGraph({
       logger,
       root,
       dependencies: false,

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -48,7 +48,19 @@ export class NpmScriptRunner implements TargetRunner {
 
   async shouldRun(target: Target) {
     // By convention, do not run anything if there is no script for this task defined in package.json (counts as "success")
-    return await this.hasNpmScript(target);
+    const hasNpmScript = await this.hasNpmScript(target);
+
+    if (target.options?.shouldRun) {
+      const result = target.options.shouldRun(target, hasNpmScript);
+
+      if (result.then) {
+        return await result;
+      }
+
+      return result;
+    }
+
+    return hasNpmScript;
   }
 
   async run(runOptions: TargetRunnerOptions) {

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -50,17 +50,7 @@ export class NpmScriptRunner implements TargetRunner {
     // By convention, do not run anything if there is no script for this task defined in package.json (counts as "success")
     const hasNpmScript = await this.hasNpmScript(target);
 
-    if (target.options?.shouldRun) {
-      const result = target.options.shouldRun(target, hasNpmScript);
-
-      if (result.then) {
-        return await result;
-      }
-
-      return result;
-    }
-
-    return hasNpmScript;
+    return hasNpmScript && (target.shouldRun ?? true);
   }
 
   async run(runOptions: TargetRunnerOptions) {

--- a/packages/runners/src/WorkerRunner.ts
+++ b/packages/runners/src/WorkerRunner.ts
@@ -50,10 +50,10 @@ export class WorkerRunner implements TargetRunner {
     const scriptModule = await this.getScriptModule(target);
 
     if (typeof scriptModule.shouldRun === "function") {
-      return await scriptModule.shouldRun(target);
+      return (await scriptModule.shouldRun(target)) && (target.shouldRun ?? true);
     }
 
-    return true;
+    return target.shouldRun ?? true;
   }
 
   async run(runOptions: TargetRunnerOptions) {

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -17,6 +17,7 @@
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
+    "p-limit": "^3.1.0",
     "workspace-tools": "0.37.0"
   },
   "devDependencies": {

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -42,7 +42,7 @@ export class TargetFactory {
    * @param config
    * @returns a package task `Target`
    */
-  async createPackageTarget(packageName: string, task: string, config: TargetConfig): Promise<Target> {
+  createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
     const { resolve } = this.options;
     const { options, deps, dependsOn, cache, inputs, priority, maxWorkers, environmentGlob, weight } = config;
     const cwd = resolve(packageName);
@@ -75,7 +75,7 @@ export class TargetFactory {
     return target;
   }
 
-  async createGlobalTarget(id: string, config: TargetConfig): Promise<Target> {
+  createGlobalTarget(id: string, config: TargetConfig): Target {
     const { root } = this.options;
     const { options, deps, dependsOn, cache, inputs, outputs, priority, maxWorkers, environmentGlob, weight } = config;
     const { task } = getPackageAndTask(id);

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -71,7 +71,6 @@ export class TargetFactory {
     };
 
     target.weight = getWeight(target, weight, maxWorkers);
-    target.shouldRun = await this.shouldRun(config, target);
 
     return target;
   }
@@ -101,16 +100,7 @@ export class TargetFactory {
     };
 
     target.weight = getWeight(target, weight, maxWorkers);
-    target.shouldRun = await this.shouldRun(config, target);
 
     return target;
-  }
-
-  shouldRun(config: TargetConfig, target: Target) {
-    if (typeof config.shouldRun === "function") {
-      return config.shouldRun(target);
-    }
-
-    return true;
   }
 }

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -67,9 +67,11 @@ export class TargetFactory {
       environmentGlob,
       weight: 1,
       options,
+      shouldRun: true,
     };
 
     target.weight = getWeight(target, weight, maxWorkers);
+    target.shouldRun = this.shouldRun(config, target);
 
     return target;
   }
@@ -95,10 +97,20 @@ export class TargetFactory {
       environmentGlob,
       weight: 1,
       options,
+      shouldRun: true,
     };
 
     target.weight = getWeight(target, weight, maxWorkers);
+    target.shouldRun = this.shouldRun(config, target);
 
     return target;
+  }
+
+  shouldRun(config: TargetConfig, target: Target) {
+    if (typeof config.shouldRun === "function") {
+      return config.shouldRun(target);
+    }
+
+    return true;
   }
 }

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -42,7 +42,7 @@ export class TargetFactory {
    * @param config
    * @returns a package task `Target`
    */
-  createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
+  async createPackageTarget(packageName: string, task: string, config: TargetConfig): Promise<Target> {
     const { resolve } = this.options;
     const { options, deps, dependsOn, cache, inputs, priority, maxWorkers, environmentGlob, weight } = config;
     const cwd = resolve(packageName);
@@ -71,12 +71,12 @@ export class TargetFactory {
     };
 
     target.weight = getWeight(target, weight, maxWorkers);
-    target.shouldRun = this.shouldRun(config, target);
+    target.shouldRun = await this.shouldRun(config, target);
 
     return target;
   }
 
-  createGlobalTarget(id: string, config: TargetConfig): Target {
+  async createGlobalTarget(id: string, config: TargetConfig): Promise<Target> {
     const { root } = this.options;
     const { options, deps, dependsOn, cache, inputs, outputs, priority, maxWorkers, environmentGlob, weight } = config;
     const { task } = getPackageAndTask(id);
@@ -101,7 +101,7 @@ export class TargetFactory {
     };
 
     target.weight = getWeight(target, weight, maxWorkers);
-    target.shouldRun = this.shouldRun(config, target);
+    target.shouldRun = await this.shouldRun(config, target);
 
     return target;
   }

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -80,6 +80,14 @@ export class WorkspaceTargetGraphBuilder {
     }
   }
 
+  shouldRun(config: TargetConfig, target: Target) {
+    if (typeof config.shouldRun === "function") {
+      return config.shouldRun(target);
+    }
+
+    return true;
+  }
+
   /**
    * Builds a scoped target graph for given tasks and packages
    *

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -60,21 +60,21 @@ export class WorkspaceTargetGraphBuilder {
    * @param id
    * @param targetDefinition
    */
-  addTargetConfig(id: string, config: TargetConfig = {}): void {
+  async addTargetConfig(id: string, config: TargetConfig = {}) {
     // Generates a target definition from the target config
     if (id.startsWith("//") || id.startsWith("#")) {
-      const target = this.targetFactory.createGlobalTarget(id, config);
+      const target = await this.targetFactory.createGlobalTarget(id, config);
       this.graphBuilder.addTarget(target);
       this.hasRootTarget = true;
     } else if (id.includes("#")) {
       const { packageName, task } = getPackageAndTask(id);
-      const target = this.targetFactory.createPackageTarget(packageName!, task, config);
+      const target = await this.targetFactory.createPackageTarget(packageName!, task, config);
       this.graphBuilder.addTarget(target);
     } else {
       const packages = Object.keys(this.packageInfos);
       for (const packageName of packages) {
         const task = id;
-        const target = this.targetFactory.createPackageTarget(packageName!, task, config);
+        const target = await this.targetFactory.createPackageTarget(packageName!, task, config);
         this.graphBuilder.addTarget(target);
       }
     }

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -6,9 +6,11 @@ import path from "path";
 
 import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
 import type { PackageInfos } from "workspace-tools";
+import type { Target } from "./types/Target.js";
 import type { TargetConfig } from "./types/TargetConfig.js";
 import { TargetGraphBuilder } from "./TargetGraphBuilder.js";
 import { TargetFactory } from "./TargetFactory.js";
+import pLimit from "p-limit";
 
 /**
  * TargetGraphBuilder class provides a builder API for registering target configs. It exposes a method called `generateTargetGraph` to
@@ -32,6 +34,8 @@ export class WorkspaceTargetGraphBuilder {
   private targetFactory: TargetFactory;
 
   private hasRootTarget = false;
+
+  private targetConfigMap = new Map<string, TargetConfig>();
 
   /**
    * Initializes the builder with package infos
@@ -63,19 +67,22 @@ export class WorkspaceTargetGraphBuilder {
   async addTargetConfig(id: string, config: TargetConfig = {}) {
     // Generates a target definition from the target config
     if (id.startsWith("//") || id.startsWith("#")) {
-      const target = await this.targetFactory.createGlobalTarget(id, config);
+      const target = this.targetFactory.createGlobalTarget(id, config);
       this.graphBuilder.addTarget(target);
+      this.targetConfigMap.set(id, config);
       this.hasRootTarget = true;
     } else if (id.includes("#")) {
       const { packageName, task } = getPackageAndTask(id);
-      const target = await this.targetFactory.createPackageTarget(packageName!, task, config);
+      const target = this.targetFactory.createPackageTarget(packageName!, task, config);
       this.graphBuilder.addTarget(target);
+      this.targetConfigMap.set(id, config);
     } else {
       const packages = Object.keys(this.packageInfos);
       for (const packageName of packages) {
         const task = id;
-        const target = await this.targetFactory.createPackageTarget(packageName!, task, config);
+        const target = this.targetFactory.createPackageTarget(packageName!, task, config);
         this.graphBuilder.addTarget(target);
+        this.targetConfigMap.set(id, config);
       }
     }
   }
@@ -101,7 +108,7 @@ export class WorkspaceTargetGraphBuilder {
    * @param scope
    * @returns
    */
-  build(tasks: string[], scope?: string[]) {
+  async build(tasks: string[], scope?: string[]) {
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(this.graphBuilder.targets, this.dependencyMap);
 
@@ -131,6 +138,21 @@ export class WorkspaceTargetGraphBuilder {
     }
 
     const subGraph = this.graphBuilder.subgraph(subGraphEntries);
+
+    const limit = pLimit(8);
+    const setShouldRunPromises: Promise<void>[] = [];
+    for (const target of subGraph.targets.values()) {
+      const config = this.targetConfigMap.get(target.id);
+      if (config) {
+        setShouldRunPromises.push(
+          limit(async () => {
+            target.shouldRun = await this.shouldRun(config, target);
+          })
+        );
+      }
+    }
+
+    await Promise.all(setShouldRunPromises);
 
     return {
       targets: subGraph.targets,

--- a/packages/target-graph/src/types/Target.ts
+++ b/packages/target-graph/src/types/Target.ts
@@ -92,4 +92,9 @@ export interface Target {
    * Whether the target should be displayed by reporters
    */
   hidden?: boolean;
+
+  /**
+   * Whether the target should be run
+   */
+  shouldRun?: boolean;
 }

--- a/packages/target-graph/src/types/TargetConfig.ts
+++ b/packages/target-graph/src/types/TargetConfig.ts
@@ -75,5 +75,5 @@ export interface TargetConfig {
    */
   options?: Record<string, any>;
 
-  shouldRun?: (target: Target) => boolean;
+  shouldRun?: (target: Target) => boolean | Promise<boolean>;
 }

--- a/packages/target-graph/src/types/TargetConfig.ts
+++ b/packages/target-graph/src/types/TargetConfig.ts
@@ -74,4 +74,6 @@ export interface TargetConfig {
    * Run options for the Target Runner. (e.g. `{ env: ...process.env, colors: true, ... }`)
    */
   options?: Record<string, any>;
+
+  shouldRun?: (target: Target) => boolean;
 }

--- a/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
@@ -1,6 +1,6 @@
 import type { PackageInfos } from "workspace-tools";
-import { WorkspaceTargetGraphBuilder } from "../src/WorkspaceTargetGraphBuilder";
-import type { TargetGraph } from "../src/types/TargetGraph";
+import { WorkspaceTargetGraphBuilder } from "../src/WorkspaceTargetGraphBuilder.js";
+import type { TargetGraph } from "../src/types/TargetGraph.js";
 
 function createPackageInfo(packages: { [id: string]: string[] }) {
   const packageInfos: PackageInfos = {};
@@ -30,7 +30,7 @@ function getGraphFromTargets(targetGraph: TargetGraph) {
 }
 
 describe("workspace target graph builder", () => {
-  it("should build a target based on a simple package graph and task graph", () => {
+  it("should build a target based on a simple package graph and task graph", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -43,7 +43,7 @@ describe("workspace target graph builder", () => {
       dependsOn: ["^build"],
     });
 
-    const targetGraph = builder.build(["build"]);
+    const targetGraph = await builder.build(["build"]);
 
     // size is 3, because we also need to account for the root target node (start target ID)
     expect(targetGraph.targets.size).toBe(3);
@@ -66,7 +66,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should generate target graphs for tasks that do not depend on each other", () => {
+  it("should generate target graphs for tasks that do not depend on each other", async () => {
     const root = "/repos/a";
     const packageInfos = createPackageInfo({
       a: ["b"],
@@ -77,7 +77,7 @@ describe("workspace target graph builder", () => {
     builder.addTargetConfig("test");
     builder.addTargetConfig("lint");
 
-    const targetGraph = builder.build(["test", "lint"]);
+    const targetGraph = await builder.build(["test", "lint"]);
 
     // includes the pseudo-target for the "start" target
     expect(targetGraph.targets.size).toBe(5);
@@ -103,7 +103,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should generate targetGraph with some specific package task target dependencies, running against all packages", () => {
+  it("should generate targetGraph with some specific package task target dependencies, running against all packages", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -122,7 +122,7 @@ describe("workspace target graph builder", () => {
       dependsOn: [],
     });
 
-    const targetGraph = builder.build(["build"]);
+    const targetGraph = await builder.build(["build"]);
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [
         [
@@ -145,7 +145,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should generate targetGraph with some specific package task target dependencies, running against a specific package", () => {
+  it("should generate targetGraph with some specific package task target dependencies, running against a specific package", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -164,7 +164,7 @@ describe("workspace target graph builder", () => {
       dependsOn: [],
     });
 
-    const targetGraph = builder.build(["build"], ["a", "b"]);
+    const targetGraph = await builder.build(["build"], ["a", "b"]);
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [
         [
@@ -179,7 +179,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should generate targetGraph with transitive dependencies", () => {
+  it("should generate targetGraph with transitive dependencies", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -196,7 +196,7 @@ describe("workspace target graph builder", () => {
 
     builder.addTargetConfig("transpile");
 
-    const targetGraph = builder.build(["bundle"], ["a"]);
+    const targetGraph = await builder.build(["bundle"], ["a"]);
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [
         [
@@ -223,7 +223,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should generate target graph for a general task on a specific target", () => {
+  it("should generate target graph for a general task on a specific target", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -242,7 +242,7 @@ describe("workspace target graph builder", () => {
     builder.addTargetConfig("common#copy");
     builder.addTargetConfig("common#build");
 
-    const targetGraph = builder.build(["build"]);
+    const targetGraph = await builder.build(["build"]);
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [
         [
@@ -281,7 +281,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should build a target graph with global task as a dependency", () => {
+  it("should build a target graph with global task as a dependency", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -298,7 +298,7 @@ describe("workspace target graph builder", () => {
       dependsOn: [],
     });
 
-    const targetGraph = builder.build(["build"]);
+    const targetGraph = await builder.build(["build"]);
 
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [
@@ -330,7 +330,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should build a target graph with global task on its own", () => {
+  it("should build a target graph with global task on its own", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -347,7 +347,7 @@ describe("workspace target graph builder", () => {
       dependsOn: [],
     });
 
-    const targetGraph = builder.build(["global:task"]);
+    const targetGraph = await builder.build(["global:task"]);
 
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [
@@ -359,7 +359,7 @@ describe("workspace target graph builder", () => {
     `);
   });
 
-  it("should build a target graph without including global task", () => {
+  it("should build a target graph without including global task", async () => {
     const root = "/repos/a";
 
     const packageInfos = createPackageInfo({
@@ -376,7 +376,7 @@ describe("workspace target graph builder", () => {
       dependsOn: [],
     });
 
-    const targetGraph = builder.build(["build"]);
+    const targetGraph = await builder.build(["build"]);
 
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "bin": "bin/monorepo-scripts.js",
   "dependencies": {
-    "@swc/core": "^1.3.14",
-    "@swc/jest": "^0.2.36",
+    "@swc/core": "^1.9.1",
+    "@swc/jest": "^0.2.37",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "depcheck": "^1.4.7",

--- a/scripts/worker/transpile.js
+++ b/scripts/worker/transpile.js
@@ -28,13 +28,20 @@ module.exports = async function transpile(data) {
       if (entry.isDirectory() && entry.name !== "node_modules" && entry.name !== "lib" && entry.name !== "tests" && entry.name !== "dist") {
         queue.push(fullPath);
       } else if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
-        const swcOutput = await swc.transformFile(fullPath, swcOptions);
         const dest = fullPath
           .replace(/([/\\])src/, "$1lib")
           .replace(".tsx", ".js")
           .replace(".ts", ".js");
+
+        const swcOutput = await swc.transformFile(fullPath, { ...swcOptions, sourceFileName: path.relative(path.dirname(dest), fullPath).replace(/\\/g, "/") });
+
+        const destMap = dest + ".map";
         await fsPromises.mkdir(path.dirname(dest), { recursive: true });
         await fsPromises.writeFile(dest, swcOutput.code);
+
+        if (swcOutput.map) {
+          await fsPromises.writeFile(destMap, swcOutput.map);
+        }
       }
     }
   }

--- a/scripts/worker/transpile.js
+++ b/scripts/worker/transpile.js
@@ -33,7 +33,10 @@ module.exports = async function transpile(data) {
           .replace(".tsx", ".js")
           .replace(".ts", ".js");
 
-        const swcOutput = await swc.transformFile(fullPath, { ...swcOptions, sourceFileName: path.relative(path.dirname(dest), fullPath).replace(/\\/g, "/") });
+        const swcOutput = await swc.transformFile(fullPath, {
+          ...swcOptions,
+          sourceFileName: path.relative(path.dirname(dest), fullPath).replace(/\\/g, "/"),
+        });
 
         const destMap = dest + ".map";
         await fsPromises.mkdir(path.dirname(dest), { recursive: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,8 +1836,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lage-run/monorepo-scripts@workspace:scripts"
   dependencies:
-    "@swc/core": "npm:^1.3.14"
-    "@swc/jest": "npm:^0.2.36"
+    "@swc/core": "npm:^1.9.1"
+    "@swc/jest": "npm:^0.2.37"
     "@typescript-eslint/eslint-plugin": "npm:^5.30.7"
     "@typescript-eslint/parser": "npm:^5.30.7"
     depcheck: "npm:^1.4.7"
@@ -2037,92 +2037,94 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-darwin-arm64@npm:1.3.56"
+"@swc/core-darwin-arm64@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-darwin-arm64@npm:1.9.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-darwin-x64@npm:1.3.56"
+"@swc/core-darwin-x64@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-darwin-x64@npm:1.9.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.56"
+"@swc/core-linux-arm-gnueabihf@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.9.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.56"
+"@swc/core-linux-arm64-gnu@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.9.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-linux-arm64-musl@npm:1.3.56"
+"@swc/core-linux-arm64-musl@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-linux-arm64-musl@npm:1.9.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-linux-x64-gnu@npm:1.3.56"
+"@swc/core-linux-x64-gnu@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-linux-x64-gnu@npm:1.9.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-linux-x64-musl@npm:1.3.56"
+"@swc/core-linux-x64-musl@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-linux-x64-musl@npm:1.9.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.56"
+"@swc/core-win32-arm64-msvc@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.9.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.56"
+"@swc/core-win32-ia32-msvc@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.9.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.3.56":
-  version: 1.3.56
-  resolution: "@swc/core-win32-x64-msvc@npm:1.3.56"
+"@swc/core-win32-x64-msvc@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core-win32-x64-msvc@npm:1.9.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.3.14":
-  version: 1.3.56
-  resolution: "@swc/core@npm:1.3.56"
+"@swc/core@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@swc/core@npm:1.9.1"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.3.56"
-    "@swc/core-darwin-x64": "npm:1.3.56"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.3.56"
-    "@swc/core-linux-arm64-gnu": "npm:1.3.56"
-    "@swc/core-linux-arm64-musl": "npm:1.3.56"
-    "@swc/core-linux-x64-gnu": "npm:1.3.56"
-    "@swc/core-linux-x64-musl": "npm:1.3.56"
-    "@swc/core-win32-arm64-msvc": "npm:1.3.56"
-    "@swc/core-win32-ia32-msvc": "npm:1.3.56"
-    "@swc/core-win32-x64-msvc": "npm:1.3.56"
+    "@swc/core-darwin-arm64": "npm:1.9.1"
+    "@swc/core-darwin-x64": "npm:1.9.1"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.9.1"
+    "@swc/core-linux-arm64-gnu": "npm:1.9.1"
+    "@swc/core-linux-arm64-musl": "npm:1.9.1"
+    "@swc/core-linux-x64-gnu": "npm:1.9.1"
+    "@swc/core-linux-x64-musl": "npm:1.9.1"
+    "@swc/core-win32-arm64-msvc": "npm:1.9.1"
+    "@swc/core-win32-ia32-msvc": "npm:1.9.1"
+    "@swc/core-win32-x64-msvc": "npm:1.9.1"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.14"
   peerDependencies:
-    "@swc/helpers": ^0.5.0
+    "@swc/helpers": "*"
   dependenciesMeta:
     "@swc/core-darwin-arm64":
       optional: true
@@ -2147,7 +2149,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: 10c0/c468e281f0249742bc0ba4b7cd4076cdbf87bfc82b8bd5ad1ca8940d36372ca22754df80ab54b22613121680718eab26b92c48c8c9f5f3abb24434f05e5e1ea0
+  checksum: 10c0/7b9a3da9bdd95216b031739ebe35983e69f17284809a62706c93edfd30ede0732060d944db23007aca9aebbc49859eb5784454c8882ae6fd04eb8bd15ac6a247
   languageName: node
   linkType: hard
 
@@ -2158,16 +2160,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/jest@npm:^0.2.36":
-  version: 0.2.36
-  resolution: "@swc/jest@npm:0.2.36"
+"@swc/jest@npm:^0.2.37":
+  version: 0.2.37
+  resolution: "@swc/jest@npm:0.2.37"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.7.0"
     "@swc/counter": "npm:^0.1.3"
     jsonc-parser: "npm:^3.2.0"
   peerDependencies:
     "@swc/core": "*"
-  checksum: 10c0/7f1993f9201420bb499c92ab28797352bcbf9e3a6c7b5a1806fdc34c9c3b46ea9e5b2f070c0e13fcf7f3c3fadbbc38777840baabb178f589bf1f67543763adb6
+  checksum: 10c0/abe10d87610bf7c172aa7ab14c64599a22e48c1f43a09d6e22733f85f25fb98e57cb4bb58b9554e60a3ac8629be559bd967d7a8601a3ceaacad618aecccebec2
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.14":
+  version: 0.1.14
+  resolution: "@swc/types@npm:0.1.14"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10c0/5ab5a213f25fbb038e8b2fa001a20c64363f81c199319373ed0228f316c046a996758fbaf906ba84d297b35e37727082d27974266db320e534da594716626529
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,6 +1922,7 @@ __metadata:
   dependencies:
     "@lage-run/monorepo-scripts": "npm:*"
     jest-diff: "npm:^29.5.0"
+    p-limit: "npm:^3.1.0"
     workspace-tools: "npm:0.37.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This pull request introduces several changes to improve the target graph creation process by making it asynchronous and adding a `shouldRun` configuration. Additionally, it includes updates to the configuration files and dependencies.

### Enhancements to target graph creation:

* `packages/cli/src/commands/info/action.ts`, `packages/cli/src/commands/run/createTargetGraph.ts`, `packages/cli/src/commands/run/runAction.ts`, `packages/cli/src/commands/run/watchAction.ts`, `packages/cli/src/commands/server/lageService.ts`: Modified the `createTargetGraph` function to be asynchronous. [[1]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL93-R93) [[2]](diffhunk://#diff-53c82ed16e017ef37948c4cc8f57206a84309f85f8a60158cae5d1e699f1e4ccL22-R22) [[3]](diffhunk://#diff-53c82ed16e017ef37948c4cc8f57206a84309f85f8a60158cae5d1e699f1e4ccL52-R52) [[4]](diffhunk://#diff-38d6eaa925c1475dfbca516c9345813b93ae2ab038b09aa2e4b03858b4d50b4dL52-R52) [[5]](diffhunk://#diff-942b6a2e47b6e53da824b6b798942262791c45ec28abf099a734b61b683bd8a3L51-R51) [[6]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L74-R74)

### Introduction of `shouldRun` configuration:

* `packages/runners/src/NpmScriptRunner.ts`, `packages/runners/src/WorkerRunner.ts`, `packages/target-graph/src/TargetFactory.ts`, `packages/target-graph/src/WorkspaceTargetGraphBuilder.ts`, `packages/target-graph/src/types/Target.ts`, `packages/target-graph/src/types/TargetConfig.ts`: Added support for `shouldRun` configuration to determine if a target should be executed. [[1]](diffhunk://#diff-6dbefa71fef7e5ffecb1c933b02b41183a5a699665e76e729bf808b4fa50b951L51-R53) [[2]](diffhunk://#diff-30c4843c7fb1729a66300faffb84953735f83f9c893481cfc248b2a53bba28f9L53-R56) [[3]](diffhunk://#diff-05ed79e2b6d527974ec9b3f4fa321eaccccf2132f635fe9ef38f719403702742R70) [[4]](diffhunk://#diff-05ed79e2b6d527974ec9b3f4fa321eaccccf2132f635fe9ef38f719403702742R99) [[5]](diffhunk://#diff-e2d1d34f1c562fb2a5f8b69f4704e6b1e8948887fe8502fb5a7c8ab6d00c2343R9-R13) [[6]](diffhunk://#diff-e2d1d34f1c562fb2a5f8b69f4704e6b1e8948887fe8502fb5a7c8ab6d00c2343R38-R39) [[7]](diffhunk://#diff-e2d1d34f1c562fb2a5f8b69f4704e6b1e8948887fe8502fb5a7c8ab6d00c2343L63-R95) [[8]](diffhunk://#diff-e2d1d34f1c562fb2a5f8b69f4704e6b1e8948887fe8502fb5a7c8ab6d00c2343L96-R111) [[9]](diffhunk://#diff-e2d1d34f1c562fb2a5f8b69f4704e6b1e8948887fe8502fb5a7c8ab6d00c2343R142-R156) [[10]](diffhunk://#diff-343b24fcad95fdb5fce146b709fe4144fd3059f26dd706ab32fe1bf73fbb16beR95-R99) [[11]](diffhunk://#diff-5cbf884a989d38aed69a09c47d9c98e8940a9983b9a91b4aeb06f5ddb0049d47R77-R78)

### Configuration and dependency updates:

* [`.swcrc`](diffhunk://#diff-77a5276f1f91b0001697639c96553e2e0cfc71a6741500c4d5f8752a5df5a9dbR2): Added schema reference and enabled source maps. [[1]](diffhunk://#diff-77a5276f1f91b0001697639c96553e2e0cfc71a6741500c4d5f8752a5df5a9dbR2) [[2]](diffhunk://#diff-77a5276f1f91b0001697639c96553e2e0cfc71a6741500c4d5f8752a5df5a9dbL13-R15)
* [`packages/target-graph/package.json`](diffhunk://#diff-ade5d9fcaefbb413b49e571197dbe5a86a1ff056083ca31724e702fe3573be7eR20): Added `p-limit` dependency.

### Test updates:

* [`packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts`](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L2-R3): Updated tests to accommodate asynchronous `build` method. [[1]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L2-R3) [[2]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L33-R33) [[3]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L46-R46) [[4]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L69-R69) [[5]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L80-R80) [[6]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L106-R106) [[7]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L125-R125) [[8]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L148-R148) [[9]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L167-R167) [[10]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L182-R182) [[11]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L199-R199) [[12]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L226-R226) [[13]](diffhunk://#diff-deda3ef79d33573ed6515d635e42d7299920effee56257bc5ae800ad773357f3L245-R245)

### Minor changes:

* [`change/change-63e56fb2-e6c8-4e28-bfeb-5c8af37dbccd.json`](diffhunk://#diff-2c225817611999a4e8548ea1869850caaf3a3d771ae7503db88c6af9905e9955R1-R25): Added minor changes related to `shouldRun` configuration.This pull request includes several changes to improve the configuration, enhance functionality, and update dependencies. The key changes are grouped by theme and summarized below:

### Configuration Improvements:

* [`.swcrc`](diffhunk://#diff-77a5276f1f91b0001697639c96553e2e0cfc71a6741500c4d5f8752a5df5a9dbR2): Added a schema reference and enabled source maps. [[1]](diffhunk://#diff-77a5276f1f91b0001697639c96553e2e0cfc71a6741500c4d5f8752a5df5a9dbR2) [[2]](diffhunk://#diff-77a5276f1f91b0001697639c96553e2e0cfc71a6741500c4d5f8752a5df5a9dbL13-R15)

### Functionality Enhancements:

* [`packages/runners/src/NpmScriptRunner.ts`](diffhunk://#diff-6dbefa71fef7e5ffecb1c933b02b41183a5a699665e76e729bf808b4fa50b951L51-R63): Modified the `shouldRun` method to allow custom logic for determining whether a script should run, based on `target.options.shouldRun`.
* [`scripts/worker/transpile.js`](diffhunk://#diff-e2d37f336dcea6f9ecbb11eb1ef6ee567f84c2b314ca9d683710254d40a14f40L31-R44): Updated the `transpile` function to include source map generation and write source maps to disk if present.

### Dependency Updates:

* [`scripts/package.json`](diffhunk://#diff-d74f97384f03053c517e34bcd695eefd751944cd55183d693ae99ef3bc50d016L7-R8): Updated `@swc/core` to version `^1.9.1` and `@swc/jest` to version `^0.2.37`.