### PR TITLE
Switch to isolated declarations for faster builds

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -6,7 +6,10 @@
       "tsx": false,
       "dynamicImport": true
     },
-    "target": "es2020"
+    "target": "es2020",
+    "experimental": {
+      "emitIsolatedDts": true
+    }
   },
   "module": {
     "type": "commonjs",

--- a/change/change-7f40e1b3-256a-42a3-a306-4cc681250ece.json
+++ b/change/change-7f40e1b3-256a-42a3-a306-4cc681250ece.json
@@ -1,0 +1,95 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/cache",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/config",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/format-hrtime",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/globby",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/hasher",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/logger",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/reporters",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/rpc",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/runners",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/scheduler",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/target-graph",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Adding isolated-declarations flag everywhere",
+      "packageName": "@lage-run/worker-threads-pool",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -7,11 +7,8 @@ module.exports = {
   pipeline: {
     "lage#bundle": ["^^transpile", "types"],
     types: {
-      type: "worker",
-      options: {
-        worker: path.join(__dirname, "scripts/worker/types.js"),
-      },
-      dependsOn: ["^types"],
+      type: "npmScript",
+      dependsOn: ["^^transpile"],
       outputs: ["lib/**/*.d.ts"],
     },
     isolatedTypes: {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^2.8.6",
     "syncpack": "^9.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "~5.0.3"
+    "typescript": "~5.7.3"
   },
   "lint-staged": {
     "!(*test).{ts,js}": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "lage transpile types build bundle",
-    "watch": "lage transpile isolatedTypes --no-cache --verbose --unstable-watch",
+    "watch": "lage transpile types --no-cache --verbose --unstable-watch",
     "change": "beachball change",
     "checkchange": "beachball check",
     "ci": "lage transpile types build test lint bundle",

--- a/packages/cache-github-actions/package.json
+++ b/packages/cache-github-actions/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "monorepo-scripts tsc",
     "start": "monorepo-scripts tsc -w --preserveWatchOutput",
-    "lint": "monorepo-scripts lint"
+    "lint": "monorepo-scripts lint",
+    "types": "monorepo-scripts tsc"
   },
   "dependencies": {
     "@actions/cache": "3.2.4",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -14,7 +14,8 @@
     "build": "monorepo-scripts tsc",
     "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
-    "lint": "monorepo-scripts lint"
+    "lint": "monorepo-scripts lint",
+    "types": "monorepo-scripts tsc"
   },
   "dependencies": {
     "@azure/identity": "^4.0.1",

--- a/packages/cache/src/backfillWrapper.ts
+++ b/packages/cache/src/backfillWrapper.ts
@@ -31,7 +31,7 @@ export function createBackfillLogger(): BackfillLogger {
 
 export function createBackfillCacheConfig(
   cwd: string,
-  cacheOptions: Partial<CacheOptions> = {},
+  cacheOptions: Partial<CacheOptions> | undefined = {},
   backfillLogger: BackfillLogger
 ): CacheOptions {
   const envConfig = getEnvConfig(backfillLogger);

--- a/packages/cache/src/backfillWrapper.ts
+++ b/packages/cache/src/backfillWrapper.ts
@@ -9,8 +9,9 @@ import { CacheStorageConfig } from "backfill-config";
 import type { Logger as BackfillLogger } from "backfill-logger";
 import type { CacheOptions } from "./types/CacheOptions.js";
 import { CredentialCache } from "./CredentialCache.js";
+import { BackfillCacheProviderOptions } from "./providers/BackfillCacheProvider.js";
 
-export function createBackfillLogger() {
+export function createBackfillLogger(): BackfillLogger {
   const stdout = process.stdout;
   const stderr = process.stderr;
   return makeLogger("error", {
@@ -28,7 +29,11 @@ export function createBackfillLogger() {
   });
 }
 
-export function createBackfillCacheConfig(cwd: string, cacheOptions: Partial<CacheOptions> = {}, backfillLogger: BackfillLogger) {
+export function createBackfillCacheConfig(
+  cwd: string,
+  cacheOptions: Partial<CacheOptions> = {},
+  backfillLogger: BackfillLogger
+): CacheOptions {
   const envConfig = getEnvConfig(backfillLogger);
   const mergedConfig = {
     ...createDefaultConfig(cwd),

--- a/packages/cache/src/chunkPromise.ts
+++ b/packages/cache/src/chunkPromise.ts
@@ -1,6 +1,6 @@
 type PromiseFn = () => Promise<unknown>;
 
-export async function chunkPromise(promises: (Promise<unknown> | PromiseFn)[], limit = 5) {
+export async function chunkPromise(promises: (Promise<unknown> | PromiseFn)[], limit = 5): Promise<void> {
   for (let i = 0; i < promises.length; i += limit) {
     await Promise.all(promises.slice(i, i + limit).map((p) => (typeof p === "function" ? p() : p)));
   }

--- a/packages/cache/src/getCacheDirectory.ts
+++ b/packages/cache/src/getCacheDirectory.ts
@@ -1,13 +1,13 @@
 import path from "path";
 
-export function getCacheDirectoryRoot(root: string) {
+export function getCacheDirectoryRoot(root: string): string {
   return path.join(root, "node_modules", ".cache", "lage");
 }
 
-export function getCacheDirectory(root: string, hash: string) {
+export function getCacheDirectory(root: string, hash: string): string {
   return path.join(getCacheDirectoryRoot(root), "cache", hash.substring(0, 4));
 }
 
-export function getLogsCacheDirectory(root: string, hash: string) {
+export function getLogsCacheDirectory(root: string, hash: string): string {
   return path.join(getCacheDirectoryRoot(root), "logs", hash.substring(0, 4));
 }

--- a/packages/cache/src/providers/BackfillCacheProvider.ts
+++ b/packages/cache/src/providers/BackfillCacheProvider.ts
@@ -126,7 +126,7 @@ export class BackfillCacheProvider implements CacheProvider {
     );
   }
 
-  getCachePath(packagePath: string, hash: string) {
+  getCachePath(packagePath: string, hash: string): string {
     return path.relative(packagePath, getCacheDirectory(this.options.root, hash));
   }
 }

--- a/packages/cache/src/providers/RemoteFallbackCacheProvider.ts
+++ b/packages/cache/src/providers/RemoteFallbackCacheProvider.ts
@@ -24,7 +24,7 @@ export class RemoteFallbackCacheProvider implements CacheProvider {
 
   constructor(private options: RemoteFallbackCacheProviderOptions) {}
 
-  async fetch(hash: string, target: Target) {
+  async fetch(hash: string, target: Target): Promise<boolean> {
     const { logger, remoteCacheProvider, localCacheProvider } = this.options;
 
     if (localCacheProvider) {
@@ -48,7 +48,7 @@ export class RemoteFallbackCacheProvider implements CacheProvider {
     return RemoteFallbackCacheProvider.localHits[hash];
   }
 
-  async put(hash: string, target: Target) {
+  async put(hash: string, target: Target): Promise<void> {
     const { logger, remoteCacheProvider, localCacheProvider, writeRemoteCache } = this.options;
     const putPromises: Promise<void>[] = [];
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,8 +15,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },

--- a/packages/cli/src/cache/createCacheProvider.ts
+++ b/packages/cli/src/cache/createCacheProvider.ts
@@ -10,7 +10,9 @@ interface CreateCacheOptions {
   cliArgs: string[];
 }
 
-export async function createCache(options: CreateCacheOptions) {
+export async function createCache(options: CreateCacheOptions): Promise<{
+    hasher: TargetHasher;
+}> {
   const { cacheOptions, root, cliArgs, logger } = options;
 
   const hasher = new TargetHasher({

--- a/packages/cli/src/cache/isRunningFromCI.ts
+++ b/packages/cli/src/cache/isRunningFromCI.ts
@@ -1,1 +1,1 @@
-export const isRunningFromCI = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);
+export const isRunningFromCI: boolean = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);

--- a/packages/cli/src/commands/addFilterOptions.ts
+++ b/packages/cli/src/commands/addFilterOptions.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 
-export function addFilterOptions(program: Command) {
+export function addFilterOptions(program: Command): Command {
   return program
     .option("--scope <scope...>", "scopes the run to a subset of packages (by default, includes the dependencies and dependents as well)")
     .option("--no-deps|--no-dependents", "disables running any dependents of the scoped packages")

--- a/packages/cli/src/commands/addLoggerOptions.ts
+++ b/packages/cli/src/commands/addLoggerOptions.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { Option } from "commander";
 
-export function addLoggerOptions(program: Command) {
+export function addLoggerOptions(program: Command): Command {
   const isCI = process.env.CI || process.env.TF_BUILD;
 
   return program

--- a/packages/cli/src/commands/affected/action.ts
+++ b/packages/cli/src/commands/affected/action.ts
@@ -8,7 +8,7 @@ interface AffectedOptions extends FilterOptions {
   outputFormat?: "json" | "graph" | "default";
 }
 
-export async function affectedAction(options: AffectedOptions) {
+export async function affectedAction(options: AffectedOptions): Promise<void> {
   const { dependencies, dependents, since, scope, ignore, outputFormat } = options;
 
   const cwd = process.cwd();

--- a/packages/cli/src/commands/affected/index.ts
+++ b/packages/cli/src/commands/affected/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { addFilterOptions } from "../addFilterOptions.js";
 import { affectedAction } from "./action.js";
 
-const affectedCommand = new Command("affected");
+const affectedCommand: Command = new Command("affected");
 
 addFilterOptions(affectedCommand)
   .action(affectedAction)

--- a/packages/cli/src/commands/cache/action.ts
+++ b/packages/cli/src/commands/cache/action.ts
@@ -10,7 +10,7 @@ interface CacheOptions extends ReporterInitOptions {
   clear?: boolean;
 }
 
-export async function cacheAction(options: CacheOptions, command: Command) {
+export async function cacheAction(options: CacheOptions, command: Command): Promise<void> {
   const cwd = process.cwd();
   const config = await getConfig(cwd);
   const logger = createLogger();

--- a/packages/cli/src/commands/cache/clearCache.ts
+++ b/packages/cli/src/commands/cache/clearCache.ts
@@ -10,7 +10,7 @@ export interface ClearCacheOptions {
   concurrency: number;
 }
 
-export async function clearCache(options: ClearCacheOptions) {
+export async function clearCache(options: ClearCacheOptions): Promise<void> {
   const { logger, cwd } = options;
 
   const config = await getConfig(cwd);

--- a/packages/cli/src/commands/cache/index.ts
+++ b/packages/cli/src/commands/cache/index.ts
@@ -2,7 +2,7 @@ import { Command, Option } from "commander";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 import { cacheAction } from "./action.js";
 
-const cacheCommand = new Command("cache");
+const cacheCommand: Command = new Command("cache");
 
 addLoggerOptions(cacheCommand)
   .action(cacheAction)

--- a/packages/cli/src/commands/cache/pruneCache.ts
+++ b/packages/cli/src/commands/cache/pruneCache.ts
@@ -11,7 +11,7 @@ export interface PruneCacheOptions {
   pruneDays: number;
 }
 
-export async function pruneCache(options: PruneCacheOptions) {
+export async function pruneCache(options: PruneCacheOptions): Promise<void> {
   const { logger, cwd, pruneDays } = options;
 
   const config = await getConfig(cwd);

--- a/packages/cli/src/commands/cache/runners/ClearCacheRunner.ts
+++ b/packages/cli/src/commands/cache/runners/ClearCacheRunner.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { rm, stat, unlink } from "fs/promises";
 
 export class ClearCacheRunner implements TargetRunner {
-  async shouldRun() {
+  async shouldRun(): Promise<boolean> {
     return true;
   }
   async run(runOptions: TargetRunnerOptions): Promise<void> {

--- a/packages/cli/src/commands/cache/runners/PruneCacheRunner.ts
+++ b/packages/cli/src/commands/cache/runners/PruneCacheRunner.ts
@@ -6,7 +6,7 @@ import { rm, stat, unlink } from "fs/promises";
 const MS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
 export class PruneCacheRunner implements TargetRunner {
-  async shouldRun() {
+  async shouldRun(): Promise<boolean> {
     return true;
   }
   async run(runOptions: TargetRunnerOptions): Promise<void> {

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from "@lage-run/logger";
+import { LogLevel, type Reporter } from "@lage-run/logger";
 import {
   JsonReporter,
   AdoReporter,
@@ -12,7 +12,7 @@ import { findPackageRoot } from "workspace-tools";
 import { readFileSync } from "fs";
 import path from "path";
 
-export function createReporter(reporter: string, options: ReporterInitOptions) {
+export function createReporter(reporter: string, options: ReporterInitOptions): Reporter {
   const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress, logFile } = options;
   const logLevel = LogLevel[logLevelName];
 

--- a/packages/cli/src/commands/exec/action.ts
+++ b/packages/cli/src/commands/exec/action.ts
@@ -17,7 +17,7 @@ interface ExecRemoteOptions extends ExecOptions {
   tasks: string[];
 }
 
-export async function execAction(options: ExecOptions, command: Command) {
+export async function execAction(options: ExecOptions, command: Command): Promise<void> {
   const logger = createLogger();
   options.cwd = options.cwd ?? process.cwd();
   options.logLevel = options.logLevel ?? "info";

--- a/packages/cli/src/commands/exec/executeInProcess.ts
+++ b/packages/cli/src/commands/exec/executeInProcess.ts
@@ -80,7 +80,7 @@ function parsePackageInfoFromArgs(root: string, cwd: string | undefined, package
   };
 }
 
-export async function executeInProcess({ cwd, args, nodeArg, logger }: ExecuteInProcessOptions) {
+export async function executeInProcess({ cwd, args, nodeArg, logger }: ExecuteInProcessOptions): Promise<void> {
   const root = getWorkspaceRoot(process.cwd())!;
   const config = await getConfig(root);
   const { pipeline } = config;

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -91,7 +91,7 @@ async function executeOnServer(args: string[], client: LageClient, logger: Logge
   }
 }
 
-export async function executeRemotely(options: ExecRemotelyOptions, command: Command) {
+export async function executeRemotely(options: ExecRemotelyOptions, command: Command): Promise<void> {
   // launch a 'lage-server.js' process, detached if it is not already running
   // send the command to the server process
   const { server, tasks, nodeArg } = options;

--- a/packages/cli/src/commands/exec/expandTargetDefinition.ts
+++ b/packages/cli/src/commands/exec/expandTargetDefinition.ts
@@ -1,6 +1,12 @@
 import { type PipelineDefinition } from "@lage-run/config";
+import { type TargetConfig } from "@lage-run/target-graph";
 
-export function expandTargetDefinition(packageName: string | undefined, task: string, pipeline: PipelineDefinition, outputs: string[]) {
+export function expandTargetDefinition(
+  packageName: string | undefined,
+  task: string,
+  pipeline: PipelineDefinition,
+  outputs: string[]
+): TargetConfig {
   const id = packageName ? `${packageName}#${task}` : task;
   const emptyDefinition = {
     cache: false,

--- a/packages/cli/src/commands/exec/index.ts
+++ b/packages/cli/src/commands/exec/index.ts
@@ -3,7 +3,7 @@ import { execAction } from "./action.js";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 import os from "os";
 
-const execCommand = new Command("exec");
+const execCommand: Command = new Command("exec");
 execCommand.option(
   "-n|--node-arg <arg>",
   "node argument to pass to worker, just a single string to be passed into node like a NODE_OPTIONS setting"

--- a/packages/cli/src/commands/exec/simulateFileAccess.ts
+++ b/packages/cli/src/commands/exec/simulateFileAccess.ts
@@ -3,7 +3,7 @@ import path from "path";
 import fs from "fs";
 import { getWorkspaceRoot } from "workspace-tools";
 
-export async function simulateFileAccess(logger: Logger, inputs: string[], outputs: string[]) {
+export async function simulateFileAccess(logger: Logger, inputs: string[], outputs: string[]): Promise<void> {
   const root = getWorkspaceRoot(process.cwd())!;
   logger.silly("Now probing and touching inputs and outputs");
 

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -76,7 +76,7 @@ interface PackageTask {
  *   ...
  * ]
  */
-export async function infoAction(options: InfoActionOptions, command: Command) {
+export async function infoAction(options: InfoActionOptions, command: Command): Promise<void> {
   const cwd = process.cwd();
   const config = await getConfig(cwd);
   const logger = createLogger();

--- a/packages/cli/src/commands/info/index.ts
+++ b/packages/cli/src/commands/info/index.ts
@@ -3,7 +3,7 @@ import { infoAction } from "./action.js";
 import { addFilterOptions } from "../addFilterOptions.js";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 
-const infoCommand = new Command("info");
+const infoCommand: Command = new Command("info");
 
 addFilterOptions(addLoggerOptions(infoCommand));
 infoCommand.description("Display information about a target graph in a workspace.\n" + "It is used by BuildXL to build a pip-graph");

--- a/packages/cli/src/commands/init/action.ts
+++ b/packages/cli/src/commands/init/action.ts
@@ -6,7 +6,7 @@ import execa from "execa";
 
 type WorkspaceManager = "rush" | "pnpm" | "yarn" | "npm";
 
-export async function initAction() {
+export async function initAction(): Promise<void> {
   const cwd = process.cwd();
 
   const config = await readConfigFile(cwd);

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { addFilterOptions } from "../addFilterOptions.js";
 import { initAction } from "./action.js";
 
-const initCommand = new Command("init");
+const initCommand: Command = new Command("init");
 
 addFilterOptions(initCommand).description("Install lage in a workspace and create a config file").action(initAction);
 

--- a/packages/cli/src/commands/initializeReporters.ts
+++ b/packages/cli/src/commands/initializeReporters.ts
@@ -1,8 +1,8 @@
 import { createReporter } from "./createReporter.js";
-import type { Logger } from "@lage-run/logger";
+import type { LogStructuredData, Logger, Reporter } from "@lage-run/logger";
 import type { ReporterInitOptions } from "../types/ReporterInitOptions.js";
 
-export function initializeReporters(logger: Logger, options: ReporterInitOptions) {
+export function initializeReporters(logger: Logger, options: ReporterInitOptions): Reporter<LogStructuredData>[] {
   const { reporter } = options;
 
   // filter out falsy values (e.g. undefined) from the reporter array

--- a/packages/cli/src/commands/isRunningFromCI.ts
+++ b/packages/cli/src/commands/isRunningFromCI.ts
@@ -1,1 +1,1 @@
-export const isRunningFromCI = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);
+export const isRunningFromCI: boolean = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);

--- a/packages/cli/src/commands/launchServerInBackground.ts
+++ b/packages/cli/src/commands/launchServerInBackground.ts
@@ -25,7 +25,7 @@ export async function launchServerInBackground({
   timeout,
   args,
   nodeArg,
-}: launchServerInBackgroundOptions) {
+}: launchServerInBackgroundOptions): Promise<void> {
   const lockfilePath = path.join(root, `node_modules/.cache/lage/.lage-server-${host}-${port}.pid`);
 
   logger.info(`Starting server on http://${host}:${port}`);

--- a/packages/cli/src/commands/parseServerOption.ts
+++ b/packages/cli/src/commands/parseServerOption.ts
@@ -1,4 +1,7 @@
-export function parseServerOption(server: boolean | string | undefined) {
+export function parseServerOption(server: boolean | string | undefined): {
+    host: string;
+    port: number;
+} {
   const isBooleanAndTrue = typeof server === "boolean" && server;
   const isEmptyServer = typeof server === "undefined" || server === false;
   const serverString = isBooleanAndTrue ? "localhost:5332" : isEmptyServer ? "localhost:5332" : server;

--- a/packages/cli/src/commands/run/action.ts
+++ b/packages/cli/src/commands/run/action.ts
@@ -23,7 +23,7 @@ interface RunOptions extends ReporterInitOptions {
   allowNoTargetRuns: boolean;
 }
 
-export async function action(options: RunOptions, command: Command) {
+export async function action(options: RunOptions, command: Command): Promise<void> {
   if (options.watch) {
     return watchAction(options, command);
   } else {

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "@lage-run/logger";
-import { WorkspaceTargetGraphBuilder } from "@lage-run/target-graph";
+import { type TargetGraph, WorkspaceTargetGraphBuilder } from "@lage-run/target-graph";
 import type { PackageInfos } from "workspace-tools";
 import { getBranchChanges, getDefaultRemoteBranch, getStagedChanges, getUnstagedChanges, getUntrackedChanges } from "workspace-tools";
 import { getFilteredPackages } from "../../filter/getFilteredPackages.js";
@@ -37,7 +37,7 @@ function getChangedFiles(since: string, cwd: string) {
   return changes;
 }
 
-export async function createTargetGraph(options: CreateTargetGraphOptions) {
+export async function createTargetGraph(options: CreateTargetGraphOptions): Promise<TargetGraph> {
   const {
     logger,
     root,

--- a/packages/cli/src/commands/run/filterArgsForTasks.ts
+++ b/packages/cli/src/commands/run/filterArgsForTasks.ts
@@ -1,4 +1,7 @@
-export function filterArgsForTasks(args: string[]) {
+export function filterArgsForTasks(args: string[]): {
+    tasks: string[];
+    taskArgs: string[];
+} {
   const optionsPosition = args.findIndex((arg) => arg.startsWith("-"));
   return {
     tasks: args.slice(0, optionsPosition === -1 ? undefined : optionsPosition),

--- a/packages/cli/src/commands/run/filterPipelineDefinitions.ts
+++ b/packages/cli/src/commands/run/filterPipelineDefinitions.ts
@@ -1,7 +1,7 @@
 import type { Target } from "@lage-run/target-graph";
 import type { PipelineDefinition } from "@lage-run/config";
 
-export function filterPipelineDefinitions(targets: IterableIterator<Target>, pipeline: PipelineDefinition) {
+export function filterPipelineDefinitions(targets: IterableIterator<Target>, pipeline: PipelineDefinition): PipelineDefinition {
   const tasksSet = new Set<string>();
 
   for (const target of targets) {

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -4,7 +4,7 @@ import { addLoggerOptions } from "../addLoggerOptions.js";
 import { isRunningFromCI } from "../isRunningFromCI.js";
 import { addFilterOptions } from "../addFilterOptions.js";
 
-const runCommand = new Command("run");
+const runCommand: Command = new Command("run");
 
 addFilterOptions(addLoggerOptions(runCommand))
   .action(action)

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -31,7 +31,7 @@ interface RunOptions extends ReporterInitOptions, FilterOptions {
   allowNoTargetRuns: boolean;
 }
 
-export async function runAction(options: RunOptions, command: Command) {
+export async function runAction(options: RunOptions, command: Command): Promise<void> {
   const cwd = process.cwd();
   const config = await getConfig(cwd);
 

--- a/packages/cli/src/commands/run/watchAction.ts
+++ b/packages/cli/src/commands/run/watchAction.ts
@@ -30,7 +30,7 @@ interface RunOptions extends ReporterInitOptions, FilterOptions {
   allowNoTargetRuns: boolean;
 }
 
-export async function watchAction(options: RunOptions, command: Command) {
+export async function watchAction(options: RunOptions, command: Command): Promise<void> {
   const cwd = process.cwd();
   const config = await getConfig(cwd);
   const concurrency = getConcurrency(options.concurrency, config.concurrency);

--- a/packages/cli/src/commands/server/MemoryStream.ts
+++ b/packages/cli/src/commands/server/MemoryStream.ts
@@ -8,7 +8,7 @@ export class MemoryStream extends Writable {
     this.chunks = [];
   }
 
-  _write(chunk: any, encoding: BufferEncoding) {
+  _write(chunk: any, encoding: BufferEncoding): void {
     this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding));
   }
 

--- a/packages/cli/src/commands/server/action.ts
+++ b/packages/cli/src/commands/server/action.ts
@@ -13,7 +13,7 @@ interface WorkerOptions extends ReporterInitOptions {
   tasks: string[];
 }
 
-export async function serverAction(options: WorkerOptions) {
+export async function serverAction(options: WorkerOptions): Promise<void> {
   const { port = 5332, host = "localhost", timeout = 1, tasks } = options;
 
   const logger = createLogger();

--- a/packages/cli/src/commands/server/getOutputFiles.ts
+++ b/packages/cli/src/commands/server/getOutputFiles.ts
@@ -5,7 +5,7 @@ import type { Target } from "@lage-run/target-graph";
 
 import path from "path";
 
-export function getOutputFiles(root: string, target: Target, outputGlob: CacheOptions["outputGlob"], packageTree: PackageTree) {
+export function getOutputFiles(root: string, target: Target, outputGlob: CacheOptions["outputGlob"], packageTree: PackageTree): string[] {
   const patterns = target.outputs ?? outputGlob ?? ["**/*"];
 
   const sourceControlledFiles = new Set(packageTree.getPackageFiles(target.packageName ?? "", patterns));

--- a/packages/cli/src/commands/server/index.ts
+++ b/packages/cli/src/commands/server/index.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { serverAction } from "./action.js";
 import { addLoggerOptions } from "../addLoggerOptions.js";
 
-const serverCommand = new Command("server");
+const serverCommand: Command = new Command("server");
 serverCommand.option(
   "-n|--node-arg <arg>",
   "node argument to pass to worker, just a single string to be passed into node like a NODE_OPTIONS setting"

--- a/packages/cli/src/filter/getFilteredPackages.ts
+++ b/packages/cli/src/filter/getFilteredPackages.ts
@@ -14,7 +14,7 @@ export function getFilteredPackages(options: {
   repoWideChanges: string[];
   includeDependents: boolean;
   includeDependencies: boolean;
-}) {
+}): string[] {
   const { scope, since, sinceIgnoreGlobs, repoWideChanges, includeDependents, includeDependencies, logger, packageInfos, root } = options;
 
   // If scoped is defined, get scoped packages
@@ -78,7 +78,7 @@ export function filterPackages(options: {
   includeDependencies: boolean;
   scopedPackages: string[] | undefined;
   changedPackages: string[] | undefined;
-}) {
+}): string[] {
   const { scopedPackages, changedPackages, packageInfos, includeDependents, includeDependencies, logger } = options;
 
   let filtered: string[] = [];

--- a/packages/cli/src/filter/hasRepoChanged.ts
+++ b/packages/cli/src/filter/hasRepoChanged.ts
@@ -2,7 +2,7 @@ import { getBranchChanges } from "workspace-tools";
 import * as fg from "fast-glob";
 import type { Logger } from "@lage-run/logger";
 
-export function hasRepoChanged(since: string, root: string, environmentGlob: string[], logger: Logger) {
+export function hasRepoChanged(since: string, root: string, environmentGlob: string[], logger: Logger): boolean {
   try {
     const changedFiles = getBranchChanges(since, root);
     const envFiles = fg.sync(environmentGlob, { cwd: root });

--- a/packages/cli/src/getBinPaths.ts
+++ b/packages/cli/src/getBinPaths.ts
@@ -14,7 +14,10 @@ function findUp(name: string, dir: string) {
   return undefined;
 }
 
-export function getBinPaths() {
+export function getBinPaths(): {
+    lage: string;
+    "lage-server": string;
+} {
   const bins = os.platform() === "win32" ? ["lage.cmd", "lage-server.cmd"] : ["lage", "lage-server"];
   const binPaths = bins.map((bin) => findUp("node_modules/.bin/" + bin, __dirname));
 
@@ -25,7 +28,10 @@ export function getBinPaths() {
   return { lage: binPaths[0]!, "lage-server": binPaths[1]! };
 }
 
-export function getBinScripts() {
+export function getBinScripts(): {
+    lage: string;
+    "lage-server": string;
+} {
   const thisPackageJsonPath = findUp("package.json", __dirname);
 
   if (!thisPackageJsonPath) {

--- a/packages/cli/src/optimizeTargetGraph.ts
+++ b/packages/cli/src/optimizeTargetGraph.ts
@@ -1,7 +1,7 @@
 import type { TargetRunnerPicker } from "@lage-run/runners";
-import { type TargetGraph, removeNodes, transitiveReduction, getStartTargetId } from "@lage-run/target-graph";
+import { type TargetGraph, removeNodes, transitiveReduction, getStartTargetId, type Target } from "@lage-run/target-graph";
 
-export async function optimizeTargetGraph(graph: TargetGraph, runnerPicker: TargetRunnerPicker) {
+export async function optimizeTargetGraph(graph: TargetGraph, runnerPicker: TargetRunnerPicker): Promise<Target[]> {
   const targetMinimizedNodes = await removeNodes([...graph.targets.values()], async (target) => {
     if (target.type === "noop") {
       return true;

--- a/packages/cli/src/showHelp.ts
+++ b/packages/cli/src/showHelp.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-export function showHelp(msg: string) {
+export function showHelp(msg: string): void {
   console.error(msg);
 
   console.log(`

--- a/packages/cli/src/types/errors.ts
+++ b/packages/cli/src/types/errors.ts
@@ -1,1 +1,1 @@
-export const NoTargetFoundError = new Error("No target found");
+export const NoTargetFoundError: Error = new Error("No target found");

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,9 +14,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
-    "test": "jest",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
+    "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/config/src/getMaxWorkersPerTask.ts
+++ b/packages/config/src/getMaxWorkersPerTask.ts
@@ -1,6 +1,6 @@
 import type { ConfigOptions } from "./types/ConfigOptions.js";
 
-export function getMaxWorkersPerTask(pipelineConfig: ConfigOptions["pipeline"], concurrency: number) {
+export function getMaxWorkersPerTask(pipelineConfig: ConfigOptions["pipeline"], concurrency: number): Map<string, number> {
   const maxWorkersPerTask = new Map<string, number>();
 
   let generalPoolCount = 0;
@@ -58,7 +58,7 @@ export function getMaxWorkersPerTask(pipelineConfig: ConfigOptions["pipeline"], 
   return maxWorkersPerTask;
 }
 
-export function getMaxWorkersPerTaskFromOptions(maxWorkersPerTask: string[]) {
+export function getMaxWorkersPerTaskFromOptions(maxWorkersPerTask: string[]): Map<string, number> {
   return new Map([
     ...maxWorkersPerTask.map((setting) => {
       const [task, maxWorkers] = setting.split(/[=:]/);

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -13,8 +13,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },

--- a/packages/e2e-tests/src/parseNdJson.ts
+++ b/packages/e2e-tests/src/parseNdJson.ts
@@ -1,6 +1,6 @@
 import type { TargetStatus } from "@lage-run/scheduler-types";
 
-export function parseNdJson(ndjson: string) {
+export function parseNdJson(ndjson: string): any[] {
   const entries = ndjson.substr(ndjson.indexOf("{"));
   return entries
     .split("\n")
@@ -20,6 +20,6 @@ export function parseNdJson(ndjson: string) {
     .filter((entry) => Object.keys(entry).length > 0);
 }
 
-export function filterEntry(data: any, pkg: string, task: string, status: TargetStatus) {
+export function filterEntry(data: any, pkg: string, task: string, status: TargetStatus): boolean {
   return data?.target?.packageName === pkg && data?.target?.task === task && data.status === status;
 }

--- a/packages/format-hrtime/package.json
+++ b/packages/format-hrtime/package.json
@@ -9,10 +9,14 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
-    "test": "jest",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
+    "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
+  },
+  "devDependencies": {
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/format-hrtime/src/formatDuration.ts
+++ b/packages/format-hrtime/src/formatDuration.ts
@@ -1,4 +1,4 @@
-export function formatDuration(seconds: string) {
+export function formatDuration(seconds: string): string {
   const raw = parseFloat(seconds);
   if (raw > 60) {
     const minutes = Math.floor(raw / 60);
@@ -10,7 +10,7 @@ export function formatDuration(seconds: string) {
   }
 }
 
-export function hrToSeconds(hrtime: [number, number]) {
+export function hrToSeconds(hrtime: [number, number]): string {
   const raw = hrtime[0] + hrtime[1] / 1e9;
   return raw.toFixed(2);
 }

--- a/packages/globby/package.json
+++ b/packages/globby/package.json
@@ -11,7 +11,7 @@
     "dts-bundle-generator": "^9.5.1",
     "esbuild": "^0.21.5",
     "globby": "^14.0.2",
-    "typescript": "~5.0.3"
+    "typescript": "~5.7.3"
   },
   "exports": {
     ".": {

--- a/packages/globby/src/index.mts
+++ b/packages/globby/src/index.mts
@@ -6,7 +6,7 @@ function cacheKey(patterns: string[], options: Options = {}) {
   return JSON.stringify({ patterns, options });
 }
 
-export async function globAsync(patterns: string[], options?: Options) {
+export async function globAsync(patterns: string[], options?: Options): Promise<string[]> {
   const key = cacheKey(patterns, options);
   if (!cache.has(key)) {
     cache.set(key, await globby(patterns, options));
@@ -14,7 +14,7 @@ export async function globAsync(patterns: string[], options?: Options) {
   return cache.get(key) || [];
 }
 
-export function glob(patterns: string[], options?: Options) {
+export function glob(patterns: string[], options?: Options): string[] {
   const key = cacheKey(patterns, options);
   if (!cache.has(key)) {
     cache.set(key, globbySync(patterns, options));

--- a/packages/globby/tsconfig.json
+++ b/packages/globby/tsconfig.json
@@ -1,11 +1,23 @@
 {
-  "extends": "../tsconfig.lage2.json",
   "compilerOptions": {
     "outDir": "./lib",
     "emitDeclarationOnly": true,
-    "module": "Node16"
+    "module": "Node16",
+    "target": "ES2020",
+    "moduleResolution": "Node16",
+    "declaration": true,
+    "lib": ["ES2020"],
+    "strict": true,
+    "noImplicitAny": false,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "sourceMap": true,
+    "typeRoots": ["../node_modules/@types", "../types", "node_modules/@types"],
+    "isolatedModules": true
   },
-  "files": [],
   "include": ["src/index.mts"],
   "exclude": ["lib/**/*.mts"]
 }

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -9,8 +9,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },

--- a/packages/hasher/src/FileHasher.ts
+++ b/packages/hasher/src/FileHasher.ts
@@ -27,7 +27,7 @@ export class FileHasher {
     this.#manifestFile = path.join(cacheDirectory, "file_hashes.manifest");
   }
 
-  async getHashesFromGit() {
+  async getHashesFromGit(): Promise<void> {
     const { root } = this.options;
     const fileHashes = await getPackageDeps(root);
     const files = [...fileHashes.keys()];
@@ -45,7 +45,7 @@ export class FileHasher {
     this.writeManifest();
   }
 
-  async readManifest() {
+  async readManifest(): Promise<void> {
     return new Promise<void>((resolve) => {
       if (!fs.existsSync(this.#manifestFile)) {
         this.getHashesFromGit().then(() => resolve());
@@ -77,7 +77,7 @@ export class FileHasher {
     });
   }
 
-  writeManifest() {
+  writeManifest(): void {
     fs.mkdirSync(path.dirname(this.#manifestFile), { recursive: true });
     const outputLines = Object.entries(this.#store).map(([relativePath, info]) => {
       return `${relativePath}\0${info.mtime.toString()}\0${info.size.toString()}\0${info.hash}`;
@@ -86,7 +86,7 @@ export class FileHasher {
     fs.writeFileSync(this.#manifestFile, outputLines.join("\n"), "utf-8");
   }
 
-  hash(files: string[]) {
+  hash(files: string[]): Record<string, string> {
     const hashes: Record<string, string> = {};
 
     const updatedFiles: string[] = [];

--- a/packages/hasher/src/PackageTree.ts
+++ b/packages/hasher/src/PackageTree.ts
@@ -27,14 +27,14 @@ export class PackageTree {
 
   constructor(private options: PackageTreeOptions) {}
 
-  reset() {
+  reset(): void {
     // reset the internal state
     this.#tree = {};
     this.#packageFiles = {};
     this.#memoizedPackageFiles = {};
   }
 
-  async initialize() {
+  async initialize(): Promise<void> {
     const { root, includeUntracked, packageInfos } = this.options;
 
     this.reset();
@@ -70,7 +70,7 @@ export class PackageTree {
     }
   }
 
-  async addToPackageTree(filePaths: string[]) {
+  async addToPackageTree(filePaths: string[]): Promise<void> {
     // key: path/to/package (packageRoot), value: array of a tuple of [file, hash]
     const packageFiles = this.#packageFiles;
 
@@ -95,7 +95,7 @@ export class PackageTree {
     }
   }
 
-  getPackageFiles(packageName: string, patterns: string[]) {
+  getPackageFiles(packageName: string, patterns: string[]): string[] {
     const { root, packageInfos } = this.options;
     const packagePath = path.relative(root, path.dirname(packageInfos[packageName].packageJsonPath)).replace(/\\/g, "/");
 

--- a/packages/hasher/src/TargetHasher.ts
+++ b/packages/hasher/src/TargetHasher.ts
@@ -73,7 +73,7 @@ export class TargetHasher {
     dependents: new Map(),
   };
 
-  getPackageInfos(workspacePackages: WorkspaceInfo) {
+  getPackageInfos(workspacePackages: WorkspaceInfo): PackageInfos {
     const { root } = this.options;
     const packageInfos: PackageInfos = {};
 
@@ -114,13 +114,13 @@ export class TargetHasher {
     }
   }
 
-  ensureInitialized() {
+  ensureInitialized(): void {
     if (!this.initializedPromise) {
       throw new Error("TargetHasher is not initialized");
     }
   }
 
-  async initialize() {
+  async initialize(): Promise<void> {
     const { environmentGlob, root } = this.options;
 
     if (this.initializedPromise) {
@@ -228,7 +228,7 @@ export class TargetHasher {
     return hashString;
   }
 
-  writeTargetHashesManifest() {
+  writeTargetHashesManifest(): void {
     for (const [id, { fileHashes, globalFileHashes }] of Object.entries(this.targetHashesLog)) {
       const targetHashesManifestPath = path.join(this.targetHashesDirectory, `${id}.json`);
       if (!fs.existsSync(path.dirname(targetHashesManifestPath))) {
@@ -238,7 +238,7 @@ export class TargetHasher {
     }
   }
 
-  async getEnvironmentGlobHashes(root: string, target: Target) {
+  async getEnvironmentGlobHashes(root: string, target: Target): Promise<Record<string, string>> {
     const globalFileHashes = target.environmentGlob
       ? this.fileHasher.hash(await globAsync(target.environmentGlob ?? [], { cwd: root }))
       : this.globalInputsHash ?? {};
@@ -246,7 +246,7 @@ export class TargetHasher {
     return globalFileHashes;
   }
 
-  async cleanup() {
+  async cleanup(): Promise<void> {
     this.writeTargetHashesManifest();
     await this.fileHasher.writeManifest();
   }

--- a/packages/hasher/src/__tests__/resolveDependenciesHelper.ts
+++ b/packages/hasher/src/__tests__/resolveDependenciesHelper.ts
@@ -4,7 +4,7 @@ const fixturesPath = path.join(__dirname, "..", "__fixtures__");
 
 import { getYarnWorkspaces, getPnpmWorkspaces, getRushWorkspaces } from "workspace-tools";
 
-export async function filterDependenciesInYarnFixture(fixture: string, filterFunction: any) {
+export async function filterDependenciesInYarnFixture(fixture: string, filterFunction: any): Promise<any> {
   const monorepo = new Monorepo("monorepo");
   await monorepo.init(path.join(fixturesPath, fixture));
   const packageRoot = monorepo.root;
@@ -18,7 +18,7 @@ export async function filterDependenciesInYarnFixture(fixture: string, filterFun
   return filteredDependencies;
 }
 
-export async function filterDependenciesInPnpmFixture(fixture: string, filterFunction: any) {
+export async function filterDependenciesInPnpmFixture(fixture: string, filterFunction: any): Promise<any> {
   const monorepo = new Monorepo("monorepo");
   await monorepo.init(path.join(fixturesPath, fixture));
   const packageRoot = monorepo.root;
@@ -32,7 +32,7 @@ export async function filterDependenciesInPnpmFixture(fixture: string, filterFun
   return filteredDependencies;
 }
 
-export async function filterDependenciesInRushFixture(fixture: string, filterFunction: any) {
+export async function filterDependenciesInRushFixture(fixture: string, filterFunction: any): Promise<any> {
   const monorepo = new Monorepo("monorepo");
   await monorepo.init(path.join(fixturesPath, fixture));
   const packageRoot = monorepo.root;

--- a/packages/hasher/src/expandInputPatterns.ts
+++ b/packages/hasher/src/expandInputPatterns.ts
@@ -1,7 +1,7 @@
 import { type Target } from "@lage-run/target-graph";
 import { type DependencyMap } from "workspace-tools";
 
-export function expandInputPatterns(patterns: string[], target: Target, dependencyMap: DependencyMap) {
+export function expandInputPatterns(patterns: string[], target: Target, dependencyMap: DependencyMap): Record<string, string[]> {
   const expandedPatterns: Record<string, string[]> = {};
 
   for (const pattern of patterns) {

--- a/packages/hasher/src/getInputFiles.ts
+++ b/packages/hasher/src/getInputFiles.ts
@@ -3,7 +3,7 @@ import { type DependencyMap } from "workspace-tools";
 import { type PackageTree } from "./PackageTree.js";
 import { expandInputPatterns } from "./expandInputPatterns.js";
 
-export function getInputFiles(target: Target, dependencyMap: DependencyMap, packageTree: PackageTree) {
+export function getInputFiles(target: Target, dependencyMap: DependencyMap, packageTree: PackageTree): string[] {
   const inputs = target.inputs ?? ["**/*"];
 
   const packagePatterns = expandInputPatterns(inputs, target, dependencyMap);

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,10 +11,14 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
-    "test": "jest",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
+    "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
+  },
+  "devDependencies": {
+    "@lage-run/monorepo-scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -6,7 +6,7 @@ import { createInterface } from "readline";
 export class Logger<TLogStructuredData extends LogStructuredData = LogStructuredData> {
   reporters: Reporter[] = [];
 
-  log(level: LogLevel, msg: string, data?: TLogStructuredData) {
+  log(level: LogLevel, msg: string, data?: TLogStructuredData): void {
     const entry = {
       timestamp: Date.now(),
       level,
@@ -19,23 +19,23 @@ export class Logger<TLogStructuredData extends LogStructuredData = LogStructured
     }
   }
 
-  info(msg: string, data?: TLogStructuredData) {
+  info(msg: string, data?: TLogStructuredData): void {
     this.log(LogLevel.info, msg, data);
   }
 
-  warn(msg: string, data?: TLogStructuredData) {
+  warn(msg: string, data?: TLogStructuredData): void {
     this.log(LogLevel.warn, msg, data);
   }
 
-  error(msg: string, data?: TLogStructuredData) {
+  error(msg: string, data?: TLogStructuredData): void {
     this.log(LogLevel.error, msg, data);
   }
 
-  verbose(msg: string, data?: TLogStructuredData) {
+  verbose(msg: string, data?: TLogStructuredData): void {
     this.log(LogLevel.verbose, msg, data);
   }
 
-  silly(msg: string, data?: TLogStructuredData) {
+  silly(msg: string, data?: TLogStructuredData): void {
     this.log(LogLevel.silly, msg, data);
   }
 
@@ -52,13 +52,13 @@ export class Logger<TLogStructuredData extends LogStructuredData = LogStructured
 
     readline.on("line", lineLogger);
 
-    return () => {
+    return (): void => {
       readline.off("line", lineLogger);
       readline.close();
     };
   }
 
-  addReporter(reporter: Reporter) {
+  addReporter(reporter: Rep: voidorter:: void any:: void any:: void any:: void any:: void any) {
     this.reporters.push(reporter);
   }
 }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -58,7 +58,7 @@ export class Logger<TLogStructuredData extends LogStructuredData = LogStructured
     };
   }
 
-  addReporter(reporter: Rep: voidorter:: void any:: void any:: void any:: void any:: void any) {
+  addReporter(reporter: Reporter): void {
     this.reporters.push(reporter);
   }
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,7 @@
 import type { LogStructuredData } from "./interfaces/LogStructuredData.js";
 import { Logger } from "./Logger.js";
 
-export default function createLogger<TLogStructuredData extends LogStructuredData = LogStructuredData>() {
+export default function createLogger<TLogStructuredData extends LogStructuredData = LogStructuredData>(): Logger<TLogStructuredData> {
   return new Logger<TLogStructuredData>();
 }
 

--- a/packages/monorepo-fixture/package.json
+++ b/packages/monorepo-fixture/package.json
@@ -10,8 +10,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
+    "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -11,9 +11,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
-    "test": "jest",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
+    "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "gradient-string": "2.0.2"
   },
   "devDependencies": {
+    "@lage-run/monorepo-scripts": "*",
     "memory-streams": "^0.1.3"
   },
   "publishConfig": {

--- a/packages/reporters/src/AdoReporter.ts
+++ b/packages/reporters/src/AdoReporter.ts
@@ -1,6 +1,6 @@
 import { formatDuration, hrToSeconds } from "@lage-run/format-hrtime";
 import { isTargetStatusLogEntry } from "./isTargetStatusLogEntry.js";
-import { LogLevel } from "@lage-run/logger";
+import { LogLevel, type LogStructuredData } from "@lage-run/logger";
 import chalk from "chalk";
 import type { Reporter, LogEntry } from "@lage-run/logger";
 import type { SchedulerRunSummary, TargetStatus } from "@lage-run/scheduler-types";
@@ -52,13 +52,13 @@ export class AdoReporter implements Reporter {
   logStream: Writable = process.stdout;
 
   private logEntries = new Map<string, LogEntry[]>();
-  readonly groupedEntries = new Map<string, LogEntry[]>();
+  readonly groupedEntries: Map<string, LogEntry<LogStructuredData>[]> = new Map<string, LogEntry[]>();
 
   constructor(private options: { logLevel?: LogLevel; grouped?: boolean }) {
     options.logLevel = options.logLevel || LogLevel.info;
   }
 
-  log(entry: LogEntry<any>) {
+  log(entry: LogEntry<any>): boolean | void {
     if (entry.data && entry.data.target && entry.data.target.hidden) {
       return;
     }
@@ -159,7 +159,7 @@ export class AdoReporter implements Reporter {
     }
   }
 
-  summarize(schedulerRunSummary: SchedulerRunSummary) {
+  summarize(schedulerRunSummary: SchedulerRunSummary): void {
     const { targetRuns, targetRunByStatus, duration } = schedulerRunSummary;
     const { failed, aborted, skipped, success, pending } = targetRunByStatus;
 

--- a/packages/reporters/src/ChromeTraceEventsReporter.ts
+++ b/packages/reporters/src/ChromeTraceEventsReporter.ts
@@ -58,11 +58,11 @@ export class ChromeTraceEventsReporter implements Reporter {
     this.logStream = fs.createWriteStream(this.outputFile, { flags: "w" });
   }
 
-  log() {
+  log(): void {
     // pass
   }
 
-  summarize(schedulerRunSummary: SchedulerRunSummary) {
+  summarize(schedulerRunSummary: SchedulerRunSummary): void {
     const { targetRuns, startTime } = schedulerRunSummary;
 
     // categorize events

--- a/packages/reporters/src/JsonReporter.ts
+++ b/packages/reporters/src/JsonReporter.ts
@@ -8,7 +8,7 @@ import type { TargetMessageEntry, TargetStatusEntry } from "./types/TargetLogEnt
 export class JsonReporter implements Reporter {
   constructor(private options: { logLevel: LogLevel }) {}
 
-  log(entry: LogEntry<TargetStatusEntry | TargetMessageEntry>) {
+  log(entry: LogEntry<TargetStatusEntry | TargetMessageEntry>): void {
     if (entry.data && entry.data.target && entry.data.target.hidden) {
       return;
     }
@@ -18,7 +18,7 @@ export class JsonReporter implements Reporter {
     }
   }
 
-  summarize(schedulerRunSummary: SchedulerRunSummary) {
+  summarize(schedulerRunSummary: SchedulerRunSummary): void {
     const { duration, targetRuns, targetRunByStatus } = schedulerRunSummary;
     const summary: any = {};
     const taskStats: any[] = [];

--- a/packages/reporters/src/LogReporter.ts
+++ b/packages/reporters/src/LogReporter.ts
@@ -1,6 +1,6 @@
 import { formatDuration, hrtimeDiff, hrToSeconds } from "@lage-run/format-hrtime";
 import { isTargetStatusLogEntry } from "./isTargetStatusLogEntry.js";
-import { LogLevel } from "@lage-run/logger";
+import { LogLevel, type LogStructuredData } from "@lage-run/logger";
 import ansiRegex from "ansi-regex";
 import chalk from "chalk";
 import type { Chalk } from "chalk";
@@ -79,13 +79,13 @@ function normalize(prefixOrMessage: string, message?: string) {
 export class LogReporter implements Reporter {
   logStream: Writable = process.stdout;
   private logEntries = new Map<string, LogEntry[]>();
-  readonly groupedEntries = new Map<string, LogEntry[]>();
+  readonly groupedEntries: Map<string, LogEntry<LogStructuredData>[]> = new Map<string, LogEntry[]>();
 
   constructor(private options: { logLevel?: LogLevel; grouped?: boolean }) {
     options.logLevel = options.logLevel || LogLevel.info;
   }
 
-  log(entry: LogEntry<any>) {
+  log(entry: LogEntry<any>): void {
     // if "hidden", do not even attempt to record or report the entry
     if (entry?.data?.target?.hidden) {
       return;
@@ -190,11 +190,11 @@ export class LogReporter implements Reporter {
     }
   }
 
-  hr() {
+  hr(): void {
     this.print("┈".repeat(80));
   }
 
-  summarize(schedulerRunSummary: SchedulerRunSummary) {
+  summarize(schedulerRunSummary: SchedulerRunSummary): void {
     const { targetRuns, targetRunByStatus, duration } = schedulerRunSummary;
     const { failed, aborted, skipped, success, pending } = targetRunByStatus;
 
@@ -281,7 +281,7 @@ export class LogReporter implements Reporter {
     this.print(`Took a total of ${formatDuration(hrToSeconds(duration))} to complete. ${allCacheHitText}`);
   }
 
-  resetLogEntries() {
+  resetLogEntries(): void {
     this.logEntries.clear();
   }
 }

--- a/packages/reporters/src/ProgressReporter.ts
+++ b/packages/reporters/src/ProgressReporter.ts
@@ -1,5 +1,5 @@
 import EventEmitter from "events";
-import { type LogEntry, LogLevel, type Reporter } from "@lage-run/logger";
+import { type LogEntry, LogLevel, type Reporter, type LogStructuredData } from "@lage-run/logger";
 import type { SchedulerRunSummary, TargetStatus } from "@lage-run/scheduler-types";
 
 // @ts-ignore Ignoring ESM in CJS errors here, but still importing the types to be used
@@ -35,7 +35,7 @@ export class ProgressReporter implements Reporter {
   startTime: [number, number] = [0, 0];
 
   logEvent: EventEmitter = new EventEmitter();
-  logEntries = new Map<string, LogEntry[]>();
+  logEntries: Map<string, LogEntry<LogStructuredData>[]> = new Map<string, LogEntry[]>();
 
   taskReporter: TaskReporter;
   tasks: Map<string, TaskReporterTask> = new Map();
@@ -46,7 +46,7 @@ export class ProgressReporter implements Reporter {
     this.print(`${fancy("lage")} - Version ${options.version} - ${options.concurrency} Workers`);
   }
 
-  createTaskReporter() {
+  createTaskReporter(): TaskReporter {
     return new TaskReporter({
       productName: "lage",
       version: this.options.version,
@@ -67,7 +67,7 @@ export class ProgressReporter implements Reporter {
     });
   }
 
-  log(entry: LogEntry<any>) {
+  log(entry: LogEntry<any>): void {
     // save the logs for errors
     if (entry.data?.target?.id) {
       if (!this.logEntries.has(entry.data.target.id)) {
@@ -122,11 +122,11 @@ export class ProgressReporter implements Reporter {
     this.logStream.write(message + "\n");
   }
 
-  hr() {
+  hr(): void {
     this.print("┈".repeat(80));
   }
 
-  summarize(schedulerRunSummary: SchedulerRunSummary) {
+  summarize(schedulerRunSummary: SchedulerRunSummary): void {
     const { targetRuns, targetRunByStatus, duration } = schedulerRunSummary;
     const { failed, aborted, skipped, success, pending, running, queued } = targetRunByStatus;
 

--- a/packages/reporters/src/VerboseFileLogReporter.ts
+++ b/packages/reporters/src/VerboseFileLogReporter.ts
@@ -28,11 +28,11 @@ export class VerboseFileLogReporter implements Reporter {
     this.fileStream = logFile ? fs.createWriteStream(logFile) : new Writable({ write() {} });
   }
 
-  cleanup() {
+  cleanup(): void {
     this.fileStream?.end();
   }
 
-  log(entry: LogEntry<any>) {
+  log(entry: LogEntry<any>): void {
     // if "hidden", do not even attempt to record or report the entry
     if (entry?.data?.target?.hidden) {
       return;
@@ -100,7 +100,7 @@ export class VerboseFileLogReporter implements Reporter {
     }
   }
 
-  summarize() {
+  summarize(): void {
     // No summary needed for VerboseFileLogReporter
   }
 }

--- a/packages/reporters/src/slowestTargetRuns.ts
+++ b/packages/reporters/src/slowestTargetRuns.ts
@@ -1,7 +1,7 @@
 import { hrtimeDiff, hrToSeconds } from "@lage-run/format-hrtime";
 import type { TargetRun } from "@lage-run/scheduler-types";
 
-export function slowestTargetRuns(targetRuns: TargetRun[]) {
+export function slowestTargetRuns(targetRuns: TargetRun[]): TargetRun<unknown>[] {
   return targetRuns
     .sort((a, b) => parseFloat(hrToSeconds(hrtimeDiff(a.duration, b.duration))))
     .filter((run) => run.status !== "skipped" && !run.target.hidden);

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "lint": "buf lint",
     "generate": "buf generate",
-    "build": "tsc"
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",

--- a/packages/rpc/src/createClient.ts
+++ b/packages/rpc/src/createClient.ts
@@ -1,6 +1,8 @@
-import { createPromiseClient } from "@connectrpc/connect";
+import { createPromiseClient, PromiseClient } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { LageService } from "./gen/lage/v1/lage_connect.js";
+import { MethodKind } from "@bufbuild/protobuf";
+import { RunTargetRequest, RunTargetResponse, PingRequest, PingResponse } from "./gen/lage/v1/lage_pb.js";
 
 export interface CreateClientOptions {
   baseUrl: string;
@@ -9,7 +11,23 @@ export interface CreateClientOptions {
 
 export type LageClient = ReturnType<typeof createClient>;
 
-export function createClient({ baseUrl, httpVersion }: CreateClientOptions) {
+export function createClient({ baseUrl, httpVersion }: CreateClientOptions): PromiseClient<{
+    readonly typeName: "connectrpc.lage.v1.LageService";
+    readonly methods: {
+        readonly runTarget: {
+            readonly name: "RunTarget";
+            readonly I: RunTargetRequest;
+            readonly O: RunTargetResponse;
+            readonly kind: MethodKind.Unary;
+        };
+        readonly ping: {
+            readonly name: "Ping";
+            readonly I: PingRequest;
+            readonly O: PingResponse;
+            readonly kind: MethodKind.Unary;
+        };
+    };
+}> {
   const transport = createGrpcTransport({
     httpVersion,
     baseUrl,

--- a/packages/rpc/src/createClient.ts
+++ b/packages/rpc/src/createClient.ts
@@ -1,8 +1,6 @@
-import { createPromiseClient, PromiseClient } from "@connectrpc/connect";
+import { createPromiseClient, type PromiseClient } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { LageService } from "./gen/lage/v1/lage_connect.js";
-import { MethodKind } from "@bufbuild/protobuf";
-import { RunTargetRequest, RunTargetResponse, PingRequest, PingResponse } from "./gen/lage/v1/lage_pb.js";
 
 export interface CreateClientOptions {
   baseUrl: string;
@@ -11,23 +9,7 @@ export interface CreateClientOptions {
 
 export type LageClient = ReturnType<typeof createClient>;
 
-export function createClient({ baseUrl, httpVersion }: CreateClientOptions): PromiseClient<{
-    readonly typeName: "connectrpc.lage.v1.LageService";
-    readonly methods: {
-        readonly runTarget: {
-            readonly name: "RunTarget";
-            readonly I: RunTargetRequest;
-            readonly O: RunTargetResponse;
-            readonly kind: MethodKind.Unary;
-        };
-        readonly ping: {
-            readonly name: "Ping";
-            readonly I: PingRequest;
-            readonly O: PingResponse;
-            readonly kind: MethodKind.Unary;
-        };
-    };
-}> {
+export function createClient({ baseUrl, httpVersion }: CreateClientOptions): PromiseClient<typeof LageService> {
   const transport = createGrpcTransport({
     httpVersion,
     baseUrl,

--- a/packages/rpc/src/createRoutes.ts
+++ b/packages/rpc/src/createRoutes.ts
@@ -3,7 +3,7 @@ import { LageService } from "./gen/lage/v1/lage_connect.js";
 import { type ILageService } from "./types/ILageService.js";
 
 export function createRoutes(serviceImpl: ILageService) {
-  return (router: ConnectRouter) => {
+  return (router: ConnectRouter): void => {
     router.service(LageService, serviceImpl);
   };
 }

--- a/packages/rpc/src/createServer.ts
+++ b/packages/rpc/src/createServer.ts
@@ -3,7 +3,7 @@ import { fastifyConnectPlugin } from "@connectrpc/connect-fastify";
 import { createRoutes } from "./createRoutes.js";
 import type { ILageService } from "./types/ILageService.js";
 
-export async function createServer(lageService: ILageService, abortController: AbortController) {
+export async function createServer(lageService: ILageService, abortController: AbortController): Promise<import("fastify").FastifyInstance<import("http2").Http2Server, import("http2").Http2ServerRequest, import("http2").Http2ServerResponse, import("fastify").FastifyBaseLogger, import("fastify").FastifyTypeProviderDefault>> {
   const server = fastify({
     http2: true,
   });

--- a/packages/rpc/src/createServer.ts
+++ b/packages/rpc/src/createServer.ts
@@ -3,10 +3,17 @@ import { fastifyConnectPlugin } from "@connectrpc/connect-fastify";
 import { createRoutes } from "./createRoutes.js";
 import type { ILageService } from "./types/ILageService.js";
 
-export async function createServer(lageService: ILageService, abortController: AbortController): Promise<import("fastify").FastifyInstance<import("http2").Http2Server, import("http2").Http2ServerRequest, import("http2").Http2ServerResponse, import("fastify").FastifyBaseLogger, import("fastify").FastifyTypeProviderDefault>> {
+import type { FastifyInstance, FastifyBaseLogger, FastifyTypeProviderDefault } from "fastify";
+import type { Http2Server, Http2ServerRequest, Http2ServerResponse } from "http2";
+
+export async function createServer(
+  lageService: ILageService,
+  abortController: AbortController
+): Promise<FastifyInstance<Http2Server, Http2ServerRequest, Http2ServerResponse, FastifyBaseLogger, FastifyTypeProviderDefault>> {
   const server = fastify({
     http2: true,
   });
+
   await server.register(fastifyConnectPlugin, {
     routes: createRoutes(lageService),
     shutdownSignal: abortController.signal,

--- a/packages/rpc/src/gen/lage/v1/lage_connect.ts
+++ b/packages/rpc/src/gen/lage/v1/lage_connect.ts
@@ -9,7 +9,31 @@ import { MethodKind } from "@bufbuild/protobuf";
 /**
  * @generated from service connectrpc.lage.v1.LageService
  */
-export const LageService = {
+export const LageService: {
+  readonly typeName: "connectrpc.lage.v1.LageService";
+  readonly methods: {
+    /**
+     * @generated from rpc connectrpc.lage.v1.LageService.RunTarget
+     */
+    readonly runTarget: {
+      readonly name: "RunTarget";
+      readonly I: typeof RunTargetRequest;
+      readonly O: typeof RunTargetResponse;
+      readonly kind: MethodKind.Unary;
+    };
+    /**
+     * a ping function to check if the server is up
+     *
+     * @generated from rpc connectrpc.lage.v1.LageService.Ping
+     */
+    readonly ping: {
+      readonly name: "Ping";
+      readonly I: typeof PingRequest;
+      readonly O: typeof PingResponse;
+      readonly kind: MethodKind.Unary;
+    };
+  };
+} = {
   typeName: "connectrpc.lage.v1.LageService",
   methods: {
     /**

--- a/packages/runners/package.json
+++ b/packages/runners/package.json
@@ -12,6 +12,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
     "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"

--- a/packages/runners/src/NoOpRunner.ts
+++ b/packages/runners/src/NoOpRunner.ts
@@ -1,11 +1,11 @@
 import type { TargetRunner } from "./types/TargetRunner.js";
 
 export class NoOpRunner implements TargetRunner {
-  async shouldRun() {
+  async shouldRun(): Promise<boolean> {
     return true;
   }
 
-  async run() {
+  async run(): Promise<void> {
     // pass
   }
 }

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -46,7 +46,7 @@ export class NpmScriptRunner implements TargetRunner {
     return !!packageJson.scripts?.[task];
   }
 
-  async shouldRun(target: Target) {
+  async shouldRun(target: Target): Promise<boolean> {
     // By convention, do not run anything if there is no script for this task defined in package.json (counts as "success")
     const hasNpmScript = await this.hasNpmScript(target);
 

--- a/packages/runners/src/WorkerRunner.ts
+++ b/packages/runners/src/WorkerRunner.ts
@@ -75,7 +75,7 @@ export class WorkerRunner implements TargetRunner {
     return await runFn({ target, weight, taskArgs, abortSignal });
   }
 
-  async getScriptModule(target: Target) {
+  async getScriptModule(target: Target): Promise<any> {
     const scriptFile = target.options?.worker ?? target.options?.script;
 
     if (!scriptFile) {

--- a/packages/scheduler-types/package.json
+++ b/packages/scheduler-types/package.json
@@ -12,7 +12,9 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
     "start": "monorepo-scripts tsc -w --preserveWatchOutput",
+    "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -12,6 +12,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
     "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -183,7 +183,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
    * Used by consumers of the scheduler to notify that the inputs to the target has changed
    * @param targetId
    */
-  markTargetAndDependentsPending(targetId): void {
+  markTargetAndDependentsPending(targetId: string): void {
     const queue = [targetId];
     while (queue.length > 0) {
       const current = queue.shift()!;

--- a/packages/scheduler/src/SimpleScheduler.ts
+++ b/packages/scheduler/src/SimpleScheduler.ts
@@ -1,7 +1,7 @@
 import { AggregatedPool } from "@lage-run/worker-threads-pool";
 import { formatBytes } from "./formatBytes.js";
 import { categorizeTargetRuns } from "./categorizeTargetRuns.js";
-import { getStartTargetId, sortTargetsByPriority } from "@lage-run/target-graph";
+import { type Target, getStartTargetId, sortTargetsByPriority } from "@lage-run/target-graph";
 import { WrappedTarget } from "./WrappedTarget.js";
 import { TargetRunnerPicker } from "@lage-run/runners";
 
@@ -77,7 +77,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
     this.runnerPicker = new TargetRunnerPicker(options.workerData.runners);
   }
 
-  getTargetsByPriority() {
+  getTargetsByPriority(): Target[] {
     return sortTargetsByPriority([...this.targetRuns.values()].map((run) => run.target));
   }
 
@@ -183,7 +183,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
    * Used by consumers of the scheduler to notify that the inputs to the target has changed
    * @param targetId
    */
-  markTargetAndDependentsPending(targetId) {
+  markTargetAndDependentsPending(targetId): void {
     const queue = [targetId];
     while (queue.length > 0) {
       const current = queue.shift()!;
@@ -203,7 +203,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
     }
   }
 
-  getReadyTargets() {
+  getReadyTargets(): WrappedTarget[] {
     const readyTargets: Set<WrappedTarget> = new Set();
 
     for (const target of this.getTargetsByPriority()) {
@@ -233,7 +233,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
     return [...readyTargets];
   }
 
-  isAllDone() {
+  isAllDone(): boolean {
     for (const t of this.targetRuns.values()) {
       if (t.status !== "skipped" && t.status !== "success" && t.target.id !== getStartTargetId()) {
         return false;
@@ -243,7 +243,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
     return true;
   }
 
-  async scheduleReadyTargets() {
+  async scheduleReadyTargets(): Promise<void> {
     if (this.isAllDone() || this.abortSignal.aborted) {
       return Promise.resolve();
     }
@@ -260,7 +260,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
     await Promise.all(promises);
   }
 
-  logProgress() {
+  logProgress(): void {
     const targetRunByStatus = categorizeTargetRuns(this.targetRuns.values());
     const total = [...this.targetRuns.values()].filter((t) => !t.target.hidden).length;
 
@@ -323,7 +323,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
     await this.scheduleReadyTargets();
   }
 
-  async cleanup() {
+  async cleanup(): Promise<void> {
     this.options.logger.silly(`Max Worker Memory Usage: ${formatBytes(this.pool.stats().maxWorkerMemoryUsage)}`);
     await this.pool.close();
   }
@@ -331,8 +331,7 @@ export class SimpleScheduler implements TargetScheduler<WorkerResult> {
   /**
    * Abort the scheduler using the abort controller.
    */
-  abort() {
+  abort(): void {
     this.abortController.abort();
   }
 }
-encodeURI;

--- a/packages/scheduler/src/WrappedTarget.ts
+++ b/packages/scheduler/src/WrappedTarget.ts
@@ -50,11 +50,11 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
   target: Target;
   threadId = 0;
 
-  get result() {
+  get result(): WorkerResult | undefined {
     return this.#result;
   }
 
-  get status() {
+  get status(): TargetStatus {
     return this.#status;
   }
 
@@ -66,11 +66,11 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     this.options.abortController = abortController;
   }
 
-  get successful() {
+  get successful(): boolean {
     return this.#status === "skipped" || this.#status === "success";
   }
 
-  get waiting() {
+  get waiting(): boolean {
     return this.#status === "pending" || this.#status === "queued";
   }
 
@@ -84,19 +84,19 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     this.options.logger.info("", { target: this.target, status: this.status });
   }
 
-  onQueued() {
+  onQueued(): void {
     this.#status = "queued";
     this.queueTime = process.hrtime();
     this.options.logger.info("", { target: this.target, status: "queued" });
   }
 
-  onAbort() {
+  onAbort(): void {
     this.#status = "aborted";
     this.duration = process.hrtime(this.startTime);
     this.options.logger.info("", { target: this.target, status: "aborted", threadId: this.threadId });
   }
 
-  onStart(threadId: number) {
+  onStart(threadId: number): void {
     if (this.status !== "running") {
       this.threadId = threadId;
       this.#status = "running";
@@ -105,7 +105,7 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     }
   }
 
-  onComplete() {
+  onComplete(): void {
     this.#status = "success";
     this.duration = process.hrtime(this.startTime);
     this.options.logger.info("", {
@@ -116,7 +116,7 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     });
   }
 
-  onFail() {
+  onFail(): void {
     this.#status = "failed";
     this.duration = process.hrtime(this.startTime);
     this.options.logger.info("", {
@@ -131,7 +131,7 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     }
   }
 
-  onSkipped(hash?: string | undefined) {
+  onSkipped(hash?: string | undefined): void {
     if (this.startTime[0] !== 0 && this.startTime[1] !== 0) {
       this.duration = process.hrtime(this.startTime);
     }
@@ -149,7 +149,7 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
     }
   }
 
-  async run() {
+  async run(): Promise<WorkerResult | undefined> {
     const { target, logger, shouldCache, abortController, root } = this.options;
 
     const abortSignal = abortController.signal;
@@ -288,7 +288,10 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
    *
    * @returns
    */
-  toJSON() {
+  toJSON(): {
+      target: string;
+      status: TargetStatus;
+  } {
     return {
       target: this.target.id,
       status: this.status,
@@ -298,7 +301,7 @@ export class WrappedTarget implements TargetRun<WorkerResult> {
   /**
    * Reset the state of this wrapped target.
    */
-  reset() {
+  reset(): void {
     this.#result = undefined;
     this.#status = "pending";
   }

--- a/packages/scheduler/src/bufferTransform.ts
+++ b/packages/scheduler/src/bufferTransform.ts
@@ -1,6 +1,9 @@
 import { Transform } from "stream";
 
-export function bufferTransform() {
+export function bufferTransform(): {
+  readonly buffer: string;
+  transform: Transform;
+} {
   const chunks: string[] = [];
 
   return {

--- a/packages/scheduler/src/cache/createCacheProvider.ts
+++ b/packages/scheduler/src/cache/createCacheProvider.ts
@@ -11,7 +11,9 @@ interface CreateCacheOptions {
   cliArgs: string[];
 }
 
-export async function createCache(options: CreateCacheOptions) {
+export async function createCache(options: CreateCacheOptions): Promise<{
+    cacheProvider: RemoteFallbackCacheProvider;
+}> {
   const { cacheOptions, logger, root, skipLocalCache } = options;
 
   const hasRemoteCacheConfig =

--- a/packages/scheduler/src/cache/isRunningFromCI.ts
+++ b/packages/scheduler/src/cache/isRunningFromCI.ts
@@ -1,1 +1,1 @@
-export const isRunningFromCI = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);
+export const isRunningFromCI: boolean = process.env.NODE_ENV !== "test" && (!!process.env.CI || !!process.env.TF_BUILD);

--- a/packages/scheduler/src/getLageOutputCacheLocation.ts
+++ b/packages/scheduler/src/getLageOutputCacheLocation.ts
@@ -1,7 +1,7 @@
 import { getLogsCacheDirectory } from "@lage-run/cache";
 import path from "path";
 
-export function getLageOutputCacheLocation(root: string, hash: string) {
+export function getLageOutputCacheLocation(root: string, hash: string): string {
   const outputPath = getLogsCacheDirectory(root, hash);
   return path.join(outputPath, hash + ".log");
 }

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -11,8 +11,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput",
+    "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
+    "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"
   },

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -12,7 +12,7 @@ export interface TargetFactoryOptions {
 }
 
 export class TargetFactory {
-  packageScripts = new Set<string>();
+  packageScripts: Set<string> = new Set<string>();
 
   constructor(private options: TargetFactoryOptions) {
     const { packageInfos } = options;
@@ -23,7 +23,7 @@ export class TargetFactory {
     }
   }
 
-  getTargetType(task: string, config: TargetConfig) {
+  getTargetType(task: string, config: TargetConfig): string {
     if (!config.type) {
       if (this.packageScripts.has(task)) {
         return "npmScript";

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -62,13 +62,13 @@ export class TargetGraphBuilder {
     } as Target);
   }
 
-  addTarget(target: Target) {
+  addTarget(target: Target): Target {
     this.targets.set(target.id, target);
     this.addDependency(getStartTargetId(), target.id);
     return target;
   }
 
-  addDependency(dependency: string, dependent: string) {
+  addDependency(dependency: string, dependent: string): void {
     if (this.targets.has(dependent)) {
       const target = this.targets.get(dependent)!;
 
@@ -89,7 +89,9 @@ export class TargetGraphBuilder {
   /**
    * Builds a target graph for given tasks and packages
    */
-  build() {
+  build(): {
+      targets: Map<string, Target>;
+  } {
     // Ensure we do not have cycles in the subgraph
     const cycleInfo = detectCycles(this.targets);
     if (cycleInfo.hasCycle) {
@@ -104,7 +106,9 @@ export class TargetGraphBuilder {
     };
   }
 
-  subgraph(entriesTargetIds: string[]) {
+  subgraph(entriesTargetIds: string[]): {
+      targets: Map<string, Target>;
+  } {
     const subgraphBuilder = new TargetGraphBuilder();
     const visited: Set<string> = new Set();
     const queue: string[] = [];

--- a/packages/target-graph/src/TargetGraphBuilder.ts
+++ b/packages/target-graph/src/TargetGraphBuilder.ts
@@ -3,6 +3,7 @@ import { prioritize } from "./prioritize.js";
 import { detectCycles } from "./detectCycles.js";
 
 import type { Target } from "./types/Target.js";
+import type { TargetGraph } from "./types/TargetGraph.js";
 
 /**
  * Target graph builder
@@ -89,9 +90,7 @@ export class TargetGraphBuilder {
   /**
    * Builds a target graph for given tasks and packages
    */
-  build(): {
-      targets: Map<string, Target>;
-  } {
+  build(): TargetGraph {
     // Ensure we do not have cycles in the subgraph
     const cycleInfo = detectCycles(this.targets);
     if (cycleInfo.hasCycle) {
@@ -106,9 +105,7 @@ export class TargetGraphBuilder {
     };
   }
 
-  subgraph(entriesTargetIds: string[]): {
-      targets: Map<string, Target>;
-  } {
+  subgraph(entriesTargetIds: string[]): TargetGraph {
     const subgraphBuilder = new TargetGraphBuilder();
     const visited: Set<string> = new Set();
     const queue: string[] = [];

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -67,7 +67,7 @@ export class WorkspaceTargetGraphBuilder {
    * @param id
    * @param targetDefinition
    */
-  async addTargetConfig(id: string, config: TargetConfig = {}, changedFiles?: string[]) {
+  async addTargetConfig(id: string, config: TargetConfig = {}, changedFiles?: string[]): Promise<void> {
     // Generates a target definition from the target config
     if (id.startsWith("//") || id.startsWith("#")) {
       const target = this.targetFactory.createGlobalTarget(id, config);
@@ -101,7 +101,7 @@ export class WorkspaceTargetGraphBuilder {
    * @param parentTarget
    * @param config
    */
-  async processStagedConfig(parentTarget: Target, config: TargetConfig, changedFiles?: string[]) {
+  async processStagedConfig(parentTarget: Target, config: TargetConfig, changedFiles?: string[]): Promise<void> {
     if (typeof config.stagedTarget === "undefined") {
       return;
     }
@@ -145,7 +145,7 @@ export class WorkspaceTargetGraphBuilder {
     }
   }
 
-  shouldRun(config: TargetConfig, target: Target) {
+  shouldRun(config: TargetConfig, target: Target): boolean | Promise<boolean> {
     if (typeof config.shouldRun === "function") {
       return config.shouldRun(target);
     }
@@ -166,7 +166,9 @@ export class WorkspaceTargetGraphBuilder {
    * @param scope
    * @param priorities the set of global priorities for the workspace.
    */
-  async build(tasks: string[], scope?: string[], priorities?: { package?: string; task: string; priority: number }[]) {
+  async build(tasks: string[], scope?: string[], priorities?: { package?: string; task: string; priority: number }[]): Promise<{
+      targets: Map<string, Target>;
+  }> {
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(this.graphBuilder.targets, this.dependencyMap);
 

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -8,6 +8,7 @@ import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMa
 import type { PackageInfos } from "workspace-tools";
 import type { Target } from "./types/Target.js";
 import type { TargetConfig } from "./types/TargetConfig.js";
+import type { TargetGraph } from "./types/TargetGraph.js";
 import { TargetGraphBuilder } from "./TargetGraphBuilder.js";
 import { TargetFactory } from "./TargetFactory.js";
 import pLimit from "p-limit";
@@ -166,9 +167,11 @@ export class WorkspaceTargetGraphBuilder {
    * @param scope
    * @param priorities the set of global priorities for the workspace.
    */
-  async build(tasks: string[], scope?: string[], priorities?: { package?: string; task: string; priority: number }[]): Promise<{
-      targets: Map<string, Target>;
-  }> {
+  async build(
+    tasks: string[],
+    scope?: string[],
+    priorities?: { package?: string; task: string; priority: number }[]
+  ): Promise<TargetGraph> {
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(this.graphBuilder.targets, this.dependencyMap);
 

--- a/packages/target-graph/src/detectCycles.ts
+++ b/packages/target-graph/src/detectCycles.ts
@@ -5,11 +5,8 @@ import type { Target } from "./types/Target.js";
  * Otherwise it returns the chain of nodes where the cycle was detected.
  */
 export function detectCycles(targets: Map<string, Target>): {
-    hasCycle: boolean;
-    cycle: string[];
-} | {
-    hasCycle: boolean;
-    cycle?: undefined;
+  hasCycle: boolean;
+  cycle?: string[];
 } {
   /**
    *  A map to keep track of the visited and visiting nodes.

--- a/packages/target-graph/src/detectCycles.ts
+++ b/packages/target-graph/src/detectCycles.ts
@@ -4,7 +4,13 @@ import type { Target } from "./types/Target.js";
  * Checks for any cycles in the dependency graph, returning `{ hasCycle: false }` if no cycles were detected.
  * Otherwise it returns the chain of nodes where the cycle was detected.
  */
-export function detectCycles(targets: Map<string, Target>) {
+export function detectCycles(targets: Map<string, Target>): {
+    hasCycle: boolean;
+    cycle: string[];
+} | {
+    hasCycle: boolean;
+    cycle?: undefined;
+} {
   /**
    *  A map to keep track of the visited and visiting nodes.
    * <node, true> entry means it is currently being visited.

--- a/packages/target-graph/src/expandDepSpecs.ts
+++ b/packages/target-graph/src/expandDepSpecs.ts
@@ -5,7 +5,7 @@ import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId.js"
 /**
  * Expands the dependency graph by adding all transitive dependencies of the given targets.
  */
-export function expandDepSpecs(targets: Map<string, Target>, dependencyMap: DependencyMap) {
+export function expandDepSpecs(targets: Map<string, Target>, dependencyMap: DependencyMap): [string, string][] {
   const dependencies: [string, string][] = [];
 
   /**

--- a/packages/target-graph/src/prioritize.ts
+++ b/packages/target-graph/src/prioritize.ts
@@ -52,7 +52,7 @@ function reverseTopoSort(targets: Map<string, Target>, nodesWithNoDependencies: 
 /**
  * Priorities for a target is actually the MAX of all the priorities of the targets that depend on it plus the current priority.
  */
-export function prioritize(targets: Map<string, Target>) {
+export function prioritize(targets: Map<string, Target>): void {
   const nodeCumulativePriorities = new Map<string, number>();
 
   const nodesWithNoDependencies = getNodesWithNoDependencies(targets);

--- a/packages/target-graph/src/sortTargetsByPriority.ts
+++ b/packages/target-graph/src/sortTargetsByPriority.ts
@@ -1,6 +1,6 @@
 import type { Target } from "./types/Target.js";
 
-export function sortTargetsByPriority(targets: Target[]) {
+export function sortTargetsByPriority(targets: Target[]): Target[] {
   return targets.sort((a, b) => {
     return (b.priority ?? 0) - (a.priority ?? 0);
   });

--- a/packages/target-graph/src/targetId.ts
+++ b/packages/target-graph/src/targetId.ts
@@ -19,11 +19,8 @@ export function getTargetId(pkgName: string | undefined, task: string) {
  * @returns
  */
 export function getPackageAndTask(targetId: string): {
-    packageName: undefined;
-    task: string;
-} | {
-    packageName: string;
-    task: string;
+  packageName?: string;
+  task: string;
 } {
   if (targetId.startsWith("Δ")) {
     return { packageName: undefined, task: targetId.slice(1) };

--- a/packages/target-graph/src/targetId.ts
+++ b/packages/target-graph/src/targetId.ts
@@ -18,7 +18,13 @@ export function getTargetId(pkgName: string | undefined, task: string) {
  * @param targetId
  * @returns
  */
-export function getPackageAndTask(targetId: string) {
+export function getPackageAndTask(targetId: string): {
+    packageName: undefined;
+    task: string;
+} | {
+    packageName: string;
+    task: string;
+} {
   if (targetId.startsWith("Δ")) {
     return { packageName: undefined, task: targetId.slice(1) };
   } else if (targetId.includes("#")) {
@@ -36,7 +42,7 @@ export function getPackageAndTask(targetId: string) {
 }
 
 const START_TARGET_ID = "__start";
-export function getStartTargetId() {
+export function getStartTargetId(): string {
   return START_TARGET_ID;
 }
 

--- a/packages/tsconfig.lage2.json
+++ b/packages/tsconfig.lage2.json
@@ -5,7 +5,6 @@
     "moduleResolution": "Node16",
     "declaration": true,
     "lib": ["ES2020"],
-    "allowJs": true,
     "strict": true,
     "noImplicitAny": false,
     "allowSyntheticDefaultImports": true,

--- a/packages/tsconfig.lage2.json
+++ b/packages/tsconfig.lage2.json
@@ -14,6 +14,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": false,
     "sourceMap": true,
-    "typeRoots": ["../node_modules/@types", "../types", "node_modules/@types"]
+    "typeRoots": ["../node_modules/@types", "../types", "node_modules/@types"],
+    "isolatedDeclarations": true,
+    "isolatedModules": true
   }
 }

--- a/packages/tsconfig.lage2.json
+++ b/packages/tsconfig.lage2.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
-    "moduleResolution": "Node16",
+    "moduleResolution": "node",
     "declaration": true,
     "lib": ["ES2020"],
     "strict": true,

--- a/packages/worker-threads-pool/package.json
+++ b/packages/worker-threads-pool/package.json
@@ -12,6 +12,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "monorepo-scripts tsc",
+    "types": "monorepo-scripts tsc",
     "start": "monorepo-scripts tsc -w --preserveWatchOutput",
     "test": "monorepo-scripts jest",
     "lint": "monorepo-scripts lint"

--- a/packages/worker-threads-pool/src/AggregatedPool.ts
+++ b/packages/worker-threads-pool/src/AggregatedPool.ts
@@ -72,7 +72,10 @@ export class AggregatedPool extends EventEmitter implements Pool {
     });
   }
 
-  stats() {
+  stats(): {
+    maxWorkerMemoryUsage: number;
+    workerRestarts: number;
+  } {
     const stats = [...this.groupedPools.values(), this.defaultPool].reduce(
       (acc, pool) => {
         if (pool) {
@@ -88,13 +91,13 @@ export class AggregatedPool extends EventEmitter implements Pool {
     return stats;
   }
 
-  async exec(
+  async exec<T>(
     data: Record<string, unknown>,
     weight: number,
     setup?: (worker: IWorker, stdout: Readable, stderr: Readable) => void,
     cleanup?: (args: any) => void,
     abortSignal?: AbortSignal
-  ): Promise<unknown> {
+  ): Promise<T | void> {
     const group = this.options.groupBy(data);
     const pool = this.groupedPools.get(group) ?? this.defaultPool;
 

--- a/packages/worker-threads-pool/src/TaskInfo.ts
+++ b/packages/worker-threads-pool/src/TaskInfo.ts
@@ -23,19 +23,19 @@ export class TaskInfo extends AsyncResource {
     }
   }
 
-  get id() {
+  get id(): string {
     return this.options.id;
   }
 
-  get weight() {
+  get weight(): number {
     return this.options.weight;
   }
 
-  get abortSignal() {
+  get abortSignal(): AbortSignal | undefined {
     return this.options.abortSignal;
   }
 
-  done(err: Error, results: unknown) {
+  done(err: Error, results: unknown): void {
     const { cleanup, worker, resolve, reject } = this.options;
 
     if (cleanup) {

--- a/packages/worker-threads-pool/src/ThreadWorker.ts
+++ b/packages/worker-threads-pool/src/ThreadWorker.ts
@@ -211,7 +211,7 @@ export class ThreadWorker extends EventEmitter implements IWorker {
     }
   }
 
-  start(work: QueueItem, abortSignal?: AbortSignal) {
+  start(work: QueueItem, abortSignal?: AbortSignal): void {
     this.status = "busy";
 
     const { task, resolve, reject, cleanup, setup } = work;
@@ -235,40 +235,40 @@ export class ThreadWorker extends EventEmitter implements IWorker {
     this.#worker.postMessage({ type: "start", task: { ...task, weight: work.weight }, id });
   }
 
-  get weight() {
+  get weight(): number {
     return this.#taskInfo?.weight ?? 1;
   }
 
-  get stdout() {
+  get stdout(): Readable {
     return this.#stdoutInfo.stream;
   }
 
-  get stderr() {
+  get stderr(): Readable {
     return this.#stderrInfo.stream;
   }
 
-  get resourceLimits() {
+  get resourceLimits(): import("worker_threads").ResourceLimits | undefined {
     return this.#worker.resourceLimits;
   }
 
-  get threadId() {
+  get threadId(): number {
     return this.#worker.threadId;
   }
 
-  terminate() {
+  terminate(): void {
     this.#worker.removeAllListeners();
     this.#worker.terminate();
     this.#worker.unref();
   }
 
-  restart() {
+  restart(): void {
     this.restarts++;
     this.status = "busy";
     this.#worker.terminate();
     this.#createNewWorker();
   }
 
-  async checkMemoryUsage() {
+  async checkMemoryUsage(): Promise<void> {
     this.#worker.postMessage({ type: "check-memory-usage" });
   }
 

--- a/packages/worker-threads-pool/src/registerWorker.ts
+++ b/packages/worker-threads-pool/src/registerWorker.ts
@@ -3,7 +3,7 @@ import { endMarker, startMarker } from "./stdioStreamMarkers.js";
 
 import type { MessagePort } from "worker_threads";
 
-export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<any> | any) {
+export function registerWorker(fn: (data: any, abortSignal?: AbortSignal) => Promise<any> | any): void {
   parentPort?.on("message", async (message) => {
     let abortController: AbortController | undefined;
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "bin": "bin/monorepo-scripts.js",
   "dependencies": {
-    "@swc/core": "^1.9.1",
+    "@swc/core": "^1.10.7",
     "@swc/jest": "^0.2.37",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",

--- a/scripts/worker/transpile.js
+++ b/scripts/worker/transpile.js
@@ -6,7 +6,6 @@ const swc = require("@swc/core");
 const { findProjectRoot } = require("workspace-tools");
 
 const root = findProjectRoot(process.cwd()) ?? process.cwd();
-const swcOptions = JSON.parse(fs.readFileSync(path.join(root, ".swcrc"), "utf8"));
 
 module.exports = async function transpile(data) {
   const { target } = data;
@@ -33,8 +32,9 @@ module.exports = async function transpile(data) {
           .replace(".tsx", ".js")
           .replace(".ts", ".js");
 
+
         const swcOutput = await swc.transformFile(fullPath, {
-          ...swcOptions,
+          configFile: path.join(root, ".swcrc"),
           sourceFileName: path.relative(path.dirname(dest), fullPath).replace(/\\/g, "/"),
         });
 
@@ -44,6 +44,15 @@ module.exports = async function transpile(data) {
 
         if (swcOutput.map) {
           await fsPromises.writeFile(destMap, swcOutput.map);
+        }
+
+        // @ts-expect-error 
+        if (swcOutput.output) {
+          // @ts-expect-error 
+          const output = JSON.parse(swcOutput.output);
+          const decls = dest.replace(/\.js$/, ".d.ts");
+          // @ts-ignore
+          await fsPromises.writeFile(decls, output.__swc_isolated_declarations__);
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,7 +1776,7 @@ __metadata:
     dts-bundle-generator: "npm:^9.5.1"
     esbuild: "npm:^0.21.5"
     globby: "npm:^14.0.2"
-    typescript: "npm:~5.0.3"
+    typescript: "npm:~5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -1814,7 +1814,7 @@ __metadata:
     prettier: "npm:^2.8.6"
     syncpack: "npm:^9.0.0"
     ts-node: "npm:^10.9.1"
-    typescript: "npm:~5.0.3"
+    typescript: "npm:~5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -8359,13 +8359,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.3":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:~5.7.3":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2f5bd1cead194905957cb34e220b1d6ff1662399adef8ec1864f74620922d860ee35b6e50eafb3b636ea6fd437195e454e1146cb630a4236b5095ed7617395c2
+  checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
   languageName: node
   linkType: hard
 
@@ -8389,13 +8389,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.0.3#optional!builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#optional!builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+"typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/c3f7b80577bddf6fab202a7925131ac733bfc414aec298c2404afcddc7a6f242cfa8395cf2d48192265052e11a7577c27f6e5fac8d8fe6a6602023c83d6b3292
+  checksum: 10c0/3b56d6afa03d9f6172d0b9cdb10e6b1efc9abc1608efd7a3d2f38773d5d8cfb9bbc68dfb72f0a7de5e8db04fc847f4e4baeddcd5ad9c9feda072234f0d788896
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,6 +1766,8 @@ __metadata:
 "@lage-run/format-hrtime@npm:^0.1.6, @lage-run/format-hrtime@workspace:packages/format-hrtime":
   version: 0.0.0-use.local
   resolution: "@lage-run/format-hrtime@workspace:packages/format-hrtime"
+  dependencies:
+    "@lage-run/monorepo-scripts": "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -1821,6 +1823,8 @@ __metadata:
 "@lage-run/logger@npm:^1.3.1, @lage-run/logger@workspace:packages/logger":
   version: 0.0.0-use.local
   resolution: "@lage-run/logger@workspace:packages/logger"
+  dependencies:
+    "@lage-run/monorepo-scripts": "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -1857,6 +1861,7 @@ __metadata:
   dependencies:
     "@lage-run/format-hrtime": "npm:^0.1.6"
     "@lage-run/logger": "npm:^1.3.1"
+    "@lage-run/monorepo-scripts": "npm:*"
     "@lage-run/scheduler-types": "npm:^0.3.23"
     "@lage-run/target-graph": "npm:^0.11.1"
     "@ms-cloudpack/task-reporter": "npm:0.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,7 +1837,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lage-run/monorepo-scripts@workspace:scripts"
   dependencies:
-    "@swc/core": "npm:^1.9.1"
+    "@swc/core": "npm:^1.10.7"
     "@swc/jest": "npm:^0.2.37"
     "@typescript-eslint/eslint-plugin": "npm:^5.30.7"
     "@typescript-eslint/parser": "npm:^5.30.7"
@@ -2039,92 +2039,92 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-darwin-arm64@npm:1.9.1"
+"@swc/core-darwin-arm64@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-darwin-arm64@npm:1.10.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-darwin-x64@npm:1.9.1"
+"@swc/core-darwin-x64@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-darwin-x64@npm:1.10.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.9.1"
+"@swc/core-linux-arm-gnueabihf@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.10.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.9.1"
+"@swc/core-linux-arm64-gnu@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.10.7"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-linux-arm64-musl@npm:1.9.1"
+"@swc/core-linux-arm64-musl@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-linux-arm64-musl@npm:1.10.7"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-linux-x64-gnu@npm:1.9.1"
+"@swc/core-linux-x64-gnu@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-linux-x64-gnu@npm:1.10.7"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-linux-x64-musl@npm:1.9.1"
+"@swc/core-linux-x64-musl@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-linux-x64-musl@npm:1.10.7"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.9.1"
+"@swc/core-win32-arm64-msvc@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.10.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.9.1"
+"@swc/core-win32-ia32-msvc@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.10.7"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core-win32-x64-msvc@npm:1.9.1"
+"@swc/core-win32-x64-msvc@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core-win32-x64-msvc@npm:1.10.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.9.1":
-  version: 1.9.1
-  resolution: "@swc/core@npm:1.9.1"
+"@swc/core@npm:^1.10.7":
+  version: 1.10.7
+  resolution: "@swc/core@npm:1.10.7"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.9.1"
-    "@swc/core-darwin-x64": "npm:1.9.1"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.9.1"
-    "@swc/core-linux-arm64-gnu": "npm:1.9.1"
-    "@swc/core-linux-arm64-musl": "npm:1.9.1"
-    "@swc/core-linux-x64-gnu": "npm:1.9.1"
-    "@swc/core-linux-x64-musl": "npm:1.9.1"
-    "@swc/core-win32-arm64-msvc": "npm:1.9.1"
-    "@swc/core-win32-ia32-msvc": "npm:1.9.1"
-    "@swc/core-win32-x64-msvc": "npm:1.9.1"
+    "@swc/core-darwin-arm64": "npm:1.10.7"
+    "@swc/core-darwin-x64": "npm:1.10.7"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.10.7"
+    "@swc/core-linux-arm64-gnu": "npm:1.10.7"
+    "@swc/core-linux-arm64-musl": "npm:1.10.7"
+    "@swc/core-linux-x64-gnu": "npm:1.10.7"
+    "@swc/core-linux-x64-musl": "npm:1.10.7"
+    "@swc/core-win32-arm64-msvc": "npm:1.10.7"
+    "@swc/core-win32-ia32-msvc": "npm:1.10.7"
+    "@swc/core-win32-x64-msvc": "npm:1.10.7"
     "@swc/counter": "npm:^0.1.3"
-    "@swc/types": "npm:^0.1.14"
+    "@swc/types": "npm:^0.1.17"
   peerDependencies:
     "@swc/helpers": "*"
   dependenciesMeta:
@@ -2151,7 +2151,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: 10c0/7b9a3da9bdd95216b031739ebe35983e69f17284809a62706c93edfd30ede0732060d944db23007aca9aebbc49859eb5784454c8882ae6fd04eb8bd15ac6a247
+  checksum: 10c0/73d3b164620590aff57512125e3cfd6dc1bb3346882fa9ad12abf8029f8be01eb71e6afc3c760c3e2cb479a2d7ff3180bf298f907768b93e3eac15fc72e0d855
   languageName: node
   linkType: hard
 
@@ -2175,12 +2175,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/types@npm:^0.1.14":
-  version: 0.1.14
-  resolution: "@swc/types@npm:0.1.14"
+"@swc/types@npm:^0.1.17":
+  version: 0.1.17
+  resolution: "@swc/types@npm:0.1.17"
   dependencies:
     "@swc/counter": "npm:^0.1.3"
-  checksum: 10c0/5ab5a213f25fbb038e8b2fa001a20c64363f81c199319373ed0228f316c046a996758fbaf906ba84d297b35e37727082d27974266db320e534da594716626529
+  checksum: 10c0/29f5c8933a16042956f1adb7383e836ed7646cbf679826e78b53fdd0c08e8572cb42152e527b6b530a9bd1052d33d0972f90f589761ccd252c12652c9b7a72fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a small repo, so it isn't strictly necessary. However, isolated declarations is giving us a 14.59s -> 5.43s improvement in typechecking. This change includes the following:

1. added an isolated-declarations flag to the main tsconfig.json: this means no allowJS
2. replacing the type check step from using a tsc worker to simply using tsc processes
3. adjusted the lage pipeline config to allow fastest parallelized builds possible.