### PR TITLE
Report the correct percentages in the progress reporter

### DIFF
--- a/change/change-0d722ee3-43ac-4570-8ae5-dbe850b35381.json
+++ b/change/change-0d722ee3-43ac-4570-8ae5-dbe850b35381.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Report the correct percentage for progress logger up front instead of only adding tasks after they start running",
+      "packageName": "@lage-run/scheduler",
+      "email": "1581488+christiango@users.noreply.github.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -80,11 +80,14 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     if (this.target.id === getStartTargetId()) {
       this.#status = "success";
     }
+
+    this.options.logger.info("", { target: this.target, status: this.status });
   }
 
   onQueued() {
     this.#status = "queued";
     this.queueTime = process.hrtime();
+    this.options.logger.info("", { target: this.target, status: "queued" });
   }
 
   onAbort() {


### PR DESCRIPTION
Fixing the issue where the denominator in the progress reporter increases over time instead of being set up front when the build graph is created.

With this change the total tasks is set by ensuring that the progress reporter gets a log statement for when the task is in the "pending" state and "queued" state. The current behavior is that the tasks are added as they start running, which means it starts with a denominator equal to the min of runnable tasks and the available workers and increases as new tasks start to run.