### PR TITLE
Fix killDetachedProcess

### DIFF
--- a/packages/e2e-tests/src/killDetachedProcess.ts
+++ b/packages/e2e-tests/src/killDetachedProcess.ts
@@ -7,18 +7,7 @@ export function killDetachedProcess(pid: number | string) {
       process.kill(pidNumber, "SIGTERM");
     } else {
       // on Windows get the process tree and kill the parent
-      const tree = execSync(`wmic process where (ParentProcessId=${pidNumber}) get ProcessId`).toString();
-
-      const pids = tree
-        .split("\n")
-        .map((line: string) => line.trim())
-        .filter((line: string) => line !== "" && line !== "ProcessId");
-
-      pids.forEach((p: string) => {
-        process.kill(parseInt(p));
-      });
-
-      process.kill(pidNumber);
+      execSync(`taskkill /f /PID ${pidNumber} /T`);
     }
   } catch (e) {
     // ignore


### PR DESCRIPTION
wmic is not installed by default... So this breaks on most dev boxes... `taskkill` is part of all windows builds for a long time.
It supports force terminating with `/F` and by pid using `/PID` as well as  entire tree via `/T`
