### PR TITLE
Add backwards compat `lage info` emitter option

### DIFF
--- a/change/change-2cc36444-b552-4fff-b7f1-99309d2e4a89.json
+++ b/change/change-2cc36444-b552-4fff-b7f1-99309d2e4a89.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add backwards compate lage info emit hack",
+      "packageName": "@lage-run/cli",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -134,7 +134,14 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
 
   const runnerPicker = new TargetRunnerPicker(pickerOptions);
 
-  const optimizedTargets = await optimizeTargetGraph(targetGraph, runnerPicker);
+  // This is a temporary flag to allow backwards compatibility with the old lage graph format used by BuildXL (formerly known as Domino).
+  // I initially worked on a commandline flag, but threading that through requires 3 different releases (lage, buildxl, ohome).
+  // This is a temp solution to be able to upgrade to Lage V2 without breaking the BuildXL integration. And allow us
+  // to update to lage v2.
+  // Unfortunately this is the only variable that we can use to not break any other customers
+  const createBackwardsCompatGraph = process.env["DOMINO"] === "1";
+
+  const optimizedTargets = await optimizeTargetGraph(targetGraph, runnerPicker, createBackwardsCompatGraph);
   const binPaths = getBinPaths();
   const packageTasks = optimizedTargets.map((target) =>
     generatePackageTask(target, taskArgs, config, options, binPaths, packageInfos, tasks)

--- a/packages/cli/src/commands/run/runAction.ts
+++ b/packages/cli/src/commands/run/runAction.ts
@@ -103,7 +103,7 @@ export async function runAction(options: RunOptions, command: Command) {
     workerIdleMemoryLimit: config.workerIdleMemoryLimit, // in bytes
   });
 
-  const optimizedTargets = await optimizeTargetGraph(targetGraph, scheduler.runnerPicker);
+  const optimizedTargets = await optimizeTargetGraph(targetGraph, scheduler.runnerPicker, false);
   const optimizedGraph: TargetGraph = {
     targets: new Map(optimizedTargets.map((target) => [target.id, target])),
   };

--- a/packages/e2e-tests/src/__snapshots__/info.test.ts.snap
+++ b/packages/e2e-tests/src/__snapshots__/info.test.ts.snap
@@ -300,6 +300,135 @@ exports[`info command custom options 1`] = `
 ]
 `;
 
