### PR TITLE
Fix priorities on lage

### DIFF
--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -103,6 +103,7 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
     outputs: config.cacheOptions.outputGlob,
     tasks,
     packageInfos,
+    priorities: config.priorities,
   });
 
   const scope = getFilteredPackages({

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -3,7 +3,7 @@ import { WorkspaceTargetGraphBuilder } from "@lage-run/target-graph";
 import type { PackageInfos } from "workspace-tools";
 import { getBranchChanges, getDefaultRemoteBranch, getStagedChanges, getUnstagedChanges, getUntrackedChanges } from "workspace-tools";
 import { getFilteredPackages } from "../../filter/getFilteredPackages.js";
-import type { PipelineDefinition } from "@lage-run/config";
+import type { PipelineDefinition, Priority } from "@lage-run/config";
 import { hasRepoChanged } from "../../filter/hasRepoChanged.js";
 
 interface CreateTargetGraphOptions {
@@ -19,6 +19,7 @@ interface CreateTargetGraphOptions {
   outputs: string[];
   tasks: string[];
   packageInfos: PackageInfos;
+  priorities: Priority[];
 }
 
 function getChangedFiles(since: string, cwd: string) {
@@ -37,7 +38,21 @@ function getChangedFiles(since: string, cwd: string) {
 }
 
 export async function createTargetGraph(options: CreateTargetGraphOptions) {
-  const { logger, root, dependencies, dependents, since, scope, repoWideChanges, ignore, pipeline, outputs, tasks, packageInfos } = options;
+  const {
+    logger,
+    root,
+    dependencies,
+    dependents,
+    since,
+    scope,
+    repoWideChanges,
+    ignore,
+    pipeline,
+    outputs,
+    tasks,
+    packageInfos,
+    priorities,
+  } = options;
 
   const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
 
@@ -80,5 +95,5 @@ export async function createTargetGraph(options: CreateTargetGraphOptions) {
     }
   }
 
-  return await builder.build(tasks, packages);
+  return await builder.build(tasks, packages, priorities);
 }

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -63,6 +63,7 @@ export async function runAction(options: RunOptions, command: Command) {
     outputs: config.cacheOptions.outputGlob,
     tasks,
     packageInfos,
+    priorities: config.priorities,
   });
 
   validateTargetGraph(targetGraph, allowNoTargetRuns);

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -61,6 +61,7 @@ export async function watchAction(options: RunOptions, command: Command) {
     outputs: config.cacheOptions.outputGlob,
     tasks,
     packageInfos,
+    priorities: config.priorities,
   });
 
   // Make sure we do not attempt writeRemoteCache in watch mode

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -73,6 +73,7 @@ async function createInitializedPromise({ cwd, logger, serverControls, nodeArg, 
     outputs: config.cacheOptions.outputGlob,
     tasks,
     packageInfos,
+    priorities: config.priorities,
   });
 
   const dependencyMap = createDependencyMap(packageInfos, { withDevDependencies: true, withPeerDependencies: false });

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -164,9 +164,9 @@ export class WorkspaceTargetGraphBuilder {
    *
    * @param tasks
    * @param scope
-   * @returns
+   * @param priorities the set of global priorities for the workspace.
    */
-  async build(tasks: string[], scope?: string[]) {
+  async build(tasks: string[], scope?: string[], priorities?: { package?: string; task: string; priority: number }[]) {
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(this.graphBuilder.targets, this.dependencyMap);
 
@@ -203,6 +203,19 @@ export class WorkspaceTargetGraphBuilder {
     }
 
     const subGraph = this.graphBuilder.subgraph(subGraphEntries);
+
+    if (priorities) {
+      for (const priorityConfig of priorities) {
+        // Right now we are only handling global priorities where the package name is set
+        if (priorityConfig.package) {
+          const targetId = getTargetId(priorityConfig.package, priorityConfig.task);
+          const target = subGraph.targets.get(targetId);
+          if (target) {
+            target.priority = target.priority ? Math.max(target.priority, priorityConfig.priority) : priorityConfig.priority;
+          }
+        }
+      }
+    }
 
     const limit = pLimit(8);
     const setShouldRunPromises: Promise<void>[] = [];

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -202,20 +202,21 @@ export class WorkspaceTargetGraphBuilder {
       }
     }
 
-    const subGraph = this.graphBuilder.subgraph(subGraphEntries);
-
+    // Add all the global priorities for individual targets
     if (priorities) {
       for (const priorityConfig of priorities) {
         // Right now we are only handling global priorities where the package name is set
         if (priorityConfig.package) {
           const targetId = getTargetId(priorityConfig.package, priorityConfig.task);
-          const target = subGraph.targets.get(targetId);
+          const target = this.graphBuilder.targets.get(targetId);
           if (target) {
             target.priority = target.priority ? Math.max(target.priority, priorityConfig.priority) : priorityConfig.priority;
           }
         }
       }
     }
+
+    const subGraph = this.graphBuilder.subgraph(subGraphEntries);
 
     const limit = pLimit(8);
     const setShouldRunPromises: Promise<void>[] = [];

--- a/packages/target-graph/src/prioritize.ts
+++ b/packages/target-graph/src/prioritize.ts
@@ -18,10 +18,10 @@ function getNewDependsOnMap(pGraphDependencyMap: Map<string, Target>): Map<strin
 }
 
 /**
- * Topologically sort the nodes in a graph - starting with nodes with no dependencies
- * @returns a list of ids in order
+ * Topologically sort the nodes in a graph in reverse order. Leaf nodes are at the beginning of the list and nodes with no dependencies are at the end of the list
+ * @returns a list of ids in reverse topological order
  */
-function topologicalSort(targets: Map<string, Target>, nodesWithNoDependencies: string[]): string[] {
+function reverseTopoSort(targets: Map<string, Target>, nodesWithNoDependencies: string[]): string[] {
   const sortedList: string[] = [];
 
   const dependsOnMap = getNewDependsOnMap(targets);
@@ -30,7 +30,7 @@ function topologicalSort(targets: Map<string, Target>, nodesWithNoDependencies: 
   while (nodesWithNoDependenciesClone.length > 0) {
     const currentId = nodesWithNoDependenciesClone.pop()!;
 
-    sortedList.push(currentId);
+    sortedList.unshift(currentId);
 
     const node = targets.get(currentId)!;
 
@@ -50,26 +50,26 @@ function topologicalSort(targets: Map<string, Target>, nodesWithNoDependencies: 
 }
 
 /**
- * Priorities for a target is actually the MAX of all the priorities of the targets that depend on it.
+ * Priorities for a target is actually the MAX of all the priorities of the targets that depend on it plus the current priority.
  */
 export function prioritize(targets: Map<string, Target>) {
   const nodeCumulativePriorities = new Map<string, number>();
 
   const nodesWithNoDependencies = getNodesWithNoDependencies(targets);
-  const topoSortedNodeIds = topologicalSort(targets, nodesWithNoDependencies);
+  const reverseTopoSortedNodeIds = reverseTopoSort(targets, nodesWithNoDependencies);
 
   /**
    * What is this loop doing?
    *
-   * Now that we have topologically sorted the nodes, we examine the each node
+   * Now that we have reverse topologically sorted the nodes, we examine the each node
    * and update the cumulative priority of all the nodes that depend on it.
    */
-  for (const currentNodeId of topoSortedNodeIds) {
+  for (const currentNodeId of reverseTopoSortedNodeIds) {
     const node = targets.get(currentNodeId)!;
     // The default priority for a node is zero
     const currentNodePriority = node.priority || 0;
 
-    const childrenPriorities = node.dependencies.map((childId) => {
+    const childrenPriorities = node.dependents.map((childId) => {
       const childCumulativePriority = nodeCumulativePriorities.get(childId);
       if (childCumulativePriority === undefined) {
         throw new Error(`Expected to have already computed the cumulative priority for node ${childId}`);

--- a/packages/target-graph/tests/TargetGraphBuilder.test.ts
+++ b/packages/target-graph/tests/TargetGraphBuilder.test.ts
@@ -11,6 +11,7 @@ describe("Target Graph Builder", () => {
     builder.addTarget(target2);
     builder.addDependency(target1.id, target2.id);
 
+    // __start --> a#build --> b#build
     const targetGraph = builder.build();
 
     expect(simplify(targetGraph.targets)).toMatchInlineSnapshot(`
@@ -22,7 +23,7 @@ describe("Target Graph Builder", () => {
             "b#build",
           ],
           "id": "__start",
-          "priority": 0,
+          "priority": 2,
         },
         {
           "dependencies": [
@@ -32,7 +33,7 @@ describe("Target Graph Builder", () => {
             "b#build",
           ],
           "id": "a#build",
-          "priority": 1,
+          "priority": 2,
         },
         {
           "dependencies": [
@@ -41,7 +42,7 @@ describe("Target Graph Builder", () => {
           ],
           "dependents": [],
           "id": "b#build",
-          "priority": 2,
+          "priority": 1,
         },
       ]
     `);
@@ -62,6 +63,8 @@ describe("Target Graph Builder", () => {
     builder.addDependency(target1.id, target3.id);
     builder.addDependency(target4.id, target1.id);
 
+    // __start --> d#build --> a#build --> b#build
+    //                                 --> c#build
     const targetGraph = builder.subgraph(["a#build"]);
 
     expect(simplify(targetGraph.targets)).toMatchInlineSnapshot(`
@@ -73,7 +76,7 @@ describe("Target Graph Builder", () => {
             "d#build",
           ],
           "id": "__start",
-          "priority": 0,
+          "priority": 2,
         },
         {
           "dependencies": [
@@ -82,7 +85,7 @@ describe("Target Graph Builder", () => {
           ],
           "dependents": [],
           "id": "a#build",
-          "priority": 2,
+          "priority": 1,
         },
         {
           "dependencies": [
@@ -92,7 +95,7 @@ describe("Target Graph Builder", () => {
             "a#build",
           ],
           "id": "d#build",
-          "priority": 1,
+          "priority": 2,
         },
       ]
     `);
@@ -113,6 +116,9 @@ describe("Target Graph Builder", () => {
     builder.addDependency(target3.id, target1.id);
     builder.addDependency(target4.id, target1.id);
 
+    // __start --> b#build --> a#build
+    //         --> c#build --> a#build
+    //         --> d#build --> a#build
     const targetGraph = builder.subgraph(["a#build"]);
 
     expect(simplify(targetGraph.targets)).toMatchInlineSnapshot(`
@@ -126,7 +132,7 @@ describe("Target Graph Builder", () => {
             "d#build",
           ],
           "id": "__start",
-          "priority": 0,
+          "priority": 101,
         },
         {
           "dependencies": [
@@ -137,7 +143,7 @@ describe("Target Graph Builder", () => {
           ],
           "dependents": [],
           "id": "a#build",
-          "priority": 101,
+          "priority": 1,
         },
         {
           "dependencies": [
@@ -147,7 +153,7 @@ describe("Target Graph Builder", () => {
             "a#build",
           ],
           "id": "b#build",
-          "priority": 100,
+          "priority": 101,
         },
         {
           "dependencies": [
@@ -157,7 +163,7 @@ describe("Target Graph Builder", () => {
             "a#build",
           ],
           "id": "c#build",
-          "priority": 1,
+          "priority": 2,
         },
         {
           "dependencies": [
@@ -167,7 +173,7 @@ describe("Target Graph Builder", () => {
             "a#build",
           ],
           "id": "d#build",
-          "priority": 1,
+          "priority": 2,
         },
       ]
     `);

--- a/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
@@ -50,7 +50,7 @@ describe("workspace target graph builder", () => {
 
     // Ensure priorities were set from the global priority argument
     expect(Array.from(targetGraph.targets.values())).toEqual([
-      expect.objectContaining({ id: "__start", priority: 0 }),
+      expect.objectContaining({ id: "__start", priority: 100 }),
       expect.objectContaining({ id: "a#build", priority: 0 }),
       expect.objectContaining({ id: "b#build", priority: 100 }),
     ]);

--- a/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
@@ -43,10 +43,17 @@ describe("workspace target graph builder", () => {
       dependsOn: ["^build"],
     });
 
-    const targetGraph = await builder.build(["build"]);
+    const targetGraph = await builder.build(["build"], undefined, [{ package: "b", task: "build", priority: 100 }]);
 
     // size is 3, because we also need to account for the root target node (start target ID)
     expect(targetGraph.targets.size).toBe(3);
+
+    // Ensure priorities were set from the global priority argument
+    expect(Array.from(targetGraph.targets.values())).toEqual([
+      expect.objectContaining({ id: "__start", priority: 0 }),
+      expect.objectContaining({ id: "a#build", priority: 0 }),
+      expect.objectContaining({ id: "b#build", priority: 100 }),
+    ]);
 
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
       [

--- a/packages/target-graph/tests/prioritize.test.ts
+++ b/packages/target-graph/tests/prioritize.test.ts
@@ -31,6 +31,14 @@ function createTarget({
 describe("prioritize", () => {
   it("should prioritize targets", () => {
     const targets = new Map<string, Target>();
+    // This graph should read that the first task is required to run before the second task in the tuple.
+    // This would be the order these tasks run where the items depend on the tasks to their left
+    // _start#x --> a#build --> b#build --> c#build --> d#build
+    //                      --> e#build
+    //          --> a#lint
+    //          --> b#lint
+    //          --> c#lint
+    //          --> d#lint
     const edges = [
       ["a#build", "b#build"],
       ["a#build", "e#build"],
@@ -58,8 +66,8 @@ describe("prioritize", () => {
         targets.set(to, createTarget({ packageName: packageName!, task, dependencies: [], dependents: [], priority: 1 }));
       }
 
-      targets.get(from)!.dependencies.push(to);
-      targets.get(to)!.dependents.push(from);
+      targets.get(to)!.dependencies.push(from);
+      targets.get(from)!.dependents.push(to);
     }
 
     targets.get("c#build")!.priority = 10;

--- a/packages/target-graph/tests/transitiveReduction.test.ts
+++ b/packages/target-graph/tests/transitiveReduction.test.ts
@@ -20,6 +20,9 @@ describe("transitiveReduction", () => {
     builder.addDependency(target2.id, target3.id);
     builder.addDependency(target4.id, target1.id);
 
+    // Graph to build
+    // _start --> d#build --> a#build --> b#build --> c#build
+
     const targetGraph = builder.subgraph(["c#build"]);
 
     const targets = [...targetGraph.targets.values()];
@@ -40,7 +43,7 @@ describe("transitiveReduction", () => {
               "d#build",
             ],
             "id": "__start",
-            "priority": 0,
+            "priority": 4,
           },
           Object {
             "dependencies": Array [
@@ -50,7 +53,7 @@ describe("transitiveReduction", () => {
             ],
             "dependents": Array [],
             "id": "c#build",
-            "priority": 4,
+            "priority": 1,
           },
           Object {
             "dependencies": Array [
@@ -62,7 +65,7 @@ describe("transitiveReduction", () => {
               "b#build",
             ],
             "id": "a#build",
-            "priority": 2,
+            "priority": 3,
           },
           Object {
             "dependencies": Array [
@@ -73,7 +76,7 @@ describe("transitiveReduction", () => {
               "c#build",
             ],
             "id": "b#build",
-            "priority": 3,
+            "priority": 2,
           },
           Object {
             "dependencies": Array [
@@ -83,7 +86,7 @@ describe("transitiveReduction", () => {
               "a#build",
             ],
             "id": "d#build",
-            "priority": 1,
+            "priority": 4,
           },
         ]"
     `);


### PR DESCRIPTION
In our repo, I noticed we have two pretty big issues that case priorities to not work anymore which is impacting our scheduling and long poles for our builds.

The two issues are the following
* The "legacy" way of updating priorities no longer works. You can see there are no hits in the repo for the priorities field https://microsoft.github.io/lage/docs/Tutorial/priority/
* Cumulative priorities are broken right now. The expectation is that targets inherit the highest priority of their children, but today it is the inverse, children are inheriting the priority of their parent.

The fixes made were the following
* We support the legacy way of updating priorities. While we do encourage the usage of pipelines to set priority, it is much easier to read the configuration when all priorities are set in one place for the entire repo. 
* For cumulative priorities we updated the prioritize function to look in reverse topological order and ensure that the current node has a priority equal to it's current priority plus the value of the child node with the highest priority. This means that if we set a leaf node to priority of 100, then all tasks that leaf node depends on will have at least a 100 priority. Today that leaf node's priority is set to 100, but all the tasks it depends on don't get this higher priority. This also fixes an issue where we are incorrectly giving high priority to tasks that depend on high priority tasks.


Example graph to illustrate cumulative priority issue

```mermaid
graph TD
    a:build
    b:build
    c:build
    d:build
    a:bundle
    b:bundle
    c:bundle
    d:bundle
    d:test
    a:build --> a:bundle
    b:build --> b:bundle
    c:build --> c:bundle
    d:build --> d:bundle
    d:bundle --> d:test
    a:build --> b:build
    a:build --> c:build
    c:build --> d:build
```

In this diagram, if we give the d:bundle a priority of 100 and no other tasks get a priority then we would expect the following:
a:build, c:build, d:build, and d:bundle should all have priority 100. All other nodes should have a priority 0.

What happens today is that d:bundle and d:test both have priority 100 and all other nodes have priority 0. This has the flaw of no dependencies of d:bundle having high priority and d:test having a higher priority than it should