### PR TITLE
Adds missing targets dependency files as inputs for lage-service

### DIFF
--- a/change/change-59938af0-4161-4e30-a935-aef8e2327605.json
+++ b/change/change-59938af0-4161-4e30-a935-aef8e2327605.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "adding missing inputs from dependencies",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -80,7 +80,7 @@ async function executeOnServer(args: string[], client: LageClient, logger: Logge
       task,
       taskArgs,
     });
-    logger.info(`Task ${response.packageName} ${response.task} exited with code ${response.exitCode} `);
+    logger.info(`Task ${response.packageName} ${response.task} exited with code ${response.exitCode}`);
     return response;
   } catch (error) {
     if (error instanceof ConnectError) {

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -215,7 +215,21 @@ export async function createLageService({
         ? glob(config.cacheOptions?.environmentGlob, { cwd: root, gitignore: true })
         : ["lage.config.js"];
 
-      const inputs = (getInputFiles(target, dependencyMap, packageTree) ?? []).concat(globalInputs);
+      const inputsSet = new Set<string>(getInputFiles(target, dependencyMap, packageTree) ?? []);
+
+      for (const globalInput of globalInputs) {
+        inputsSet.add(globalInput);
+      }
+
+      const targetDepsFiles = new Set<string>();
+      for (const dependency of target.dependencies) {
+        const depInputs = getInputFiles(targetGraph.targets.get(dependency)!, dependencyMap, packageTree);
+        if (depInputs) {
+          depInputs.forEach((file) => targetDepsFiles.add(file));
+        }
+      }
+
+      const inputs = Array.from(inputsSet);
 
       try {
         await pool.exec(

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -231,6 +231,17 @@ export async function createLageService({
 
       const inputs = Array.from(inputsSet);
 
+      let results: {
+        packageName?: string;
+        task: string;
+        exitCode: number;
+        inputs: string[];
+        outputs: string[];
+        stdout: string;
+        stderr: string;
+        id: string;
+      };
+
       try {
         await pool.exec(
           task,
@@ -272,11 +283,10 @@ export async function createLageService({
 
         const outputs = getOutputFiles(root, target, config.cacheOptions?.outputGlob, packageTree);
 
-        return {
+        results = {
           packageName: request.packageName,
           task: request.task,
           exitCode: 0,
-          hash: "",
           inputs,
           outputs,
           stdout: writableStdout.toString(),
@@ -286,11 +296,10 @@ export async function createLageService({
       } catch (e) {
         const outputs = getOutputFiles(root, target, config.cacheOptions?.outputGlob, packageTree);
 
-        return {
+        results = {
           packageName: request.packageName,
           task: request.task,
           exitCode: 1,
-          hash: "",
           inputs,
           outputs,
           stdout: "",
@@ -298,6 +307,10 @@ export async function createLageService({
           id,
         };
       }
+
+      logger.info(`${request.packageName}#${request.task} results`, results);
+
+      return results;
     },
   };
 }

--- a/packages/e2e-tests/src/lageserver.test.ts
+++ b/packages/e2e-tests/src/lageserver.test.ts
@@ -2,15 +2,8 @@ import { Monorepo } from "./mock/monorepo.js";
 import { parseNdJson } from "./parseNdJson.js";
 
 describe("lageserver", () => {
-  let repo: Monorepo | undefined;
-
-  afterEach(async () => {
-    await repo?.cleanup();
-    repo = undefined;
-  });
-
   it("connects to a running server", async () => {
-    repo = new Monorepo("basics");
+    const repo = new Monorepo("basics");
 
     repo.init();
     repo.addPackage("a", ["b"]);
@@ -28,10 +21,11 @@ describe("lageserver", () => {
     serverProcess.kill();
 
     expect(jsonOutput.find((entry) => entry.data?.target?.id === "a#build" && entry.msg === "Finished")).toBeTruthy();
+    await repo.cleanup();
   });
 
   it("launches a background server", async () => {
-    repo = new Monorepo("basics");
+    const repo = new Monorepo("basics");
 
     repo.init();
     repo.addPackage("a", ["b"]);
@@ -50,5 +44,75 @@ describe("lageserver", () => {
     } catch (e) {
       // ignore if cannot kill this
     }
+
+    await repo.cleanup();
+  });
+
+  it("reports inputs for targets and their dependencies' files", async () => {
+    const repo = new Monorepo("basics");
+
+    repo.init();
+
+    repo.addPackage("a", ["b"]);
+    repo.addPackage("b");
+
+    repo.install();
+
+    repo.commitFiles({
+      "packages/a/src/index.ts": "console.log('a');",
+      "packages/a/extra.ts": "console.log('a');",
+      "packages/b/alt/index.ts": "console.log('b');",
+      "packages/b/src/extra.ts": "console.log('b');",
+    });
+
+    repo.setLageConfig(
+      `module.exports = {
+        pipeline: {
+          "a#build": {
+            inputs: ["src/**"],
+            dependsOn: ["^build"],
+          },
+
+          "b#build": {
+            inputs: ["alt/**"],
+            dependsOn: ["^build"],
+          },
+        },
+      };`
+    );
+
+    const results = repo.run("lage", [
+      "exec",
+      "a",
+      "build",
+      "--tasks",
+      "build",
+      "--server",
+      "localhost:5111",
+      "--timeout",
+      "2",
+      "--reporter",
+      "json",
+    ]);
+
+    const output = results.stdout + results.stderr;
+    const jsonOutput = parseNdJson(output);
+    const started = jsonOutput.find((entry) => entry.data?.pid && entry.msg === "Server started");
+    expect(started?.data.pid).not.toBeUndefined();
+
+    try {
+      process.kill(parseInt(started?.data.pid));
+    } catch (e) {
+      // ignore if cannot kill this
+    }
+
+    const inputs = jsonOutput.filter((entry) => entry.data?.inputs);
+    expect(inputs).toHaveLength(2);
+    expect(inputs.find((entry) => entry.data?.inputs.includes("src/index.ts"))).toBeGreaterThan(0);
+    expect(inputs.find((entry) => entry.data?.inputs.includes("extra.ts"))).toBeLessThan(0);
+    expect(inputs.find((entry) => entry.data?.inputs.includes("alt/index.ts"))).toBeGreaterThan(0);
+    expect(inputs.find((entry) => entry.data?.inputs.includes("src/extra.ts"))).toBeLessThan(0);
+
+    await repo.cleanup();
   });
 });

--- a/packages/e2e-tests/src/mock/monorepo.ts
+++ b/packages/e2e-tests/src/mock/monorepo.ts
@@ -41,7 +41,7 @@ export class Monorepo {
     }
 
     fs.cpSync(path.resolve(__dirname, "..", "..", "yarn"), path.dirname(this.yarnPath), { recursive: true });
-    execa.sync(`"${process.execPath}"`, [`"${this.yarnPath}"`, "install"], { cwd: this.root, shell: true });
+    execa.sync(`"${process.execPath}"`, [`"${this.yarnPath}"`, "install", "--no-immutable"], { cwd: this.root, shell: true });
   }
 
   generateRepoFiles() {

--- a/packages/e2e-tests/src/mock/monorepo.ts
+++ b/packages/e2e-tests/src/mock/monorepo.ts
@@ -46,7 +46,10 @@ export class Monorepo {
 
   generateRepoFiles() {
     this.commitFiles({
-      ".yarnrc.yml": `yarnPath: "${this.yarnPath.replace(/\\/g, "/")}"\ncacheFolder: "${this.root.replace(/\\/g, "/")}/.yarn/cache"\nnodeLinker: node-modules`,
+      ".yarnrc.yml": `yarnPath: "${this.yarnPath.replace(/\\/g, "/")}"\ncacheFolder: "${this.root.replace(
+        /\\/g,
+        "/"
+      )}/.yarn/cache"\nnodeLinker: node-modules`,
       "package.json": {
         name: this.name.replace(/ /g, "-"),
         version: "0.1.0",
@@ -154,12 +157,18 @@ export class Monorepo {
     });
   }
 
-  runServer() {
-    return execa.default(process.execPath, [path.join(this.root, "node_modules/lage/dist/lage-server.js")], {
+  runServer(tasks: string[]) {
+    const cp = execa.default(process.execPath, [path.join(this.root, "node_modules/lage/dist/lage-server.js"), "--tasks", ...tasks], {
       cwd: this.root,
       detached: true,
       stdio: "ignore",
     });
+
+    if (cp && !cp.pid) {
+      throw new Error("Failed to start server");
+    }
+
+    return cp;
   }
 
   async cleanup() {

--- a/packages/e2e-tests/src/mock/monorepo.ts
+++ b/packages/e2e-tests/src/mock/monorepo.ts
@@ -46,7 +46,7 @@ export class Monorepo {
 
   generateRepoFiles() {
     this.commitFiles({
-      ".yarnrc.yml": `yarnPath: "${this.yarnPath}"\ncacheFolder: "${this.root}/.yarn/cache"\nnodeLinker: node-modules`,
+      ".yarnrc.yml": `yarnPath: "${this.yarnPath.replace(/\\/g, "/")}"\ncacheFolder: "${this.root.replace(/\\/g, "/")}/.yarn/cache"\nnodeLinker: node-modules`,
       "package.json": {
         name: this.name.replace(/ /g, "-"),
         version: "0.1.0",

--- a/packages/e2e-tests/src/mock/monorepo.ts
+++ b/packages/e2e-tests/src/mock/monorepo.ts
@@ -46,7 +46,7 @@ export class Monorepo {
 
   generateRepoFiles() {
     this.commitFiles({
-      ".yarnrc": `yarn-path "${this.yarnPath}"`,
+      ".yarnrc.yml": `yarnPath: "${this.yarnPath}"\ncacheFolder: "${this.root}/.yarn/cache"\nnodeLinker: node-modules`,
       "package.json": {
         name: this.name.replace(/ /g, "-"),
         version: "0.1.0",


### PR DESCRIPTION
When using the `info --server` mode, we need to report all the inputs for a target. Lage internally uses target dependencies hashes to inform when to rebuild if its dependencies have changed. This wasn't not in place for the lageService.ts. We are adding this into the server so that the proper tracking of inputs can be sent back to external runners like BuildXL.