### PR TITLE
Allow jsonreporter to pretty print json

### DIFF
--- a/change/change-2d908239-0af7-4222-b852-fd1d8f2c39c0.json
+++ b/change/change-2d908239-0af7-4222-b852-fd1d8f2c39c0.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add support to json formatter to pretty print and indent the json when the log level is set to verbose or silly...",
+      "packageName": "@lage-run/reporters",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/tests/jsonReporter.test.ts
+++ b/packages/cli/tests/jsonReporter.test.ts
@@ -1,0 +1,70 @@
+import { Logger } from "@lage-run/logger";
+import { initializeReporters } from "../src/commands/initializeReporters.js";
+
+const testObject = {
+  x: "field x",
+  number: 1,
+  array: [1, 2, 3],
+  object: { a: 1, b: 2 },
+};
+
+describe("json reporter", () => {
+  it("infoShouldLogCondensed", () => {
+    jest.spyOn(Date, "now").mockImplementation(() => 0);
+    const logSpy = jest.spyOn(console, "log");
+
+    const logger = new Logger();
+    initializeReporters(logger, {
+      concurrency: 1,
+      grouped: false,
+      logLevel: "info",
+      progress: true,
+      reporter: ["json"],
+      verbose: false,
+    });
+
+    logger.info("test Json", testObject);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '{"timestamp":0,"level":30,"msg":"test Json","data":{"x":"field x","number":1,"array":[1,2,3],"object":{"a":1,"b":2}}}'
+    );
+  });
+
+  it("verboseShouldLogCondensed", () => {
+    jest.setSystemTime(new Date("2020-01-01"));
+    const logSpy = jest.spyOn(console, "log");
+
+    const logger = new Logger();
+    initializeReporters(logger, {
+      concurrency: 1,
+      grouped: false,
+      logLevel: "verbose",
+      progress: true,
+      reporter: ["json"],
+      verbose: false,
+    });
+
+    logger.info("test Json", testObject);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      `{
+  \"timestamp\": 0,
+  \"level\": 30,
+  \"msg\": \"test Json\",
+  \"data\": {
+    \"x\": \"field x\",
+    \"number\": 1,
+    \"array\": [
+      1,
+      2,
+      3
+    ],
+    \"object\": {
+      \"a\": 1,
+      \"b\": 2
+    }
+  }
+}`
+    );
+  });
+});

--- a/packages/reporters/src/JsonReporter.ts
+++ b/packages/reporters/src/JsonReporter.ts
@@ -2,7 +2,8 @@
 
 import { hrToSeconds } from "@lage-run/format-hrtime";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
-import type { LogEntry, LogLevel, Reporter } from "@lage-run/logger";
+import { type LogEntry, LogLevel, type Reporter } from "@lage-run/logger";
+
 import type { TargetMessageEntry, TargetStatusEntry } from "./types/TargetLogEntry.js";
 
 export class JsonReporter implements Reporter {
@@ -14,7 +15,8 @@ export class JsonReporter implements Reporter {
     }
 
     if (this.options.logLevel >= entry.level) {
-      console.log(JSON.stringify(entry));
+      const shouldIndent = this.options.logLevel >= LogLevel.verbose;
+      console.log(JSON.stringify(entry, null, shouldIndent ? 2 : 0));
     }
   }
 


### PR DESCRIPTION
This change will have the json reporter pretty-print the json when the verbosity of the logger is set to verbose or silly.