### PR TITLE
aggregated pool for the info / server worker command

### DIFF
--- a/change/change-d4dc6717-fff7-4abb-b0e4-9af8cf0ba82c.json
+++ b/change/change-d4dc6717-fff7-4abb-b0e4-9af8cf0ba82c.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fixes the server worker model to use aggregated pool",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Fixes the server worker model to use aggregated pool",
+      "packageName": "@lage-run/worker-threads-pool",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@lage-run/cache": "^1.3.10",
     "@lage-run/config": "^0.4.11",
+    "@lage-run/format-hrtime": "^0.1.6",
     "@lage-run/globby": "^14.2.0",
     "@lage-run/hasher": "^1.6.7",
     "@lage-run/logger": "^1.3.1",

--- a/packages/cli/src/commands/exec/action.ts
+++ b/packages/cli/src/commands/exec/action.ts
@@ -10,6 +10,11 @@ interface ExecOptions extends ReporterInitOptions {
   server?: boolean | string;
   timeout?: number;
   nodeArg?: string;
+  tasks?: string[];
+}
+
+interface ExecRemoteOptions extends ExecOptions {
+  tasks: string[];
 }
 
 export async function execAction(options: ExecOptions, command: Command) {
@@ -22,7 +27,12 @@ export async function execAction(options: ExecOptions, command: Command) {
   const { server } = options;
   if (server) {
     logger.info("Running in server mode");
-    await executeRemotely(options, command);
+
+    if (typeof options.tasks === "undefined") {
+      throw new Error("No tasks specified, this is required for when running in server mode");
+    }
+
+    await executeRemotely(options as ExecRemoteOptions, command);
   } else {
     await executeInProcess({ logger, args: command.args, cwd: options.cwd, nodeArg: options.nodeArg });
   }

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -14,6 +14,7 @@ import path from "path";
 import fs from "fs";
 import { getWorkspaceRoot } from "workspace-tools";
 import type { Command } from "commander";
+import { launchServerInBackground } from "../launchServerInBackground.js";
 
 interface ExecRemotelyOptions extends ReporterInitOptions {
   cwd?: string;
@@ -121,7 +122,7 @@ export async function executeRemotely(options: ExecRemotelyOptions, command: Com
   // launch a 'lage-server.js' process, detached if it is not already running
   // send the command to the server process
   const { server, tasks } = options;
-  const timeout = options.timeout ?? 120;
+  const timeout = options.timeout ?? 5 * 60;
 
   const { host, port } = parseServerOption(server);
 
@@ -132,56 +133,21 @@ export async function executeRemotely(options: ExecRemotelyOptions, command: Com
 
   const root = getWorkspaceRoot(options.cwd ?? process.cwd())!;
 
-  const lockfilePath = path.join(root, `node_modules/.cache/lage/.lage-server-${host}-${port}.pid`);
-
   let client = await tryCreateClient(host, port);
   const args = command.args;
 
   logger.info(`Command args ${command.args.join(" ")}`);
 
   if (!client) {
-    logger.info(`Starting server on http://${host}:${port}`);
-    logger.info(`acquiring lock: ${lockfilePath}`);
-
-    ensurePidFile(lockfilePath);
-
-    const releaseLock = await lockfile.lock(lockfilePath, {
-      stale: 1000 * 60 * 1,
-      retries: {
-        retries: 10,
-        factor: 3,
-        minTimeout: 0.5 * 1000,
-        maxTimeout: 60 * 1000,
-        randomize: true,
-      },
+    await launchServerInBackground({
+      host,
+      port,
+      tasks,
+      args,
+      timeout,
+      logger,
+      root,
     });
-
-    const pid = parseInt(fs.readFileSync(lockfilePath, "utf-8"));
-    const isServerRunning = pid && isAlive(pid);
-    logger.info("Checking if server is already running", { pid, isServerRunning });
-    if (pid && isServerRunning) {
-      logger.info("Server already running", { pid });
-    } else {
-      const binPaths = getBinPaths();
-      const lageServerBinPath = binPaths["lage-server"];
-      const lageServerArgs = ["--tasks", ...tasks, "--host", host, "--port", `${port}`, "--timeout", `${timeout}`, ...args];
-
-      logger.info(`Launching lage-server with these parameters: ${lageServerArgs.join(" ")}`);
-      const child = execa(lageServerBinPath, lageServerArgs, {
-        cwd: root,
-        detached: true,
-        stdio: "ignore",
-      });
-
-      if (child && child.pid) {
-        fs.writeFileSync(lockfilePath, child.pid.toString());
-      }
-
-      child.unref();
-      logger.info("Server started", { pid: child.pid });
-    }
-
-    await releaseLock();
 
     logger.info("Creating a client to connect to the background services");
     client = await tryCreateClientWithRetries(host, port, logger);

--- a/packages/cli/src/commands/exec/index.ts
+++ b/packages/cli/src/commands/exec/index.ts
@@ -6,7 +6,7 @@ import os from "os";
 const execCommand = new Command("exec");
 execCommand.option("-c|--concurrency <number>", "max jobs to run at a time", (v) => parseInt(v), os.cpus().length - 1);
 execCommand.option("-s|--server [host:port]", "lage server host");
-execCommand.option<number>("-t|--timeout <seconds>", "lage server autoshutoff timeout", (v) => parseInt(v), 3 * 60);
+execCommand.option<number>("-t|--timeout <seconds>", "lage server autoshutoff timeout", (v) => parseInt(v), 5 * 60);
 execCommand.option("--tasks [tasks...]", "A list of tasks to run, separated by space e.g. 'build test', used with --server");
 addLoggerOptions(execCommand).action(execAction);
 export { execCommand };

--- a/packages/cli/src/commands/exec/index.ts
+++ b/packages/cli/src/commands/exec/index.ts
@@ -7,6 +7,6 @@ const execCommand = new Command("exec");
 execCommand.option("-c|--concurrency <number>", "max jobs to run at a time", (v) => parseInt(v), os.cpus().length - 1);
 execCommand.option("-s|--server [host:port]", "lage server host");
 execCommand.option<number>("-t|--timeout <seconds>", "lage server autoshutoff timeout", (v) => parseInt(v), 3 * 60);
-
+execCommand.option("--tasks [tasks...]", "A list of tasks to run, separated by space e.g. 'build test', used with --server");
 addLoggerOptions(execCommand).action(execAction);
 export { execCommand };

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -123,7 +123,9 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
 
   const optimizedTargets = await optimizeTargetGraph(targetGraph, runnerPicker);
   const binPaths = getBinPaths();
-  const packageTasks = optimizedTargets.map((target) => generatePackageTask(target, taskArgs, config, options, binPaths, packageInfos));
+  const packageTasks = optimizedTargets.map((target) =>
+    generatePackageTask(target, taskArgs, config, options, binPaths, packageInfos, tasks)
+  );
 
   logger.info("info", {
     command: command.args,
@@ -138,9 +140,10 @@ function generatePackageTask(
   config: ConfigOptions,
   options: InfoActionOptions,
   binPaths: { lage: string; "lage-server": string },
-  packageInfos: PackageInfos
+  packageInfos: PackageInfos,
+  tasks: string[]
 ): PackageTask {
-  const command = generateCommand(target, taskArgs, config, options, binPaths, packageInfos);
+  const command = generateCommand(target, taskArgs, config, options, binPaths, packageInfos, tasks);
   const workingDirectory = getWorkingDirectory(target);
 
   const packageTask: PackageTask = {
@@ -161,7 +164,8 @@ function generateCommand(
   config: ConfigOptions,
   options: InfoActionOptions,
   binPaths: { lage: string; "lage-server": string },
-  packageInfos: PackageInfos
+  packageInfos: PackageInfos,
+  tasks: string[]
 ) {
   const shouldRunWorkersAsService =
     (typeof process.env.LAGE_WORKER_SERVER === "string" && process.env.LAGE_WORKER_SERVER !== "false") || !!options.server;
@@ -183,7 +187,7 @@ function generateCommand(
     return command;
   } else if (target.type === "worker" && shouldRunWorkersAsService) {
     const { host, port } = parseServerOption(options.server);
-    const command = [binPaths["lage"], "exec", "--server", `${host}:${port}`];
+    const command = [binPaths["lage"], "exec", "--tasks", ...tasks, "--server", `${host}:${port}`];
     if (options.concurrency) {
       command.push("--concurrency", options.concurrency.toString());
     }

--- a/packages/cli/src/commands/launchServerInBackground.ts
+++ b/packages/cli/src/commands/launchServerInBackground.ts
@@ -49,6 +49,7 @@ export async function launchServerInBackground({ logger, root, host, port, tasks
       cwd: root,
       detached: true,
       stdio: "ignore",
+      maxBuffer: 1024 * 1024 * 100,
     });
 
     if (child && child.pid) {

--- a/packages/cli/src/commands/launchServerInBackground.ts
+++ b/packages/cli/src/commands/launchServerInBackground.ts
@@ -1,0 +1,86 @@
+import type { Logger } from "@lage-run/logger";
+import fs from "fs";
+import path from "path";
+import lockfile from "proper-lockfile";
+import execa from "execa";
+import { getBinPaths } from "../getBinPaths.js";
+
+export interface launchServerInBackgroundOptions {
+  logger: Logger;
+  root: string;
+  host: string;
+  port: number;
+  tasks: string[];
+  timeout: number;
+  args: string[];
+}
+
+export async function launchServerInBackground({ logger, root, host, port, tasks, timeout, args }: launchServerInBackgroundOptions) {
+  const lockfilePath = path.join(root, `node_modules/.cache/lage/.lage-server-${host}-${port}.pid`);
+
+  logger.info(`Starting server on http://${host}:${port}`);
+  logger.info(`acquiring lock: ${lockfilePath}`);
+
+  ensurePidFile(lockfilePath);
+
+  const releaseLock = await lockfile.lock(lockfilePath, {
+    stale: 1000 * 60 * 1,
+    retries: {
+      retries: 10,
+      factor: 3,
+      minTimeout: 0.5 * 1000,
+      maxTimeout: 60 * 1000,
+      randomize: true,
+    },
+  });
+
+  const pid = parseInt(fs.readFileSync(lockfilePath, "utf-8"));
+  const isServerRunning = pid && isAlive(pid);
+  logger.info("Checking if server is already running", { pid, isServerRunning });
+  if (pid && isServerRunning) {
+    logger.info("Server already running", { pid });
+  } else {
+    const binPaths = getBinPaths();
+    const lageServerBinPath = binPaths["lage-server"];
+    const lageServerArgs = ["--tasks", ...tasks, "--host", host, "--port", `${port}`, "--timeout", `${timeout}`, ...args];
+
+    logger.info(`Launching lage-server with these parameters: ${lageServerArgs.join(" ")}`);
+    const child = execa(lageServerBinPath, lageServerArgs, {
+      cwd: root,
+      detached: true,
+      stdio: "ignore",
+    });
+
+    if (child && child.pid) {
+      fs.writeFileSync(lockfilePath, child.pid.toString());
+    }
+
+    child.unref();
+    logger.info("Server started", { pid: child.pid });
+  }
+
+  await releaseLock();
+}
+
+function ensurePidFile(lockfilePath: string) {
+  if (!fs.existsSync(path.dirname(lockfilePath))) {
+    fs.mkdirSync(path.dirname(lockfilePath), { recursive: true });
+  }
+
+  if (!fs.existsSync(lockfilePath)) {
+    try {
+      const fd = fs.openSync(lockfilePath, "w");
+      fs.closeSync(fd);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function isAlive(pid: number) {
+  try {
+    return process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/commands/server/action.ts
+++ b/packages/cli/src/commands/server/action.ts
@@ -10,10 +10,11 @@ interface WorkerOptions extends ReporterInitOptions {
   host?: string;
   timeout?: number;
   shutdown: boolean;
+  tasks: string[];
 }
 
 export async function serverAction(options: WorkerOptions) {
-  const { port = 5332, host = "localhost", timeout = 1 } = options;
+  const { port = 5332, host = "localhost", timeout = 1, tasks } = options;
 
   const logger = createLogger();
   options.logLevel = options.logLevel ?? "info";
@@ -33,7 +34,8 @@ export async function serverAction(options: WorkerOptions) {
       clearCountdown: clearTimer,
     },
     logger,
-    maxWorkers: options.concurrency,
+    concurrency: options.concurrency,
+    tasks,
   });
   const server = await createServer(lageService, abortController);
 

--- a/packages/cli/src/commands/server/index.ts
+++ b/packages/cli/src/commands/server/index.ts
@@ -4,10 +4,11 @@ import { serverAction } from "./action.js";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 
 const serverCommand = new Command("server");
-serverCommand.option("-c|--concurrency <number>", "max jobs to run at a time", (v) => parseInt(v), os.cpus().length - 1);
+serverCommand.option("-c|--concurrency <number>", "max jobs to run at a time", (v) => parseInt(v));
 serverCommand.option("-h|--host <host>", "lage server host", "localhost");
 serverCommand.option<number>("-p|--port <port>", "lage worker server port", (v) => parseInt(v), 5332);
 serverCommand.option<number>("-t|--timeout <seconds>", "lage server autoshutoff timeout", (v) => parseInt(v), 1 * 60);
+serverCommand.option("--tasks <tasks...>", "A list of tasks to run, separated by space e.g. 'build test'");
 
 addLoggerOptions(serverCommand).action(serverAction);
 

--- a/packages/cli/src/commands/server/index.ts
+++ b/packages/cli/src/commands/server/index.ts
@@ -7,7 +7,7 @@ const serverCommand = new Command("server");
 serverCommand.option("-c|--concurrency <number>", "max jobs to run at a time", (v) => parseInt(v));
 serverCommand.option("-h|--host <host>", "lage server host", "localhost");
 serverCommand.option<number>("-p|--port <port>", "lage worker server port", (v) => parseInt(v), 5332);
-serverCommand.option<number>("-t|--timeout <seconds>", "lage server autoshutoff timeout", (v) => parseInt(v), 1 * 60);
+serverCommand.option<number>("-t|--timeout <seconds>", "lage server autoshutoff timeout", (v) => parseInt(v), 5 * 60);
 serverCommand.option("--tasks <tasks...>", "A list of tasks to run, separated by space e.g. 'build test'");
 
 addLoggerOptions(serverCommand).action(serverAction);

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -1,10 +1,9 @@
-import { type ConfigOptions, getConfig, type PipelineDefinition, getConcurrency, getMaxWorkersPerTask } from "@lage-run/config";
+import { type ConfigOptions, getConfig, getConcurrency, getMaxWorkersPerTask } from "@lage-run/config";
 import type { Logger } from "@lage-run/logger";
 import type { ILageService } from "@lage-run/rpc";
 import { getTargetId, type TargetGraph } from "@lage-run/target-graph";
 import { type DependencyMap, getPackageInfos, getWorkspaceRoot } from "workspace-tools";
 import { createTargetGraph } from "../run/createTargetGraph.js";
-import { getPackageAndTask } from "@lage-run/target-graph";
 import { type Readable } from "stream";
 import { type Pool, AggregatedPool } from "@lage-run/worker-threads-pool";
 import { getInputFiles, PackageTree } from "@lage-run/hasher";
@@ -14,19 +13,6 @@ import { glob } from "@lage-run/globby";
 import { MemoryStream } from "./MemoryStream.js";
 import { runnerPickerOptions } from "../../runnerPickerOptions.js";
 import { filterPipelineDefinitions } from "../run/filterPipelineDefinitions.js";
-
-function findAllTasks(pipeline: PipelineDefinition) {
-  const tasks = new Set<string>();
-  for (const key of Object.keys(pipeline)) {
-    if (key.includes("#") || key.startsWith("#") || key.endsWith("//")) {
-      const { task } = getPackageAndTask(key);
-      tasks.add(task);
-    } else {
-      tasks.add(key);
-    }
-  }
-  return Array.from(tasks);
-}
 
 interface LageServiceContext {
   config: ConfigOptions;

--- a/packages/e2e-tests/src/lageserver.test.ts
+++ b/packages/e2e-tests/src/lageserver.test.ts
@@ -21,7 +21,7 @@ describe("lageserver", () => {
     const serverProcess = repo.runServer();
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    const results = repo.run("lage", ["exec", "--server", "--", "a", "build"]);
+    const results = repo.run("lage", ["exec", "--server", "--tasks", "build", "--", "a", "build"]);
     const output = results.stdout + results.stderr;
     const jsonOutput = parseNdJson(output);
 
@@ -39,7 +39,7 @@ describe("lageserver", () => {
 
     repo.install();
 
-    const results = repo.run("lage", ["exec", "a", "build", "--server", "localhost:5112", "--timeout", "2"]);
+    const results = repo.run("lage", ["exec", "a", "build", "--tasks", "build", "--server", "localhost:5112", "--timeout", "2"]);
     const output = results.stdout + results.stderr;
     const jsonOutput = parseNdJson(output);
     const started = jsonOutput.find((entry) => entry.data?.pid && entry.msg === "Server started");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,6 +1703,7 @@ __metadata:
   dependencies:
     "@lage-run/cache": "npm:^1.3.10"
     "@lage-run/config": "npm:^0.4.11"
+    "@lage-run/format-hrtime": "npm:^0.1.6"
     "@lage-run/globby": "npm:^14.2.0"
     "@lage-run/hasher": "npm:^1.6.7"
     "@lage-run/logger": "npm:^1.3.1"


### PR DESCRIPTION
1. we moved to aggregated pool in anticipation of multiple task types using this pool for lage server
2. now pay attention to the concurrency setting in the lage.config.js like "run" command
3. allow maxWorker setting to influence the final concurrency setting in the pool
4. added --tasks to the server command so it can utilize that to calculate the maxWorkers correctly based on a smaller build graph

## AI SUMMARY

This pull request includes several changes to improve the `@lage-run/cli` package, particularly focusing on the server worker model and task management. The most important changes include fixing the server worker model to use an aggregated pool, adding a new `tasks` option, and refactoring the code for better modularity and maintainability.

### Improvements to server worker model:

* [`change/change-d4dc6717-fff7-4abb-b0e4-9af8cf0ba82c.json`](diffhunk://#diff-a93674adc8f892270e9951f272230162879312dc6e473bbc0a10ac7072851e79R1-R18): Fixes the server worker model to use an aggregated pool for both `@lage-run/cli` and `@lage-run/worker-threads-pool` packages.
* [`packages/cli/src/commands/server/lageService.ts`](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L1-R17): Replaces `WorkerPool` with `AggregatedPool` and adds task management functionality. [[1]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L1-R17) [[2]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L49-L72) [[3]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L99-R119) [[4]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R129-R132) [[5]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L131-R160) [[6]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L161-L165) [[7]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L179-L180)

### New `tasks` option:

* [`packages/cli/src/commands/exec/action.ts`](diffhunk://#diff-41dba887620c904ef6c6876a56f0d0c8262b0ac0adf5a3dc1aa602cfc1326746R13-R17): Adds `tasks` option to `ExecOptions` and `ExecRemoteOptions` interfaces, and ensures tasks are specified when running in server mode. [[1]](diffhunk://#diff-41dba887620c904ef6c6876a56f0d0c8262b0ac0adf5a3dc1aa602cfc1326746R13-R17) [[2]](diffhunk://#diff-41dba887620c904ef6c6876a56f0d0c8262b0ac0adf5a3dc1aa602cfc1326746L25-R35)
* [`packages/cli/src/commands/server/action.ts`](diffhunk://#diff-1a17e5e7c95006646f84fed452ea96fb1d90ca75a3695be3b695de167837cf0dR13-R17): Adds `tasks` option to `WorkerOptions` interface and updates `serverAction` to handle tasks. [[1]](diffhunk://#diff-1a17e5e7c95006646f84fed452ea96fb1d90ca75a3695be3b695de167837cf0dR13-R17) [[2]](diffhunk://#diff-1a17e5e7c95006646f84fed452ea96fb1d90ca75a3695be3b695de167837cf0dL36-R38)
* [`packages/cli/src/commands/exec/index.ts`](diffhunk://#diff-0887dfcc1d68e57a6f87b99d110a6eb44c53914974661696670cbd82f10f8c84L9-R10): Adds `tasks` option to the `execCommand`.
* [`packages/cli/src/commands/server/index.ts`](diffhunk://#diff-d37e2fefe90389d46e36594ee11a3631aa3d437b36af70494012498800dadd3aL7-R11): Adds `tasks` option to the `serverCommand`.

### Code refactoring for modularity:

* [`packages/cli/src/commands/exec/executeRemotely.ts`](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR16-R23): Refactors code to use the new `launchServerInBackground` function. [[1]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR16-R23) [[2]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bL118-R125) [[3]](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bL133-L181)
* [`packages/cli/src/commands/launchServerInBackground.ts`](diffhunk://#diff-f0ec5c09527d5047cbfb81167d580af9ee404bf11a899d390c54929b096065f1R1-R87): Adds a new module to handle launching the server in the background with proper locking and task management.

### Dependency updates:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758R26): Adds `@lage-run/format-hrtime` dependency.

### Task management in info command:

* [`packages/cli/src/commands/info/action.ts`](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL126-R128): Updates `generatePackageTask` and `generateCommand` functions to include tasks. [[1]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL126-R128) [[2]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL141-R146) [[3]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL164-R168) [[4]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL186-R190)