### PR TITLE
added exit code support for the npm runner with the executeInProcess (lage exec) command

### DIFF
--- a/change/change-fcd9a2bc-fee7-4419-91cf-7232ab9f5f13.json
+++ b/change/change-fcd9a2bc-fee7-4419-91cf-7232ab9f5f13.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "adding exit code support for executeInProcess",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "adding exit code support for executeInProcess",
+      "packageName": "@lage-run/runners",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/exec/executeInProcess.ts
+++ b/packages/cli/src/commands/exec/executeInProcess.ts
@@ -114,11 +114,18 @@ export async function executeInProcess({ cwd, args, nodeArg, logger }: ExecuteIn
 
   if (await runner.shouldRun(target)) {
     logger.info("Running target", { target });
-    await runner.run({
+    const result = await runner.run({
       target,
       weight: 1,
       abortSignal: new AbortController().signal,
     });
+
+    if (typeof result?.exitCode !== "undefined" && result.exitCode !== 0) {
+      logger.error("Failed", { target });
+      process.exitCode = result.exitCode;
+      return;
+    }
+
     logger.info("Finished", { target });
   }
 }

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -137,7 +137,7 @@ export class NpmScriptRunner implements TargetRunner {
           return resolve({ exitCode: code });
         }
 
-        reject(new Error(`NPM Script Runner: ${npmCmd} ${npmRunArgs.join(" ")} exited with code ${code}`));
+        reject({ exitCode: code, error: new Error(`NPM Script Runner: ${npmCmd} ${npmRunArgs.join(" ")} exited with code ${code}`) });
       };
 
       const { pid } = childProcess;

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { readFile } from "fs/promises";
 import { spawn, type ChildProcess } from "child_process";
 import os from "os";
-import type { TargetRunner, TargetRunnerOptions } from "./types/TargetRunner.js";
+import type { RunnerResult, TargetRunner, TargetRunnerOptions } from "./types/TargetRunner.js";
 import type { Target } from "@lage-run/target-graph";
 
 export interface NpmScriptRunnerOptions {
@@ -53,7 +53,7 @@ export class NpmScriptRunner implements TargetRunner {
     return hasNpmScript && (target.shouldRun ?? true);
   }
 
-  async run(runOptions: TargetRunnerOptions) {
+  async run(runOptions: TargetRunnerOptions): Promise<RunnerResult> {
     const { target, weight, abortSignal } = runOptions;
     const { nodeOptions, npmCmd, taskArgs } = this.options;
     const task = target.options?.script ?? target.task;
@@ -66,7 +66,7 @@ export class NpmScriptRunner implements TargetRunner {
      */
     if (abortSignal) {
       if (abortSignal.aborted) {
-        return;
+        return { exitCode: 1 };
       }
 
       const abortSignalHandler = () => {
@@ -101,7 +101,7 @@ export class NpmScriptRunner implements TargetRunner {
     const npmRunArgs = this.getNpmArgs(task, taskArgs);
     const npmRunNodeOptions = [nodeOptions, target.options?.nodeOptions].filter((str) => str).join(" ");
 
-    await new Promise<void>((resolve, reject) => {
+    return await new Promise<RunnerResult>((resolve, reject) => {
       childProcess = spawn(npmCmd, npmRunArgs, {
         cwd: target.cwd,
         stdio: ["inherit", "pipe", "pipe"],
@@ -134,7 +134,7 @@ export class NpmScriptRunner implements TargetRunner {
         childProcess?.stdin?.destroy();
 
         if (code === 0) {
-          return resolve();
+          return resolve({ exitCode: code });
         }
 
         reject(new Error(`NPM Script Runner: ${npmCmd} ${npmRunArgs.join(" ")} exited with code ${code}`));

--- a/packages/runners/src/WorkerRunner.ts
+++ b/packages/runners/src/WorkerRunner.ts
@@ -1,4 +1,4 @@
-import type { TargetRunner, TargetRunnerOptions } from "./types/TargetRunner.js";
+import type { RunnerResult, TargetRunner, TargetRunnerOptions } from "./types/TargetRunner.js";
 import type { Target } from "@lage-run/target-graph";
 import { pathToFileURL } from "url";
 
@@ -56,7 +56,7 @@ export class WorkerRunner implements TargetRunner {
     return target.shouldRun ?? true;
   }
 
-  async run(runOptions: TargetRunnerOptions) {
+  async run(runOptions: TargetRunnerOptions): Promise<RunnerResult> {
     const { target, weight, abortSignal } = runOptions;
     const { taskArgs } = this.options;
 

--- a/packages/runners/src/types/TargetRunner.ts
+++ b/packages/runners/src/types/TargetRunner.ts
@@ -6,8 +6,12 @@ export interface TargetRunnerOptions {
   abortSignal?: AbortSignal;
 }
 
-export interface TargetRunner {
+export interface RunnerResult {
+  exitCode?: number;
+}
+
+export interface TargetRunner<T extends RunnerResult = RunnerResult> {
   shouldRun(target: Target): Promise<boolean>;
-  run(options: TargetRunnerOptions): Promise<unknown>;
+  run(options: TargetRunnerOptions): Promise<T | void>;
   cleanup?(): Promise<void> | void;
 }


### PR DESCRIPTION
This pull request introduces exit code support for the `executeInProcess` function and updates related runner classes to handle and return exit codes properly. The most important changes include adding the `RunnerResult` interface, modifying the `NpmScriptRunner` and `WorkerRunner` classes to return this result, and updating the `executeInProcess` function to handle these exit codes.

### Exit Code Support:

* Added `RunnerResult` interface with an optional `exitCode` property in `TargetRunner` types.
* Modified `NpmScriptRunner` and `WorkerRunner` classes to return `RunnerResult` from the `run` method. [[1]](diffhunk://#diff-6dbefa71fef7e5ffecb1c933b02b41183a5a699665e76e729bf808b4fa50b951L56-R56) [[2]](diffhunk://#diff-30c4843c7fb1729a66300faffb84953735f83f9c893481cfc248b2a53bba28f9L59-R59)
* Updated `executeInProcess` function to check and handle the `exitCode` from the runner's result.

### Dependency Updates:

* Updated imports in `NpmScriptRunner.ts` and `WorkerRunner.ts` to include `RunnerResult` type. [[1]](diffhunk://#diff-6dbefa71fef7e5ffecb1c933b02b41183a5a699665e76e729bf808b4fa50b951L5-R5) [[2]](diffhunk://#diff-30c4843c7fb1729a66300faffb84953735f83f9c893481cfc248b2a53bba28f9L1-R1)

### Configuration:

* Added patch changes for `@lage-run/cli` and `@lage-run/runners` in the change log file.