### PR TITLE
Add support to json formatter to pretty print and indent the json 

### DIFF
--- a/change/change-2d908239-0af7-4222-b852-fd1d8f2c39c0.json
+++ b/change/change-2d908239-0af7-4222-b852-fd1d8f2c39c0.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add support to json formatter to pretty print and indent the json when the log level is set to verbose or silly...",
+      "packageName": "@lage-run/reporters",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-8f27489a-90c7-4692-a3b6-ffdb7f747989.json
+++ b/change/change-8f27489a-90c7-4692-a3b6-ffdb7f747989.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add support to json formatter to pretty print and indent the json when the log level is set to verbose or silly...",
+      "packageName": "@lage-run/cli",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -13,7 +13,7 @@ import { readFileSync } from "fs";
 import path from "path";
 
 export function createReporter(reporter: string, options: ReporterInitOptions) {
-  const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress, logFile } = options;
+  const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress, logFile, indented } = options;
   const logLevel = LogLevel[logLevelName];
 
   const root = findPackageRoot(__filename)!;
@@ -27,7 +27,7 @@ export function createReporter(reporter: string, options: ReporterInitOptions) {
         outputFile: typeof profile === "string" ? profile : undefined,
       });
     case "json":
-      return new JsonReporter({ logLevel });
+      return new JsonReporter({ logLevel, indented: indented ?? false });
     case "azureDevops":
     case "adoLog":
       return new AdoReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel });

--- a/packages/cli/src/commands/options.ts
+++ b/packages/cli/src/commands/options.ts
@@ -10,6 +10,7 @@ const options = {
     logLevel: new Option("--log-level <level>", "log level").choices(["info", "warn", "error", "verbose", "silly"]).conflicts("verbose"),
     logFile: new Option("--log-file <file>", "when used with --reporter vfl, writes verbose, ungrouped logs to the specified file"),
     verbose: new Option("--verbose", "verbose output").default(false),
+    indented: new Option("--indented", "enabled indentation of the JSON output").default(false),
   },
   pool: {
     concurrency: new Option("-c|--concurrency <number>", "max jobs to run at a time").argParser((v) => parseInt(v)),

--- a/packages/cli/src/types/ReporterInitOptions.ts
+++ b/packages/cli/src/types/ReporterInitOptions.ts
@@ -9,4 +9,5 @@ export interface ReporterInitOptions {
   logLevel: keyof typeof LogLevel;
   profile?: boolean | string;
   logFile?: string;
+  indented?: boolean;
 }

--- a/packages/cli/tests/jsonReporter.test.ts
+++ b/packages/cli/tests/jsonReporter.test.ts
@@ -1,0 +1,74 @@
+import { Logger } from "@lage-run/logger";
+import { initializeReporters } from "../src/commands/initializeReporters.js";
+
+const testObject = {
+  x: "field x",
+  number: 1,
+  array: [1, 2, 3],
+  object: { a: 1, b: 2 },
+};
+
+describe("json reporter", () => {
+  it("indentedFalseShouldLogCondensed", () => {
+    jest.spyOn(Date, "now").mockImplementation(() => 0);
+    const logSpy = jest.spyOn(console, "log");
+
+    const logger = new Logger();
+    initializeReporters(logger, {
+      concurrency: 1,
+      grouped: false,
+      logLevel: "info",
+      progress: true,
+      reporter: ["json"],
+      verbose: false,
+      indented: false,
+    });
+
+    logger.info("test Json", testObject);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '{"timestamp":0,"level":30,"msg":"test Json","data":{"x":"field x","number":1,"array":[1,2,3],"object":{"a":1,"b":2}}}'
+    );
+    jest.clearAllMocks();
+  });
+
+  it("indentedTrueShouldLogCondensed", () => {
+    jest.setSystemTime(new Date("2020-01-01"));
+    const logSpy = jest.spyOn(console, "log");
+
+    const logger = new Logger();
+    initializeReporters(logger, {
+      concurrency: 1,
+      grouped: false,
+      logLevel: "verbose",
+      progress: true,
+      reporter: ["json"],
+      verbose: false,
+      indented: true,
+    });
+
+    logger.info("test Json", testObject);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      `{
+  \"timestamp\": 0,
+  \"level\": 30,
+  \"msg\": \"test Json\",
+  \"data\": {
+    \"x\": \"field x\",
+    \"number\": 1,
+    \"array\": [
+      1,
+      2,
+      3
+    ],
+    \"object\": {
+      \"a\": 1,
+      \"b\": 2
+    }
+  }
+}`
+    );
+    jest.clearAllMocks();
+  });
+});

--- a/packages/reporters/src/JsonReporter.ts
+++ b/packages/reporters/src/JsonReporter.ts
@@ -2,11 +2,13 @@
 
 import { hrToSeconds } from "@lage-run/format-hrtime";
 import type { SchedulerRunSummary } from "@lage-run/scheduler-types";
-import type { LogEntry, LogLevel, Reporter } from "@lage-run/logger";
+import type { LogLevel } from "@lage-run/logger";
+import { type LogEntry, type Reporter } from "@lage-run/logger";
+
 import type { TargetMessageEntry, TargetStatusEntry } from "./types/TargetLogEntry.js";
 
 export class JsonReporter implements Reporter {
-  constructor(private options: { logLevel: LogLevel }) {}
+  constructor(private options: { logLevel: LogLevel; indented: boolean }) {}
 
   log(entry: LogEntry<TargetStatusEntry | TargetMessageEntry>) {
     if (entry.data && entry.data.target && entry.data.target.hidden) {
@@ -14,7 +16,7 @@ export class JsonReporter implements Reporter {
     }
 
     if (this.options.logLevel >= entry.level) {
-      console.log(JSON.stringify(entry));
+      console.log(this.options.indented ? JSON.stringify(entry, null, 2) : JSON.stringify(entry));
     }
   }
 

--- a/packages/reporters/tests/JsonReporter.test.ts
+++ b/packages/reporters/tests/JsonReporter.test.ts
@@ -22,7 +22,7 @@ describe("JsonReporter", () => {
       rawLogs.push(JSON.parse(message));
     });
 
-    const reporter = new JsonReporter({ logLevel: LogLevel.verbose });
+    const reporter = new JsonReporter({ logLevel: LogLevel.verbose, indented: false });
 
     const aBuildTarget = createTarget("a", "build");
     const aTestTarget = createTarget("a", "test");
@@ -352,7 +352,7 @@ describe("JsonReporter", () => {
       rawLogs.push(JSON.parse(message));
     });
 
-    const reporter = new JsonReporter({ logLevel: LogLevel.verbose });
+    const reporter = new JsonReporter({ logLevel: LogLevel.verbose, indented: false });
 
     const aBuildTarget = createTarget("a", "build");
     const aTestTarget = createTarget("a", "test");


### PR DESCRIPTION
When you use `yarn info` the normal json output is condensed. This changes allows you to pass `--indented` to lage which will enable indentation on the json reporter.