+exports[`info command lage info drops direct dependencies when transtive and keeps __start 1`] = `
+[
+  {
+    "data": {
+      "command": [
+        "build",
+      ],
+      "packageTasks": [
+        {
+          "command": [],
+          "dependencies": [],
+          "id": "__start",
+          "package": "",
+          "task": "__start",
+          "workingDirectory": "",
+        },
+        {
+          "command": [
+            "node",
+            "./build.js",
+          ],
+          "dependencies": [
+            "b#build",
+          ],
+          "id": "a#build",
+          "package": "a",
+          "task": "build",
+          "workingDirectory": "packages/a",
+        },
+        {
+          "command": [
+            "node",
+            "./build.js",
+          ],
+          "dependencies": [
+            "c#build",
+          ],
+          "id": "b#build",
+          "package": "b",
+          "task": "build",
+          "workingDirectory": "packages/b",
+        },
+        {
+          "command": [
+            "node",
+            "./build.js",
+          ],
+          "dependencies": [
+            "__start",
+          ],
+          "id": "c#build",
+          "package": "c",
+          "task": "build",
+          "workingDirectory": "packages/c",
+        },
+      ],
+      "scope": [
+        "a",
+        "b",
+        "c",
+        "d",
+      ],
+    },
+    "level": 30,
+    "msg": "info",
+  },
+]
+`;
+
+exports[`info command lage info in back compat mode keeps direct dependencies and drops __start 1`] = `
+[
+  {
+    "data": {
+      "command": [
+        "build",
+      ],
+      "packageTasks": [
+        {
+          "command": [
+            "node",
+            "./build.js",
+          ],
+          "dependencies": [
+            "b#build",
+            "c#build",
+          ],
+          "id": "a#build",
+          "package": "a",
+          "task": "build",
+          "workingDirectory": "packages/a",
+        },
+        {
+          "command": [
+            "node",
+            "./build.js",
+          ],
+          "dependencies": [
+            "c#build",
+          ],
+          "id": "b#build",
+          "package": "b",
+          "task": "build",
+          "workingDirectory": "packages/b",
+        },
+        {
+          "command": [
+            "node",
+            "./build.js",
+          ],
+          "dependencies": [],
+          "id": "c#build",
+          "package": "c",
+          "task": "build",
+          "workingDirectory": "packages/c",
+        },
+      ],
+      "scope": [
+        "a",
+        "b",
+        "c",
+        "d",
+      ],
+    },
+    "level": 30,
+    "msg": "info",
+  },
+]
+`;
+
 exports[`info command scoped info test case 1`] = `
 [
   {

--- a/packages/e2e-tests/src/info.test.ts
+++ b/packages/e2e-tests/src/info.test.ts
@@ -67,6 +67,57 @@ describe("info command", () => {
     await repo.cleanup();
   });
 
+  it("lage info drops direct dependencies when transtive and keeps __start", async () => {
+    const repo = new Monorepo("transitive-info-dropped");
+    repo.init();
+    repo.addPackage("a", ["b", "c"]);
+    repo.addPackage("b", ["c", "d"]);
+    repo.addPackage("c", []);
+    repo.addPackage("d", [], { nobuild: "echo 'no build'" });
+    repo.install();
+
+    const results = repo.run("writeInfo", ["build"]);
+
+    const output = results.stdout + results.stderr;
+    const jsonOutput = parseNdJson(output);
+
+    const taskA = jsonOutput[0].data.packageTasks.find(({ id }) => id === "a#build");
+    expect(taskA.dependencies).toEqual(["b#build"]);
+
+    const taskC = jsonOutput[0].data.packageTasks.find(({ id }) => id === "c#build");
+    expect(taskC.dependencies).toEqual(["__start"]);
+
+    expect(jsonOutput).toMatchSnapshot();
+
+    await repo.cleanup();
+  });
+
+  it("lage info in back compat mode keeps direct dependencies and drops __start", async () => {
+    const repo = new Monorepo("transitive-info-dropped");
+    repo.init();
+    repo.addPackage("a", ["b", "c"]);
+    repo.addPackage("b", ["c", "d"]);
+    repo.addPackage("c", []);
+    repo.addPackage("d", [], { nobuild: "echo 'no build'" });
+    repo.install();
+
+    const backCompatEnvVars = { DOMINO: "1" };
+    const results = repo.run("writeInfo", ["build"], false, { env: backCompatEnvVars });
+
+    const output = results.stdout + results.stderr;
+    const jsonOutput = parseNdJson(output);
+
+    const task = jsonOutput[0].data.packageTasks.find(({ id }) => id === "a#build");
+    expect(task.dependencies).toEqual(["b#build", "c#build"]);
+
+    const taskC = jsonOutput[0].data.packageTasks.find(({ id }) => id === "c#build");
+    expect(taskC.dependencies).toEqual([]);
+
+    expect(jsonOutput).toMatchSnapshot();
+
+    await repo.cleanup();
+  });
+
   it("custom inputs, outputs and weight value", async () => {
     const repo = new Monorepo("scoped-info");
 

--- a/packages/e2e-tests/src/mock/monorepo.ts
+++ b/packages/e2e-tests/src/mock/monorepo.ts
@@ -151,9 +151,10 @@ export class Monorepo {
     execa.sync("git", ["commit", "-m", "commit files"], { cwd: this.root });
   }
 
-  run(command: string, args?: string[], silent?: boolean) {
+  run(command: string, args?: string[], silent?: boolean, options?: Partial<execa.SyncOptions>) {
     return execa.sync(process.execPath, [this.yarnPath, ...(silent === true ? ["--silent"] : []), command, ...(args || [])], {
       cwd: this.root,
+      ...options,
     });
   }
 


### PR DESCRIPTION
We have to use a bit of a hack to trigger the back compat way to emit lage info. V2 changed the format by emitting the `__start` event as well as stripping direct dependencies to have a smaller graph to make the scheduler in lage faster and reduce memory. When translating this to BuildXL it is missing critical file allowences since buildXL validates that processes read files that are declared as sources as well as dependencies.

Ideally this will be done via a command-line flag but to do so I'd have to make commits in 4 repo's with each their own release to update the core version of lage in office monorepo. This will allow me to update to v2 directly while updating the infrastructure to pass the flag.

#859 tracks removal fo that flag.