### PR TITLE
Fix git command for getting untracked files in PackageTree.ts

### DIFF
--- a/change/change-c4e84858-7d91-4297-91aa-4754d7be8699.json
+++ b/change/change-c4e84858-7d91-4297-91aa-4754d7be8699.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix git command for getting untracked files in PackageTree.ts",
+      "packageName": "@lage-run/hasher",
+      "email": "slivanov@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/hasher/src/PackageTree.ts
+++ b/packages/hasher/src/PackageTree.ts
@@ -62,7 +62,7 @@ export class PackageTree {
 
     if (includeUntracked) {
       // Also get all untracked files in the workspace according to git
-      const lsOtherResults = await execa("git", ["ls-files", "-o", "--exclude-standard"], { cwd: root });
+      const lsOtherResults = await execa("git", ["ls-files", "-o", "-z", "--exclude-standard"], { cwd: root });
       if (lsOtherResults.exitCode === 0) {
         const files = lsOtherResults.stdout.split("\0").filter(Boolean);
         this.addToPackageTree(files);


### PR DESCRIPTION
Bug description:

1. Have 2+ untracked files changed in the repo
2. lage build
3. Change any of untracked files
4. lage build
5. Expected behavior: lage will rebuild package in which untracked file is changed
6. Actual behavior: lage does not build anything - it cash hits all packages - reason: Lage do not see untracked files correctly because git output is wrongly parsed.

Bug fix:
Add option "-z" in relevant git command
