### PR TITLE
Escape ADO cache write to remote cache with env.LAGE_WRITE_CACHE=false 

### DIFF
--- a/change/change-0d4e37a4-9e94-45dd-95cf-b04a3edda384.json
+++ b/change/change-0d4e37a4-9e94-45dd-95cf-b04a3edda384.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Escape with env.LAGE_WRITE_CACHE",
+      "packageName": "@lage-run/scheduler",
+      "email": "brunoru@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/scheduler/src/cache/createCacheProvider.ts
+++ b/packages/scheduler/src/cache/createCacheProvider.ts
@@ -35,7 +35,7 @@ export async function createCache(options: CreateCacheOptions) {
           }),
     remoteCacheProvider: hasRemoteCacheConfig ? new BackfillCacheProvider({ logger, root, cacheOptions: cacheOptions ?? {} }) : undefined,
     writeRemoteCache:
-      cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI,
+      (cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI) && String(process.env.LAGE_WRITE_CACHE).toLowerCase() !== "false",
   });
 
   return { cacheProvider };

--- a/packages/scheduler/src/cache/createCacheProvider.ts
+++ b/packages/scheduler/src/cache/createCacheProvider.ts
@@ -35,7 +35,8 @@ export async function createCache(options: CreateCacheOptions) {
           }),
     remoteCacheProvider: hasRemoteCacheConfig ? new BackfillCacheProvider({ logger, root, cacheOptions: cacheOptions ?? {} }) : undefined,
     writeRemoteCache:
-      (cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI) && String(process.env.LAGE_WRITE_CACHE).toLowerCase() !== "false",
+      (cacheOptions?.writeRemoteCache === true || String(process.env.LAGE_WRITE_CACHE).toLowerCase() === "true" || isRunningFromCI) &&
+      String(process.env.LAGE_WRITE_CACHE).toLowerCase() !== "false",
   });
 
   return { cacheProvider };


### PR DESCRIPTION
As currently designed, there doesnt seem to be any way to override the write back behavior of one ADO pipeline over another due to isRunningFromCI always being true in a pipeline environment where `process.env.NODE_ENV !== "test"` is true.

```javascript
const isRunningFromCI = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);
```
since forcing `process.env.NODE_ENV` to equal true will change isRunningFromCI behavior in other parts of lage it is best to escape this issue by having env.LAGE_WRITE_CACHE overide it when set to false. 