### PR TITLE
Fix outputs to include the correct path for the hash_xyz hash hint file

### DIFF
--- a/change/change-18d016a1-a33f-41d3-847e-51920ed380ec.json
+++ b/change/change-18d016a1-a33f-41d3-847e-51920ed380ec.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "fixing outputs to have correct outputs",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -311,7 +311,8 @@ export async function createLageService({
         );
 
         const outputs = getOutputFiles(root, target, config.cacheOptions?.outputGlob, packageTree);
-        outputs.push(targetHashFile);
+        const targetHashFileRelativePath = path.relative(root, targetHashFullPath).replace(/\\/g, "/");
+        outputs.push(targetHashFileRelativePath);
 
         results = {
           packageName: request.packageName,
@@ -326,7 +327,8 @@ export async function createLageService({
         };
       } catch (e) {
         const outputs = getOutputFiles(root, target, config.cacheOptions?.outputGlob, packageTree);
-        outputs.push(targetHashFile);
+        const targetHashFileRelativePath = path.relative(root, targetHashFullPath).replace(/\\/g, "/");
+        outputs.push(targetHashFileRelativePath);
 
         targetRun.status = "failed";
         targetRun.duration = hrtimeDiff(targetRun.startTime, process.hrtime());

--- a/packages/e2e-tests/src/lageserver.test.ts
+++ b/packages/e2e-tests/src/lageserver.test.ts
@@ -150,9 +150,13 @@ describe("lageserver", () => {
       expect(aResults.inputs.find((input) => input === "packages/c/node_modules/.lage/hash_build")).toBeUndefined();
       expect(aResults.inputs.find((input) => input === "packages/a/alt/extra.ts")).toBeUndefined();
 
+      expect(aResults.outputs.find((output) => output === "packages/a/node_modules/.lage/hash_build")).toBeTruthy();
+
       expect(bResults.inputs.find((input) => input === "packages/b/src/extra.ts")).toBeUndefined();
       expect(bResults.inputs.find((input) => input === "packages/b/alt/index.ts")).toBeTruthy();
       expect(bResults.inputs.find((input) => input === "packages/c/node_modules/.lage/hash_build")).toBeTruthy();
+
+      expect(aResults.outputs.find((output) => output === "packages/b/node_modules/.lage/hash_build")).toBeTruthy();
 
       await repo.cleanup();
     }, 40000);

--- a/packages/e2e-tests/src/lageserver.test.ts
+++ b/packages/e2e-tests/src/lageserver.test.ts
@@ -156,7 +156,7 @@ describe("lageserver", () => {
       expect(bResults.inputs.find((input) => input === "packages/b/alt/index.ts")).toBeTruthy();
       expect(bResults.inputs.find((input) => input === "packages/c/node_modules/.lage/hash_build")).toBeTruthy();
 
-      expect(aResults.outputs.find((output) => output === "packages/b/node_modules/.lage/hash_build")).toBeTruthy();
+      expect(bResults.outputs.find((output) => output === "packages/b/node_modules/.lage/hash_build")).toBeTruthy();
 
       await repo.cleanup();
     }, 40000);


### PR DESCRIPTION
This pull request includes several changes to improve the handling of output files in the `@lage-run/cli` package. The most important changes involve fixing the outputs to ensure they have the correct paths and updating the end-to-end tests to validate these changes.

Fixes and improvements:

* [`change/change-18d016a1-a33f-41d3-847e-51920ed380ec.json`](diffhunk://#diff-72202b986030edd1ba6510ab570f2f53b59950b1e5327b6148af6466549b8c7dR1-R11): Added a patch change to fix the outputs to have correct paths for the `@lage-run/cli` package.

Code updates:

* [`packages/cli/src/commands/server/lageService.ts`](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L314-R315): Modified the `createLageService` function to use relative paths for the target hash file, ensuring consistent path formatting. [[1]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L314-R315) [[2]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L329-R331)

Testing:

* [`packages/e2e-tests/src/lageserver.test.ts`](diffhunk://#diff-77656ff115c88a262d667274161bb25821f3b7e1597c6d5e9de95d159754ae13R153-R160): Updated end-to-end tests to check for the correct output paths in the `lageserver` test suite.