### PR TITLE
Adding global input hashes in lage server worker

### DIFF
--- a/change/change-1ac49201-a1a8-4f31-a6a4-b5d05e1d76a0.json
+++ b/change/change-1ac49201-a1a8-4f31-a6a4-b5d05e1d76a0.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "cheat on optimization by leverage the fact that 'info' command is called before anything else ALWAYS in BXL",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "cheat on optimization by leverage the fact that 'info' command is called before anything else ALWAYS in BXL",
+      "packageName": "@lage-run/hasher",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "cheat on optimization by leverage the fact that 'info' command is called before anything else ALWAYS in BXL",
+      "packageName": "@lage-run/rpc",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-be167829-f523-4d7e-8fe1-e50eac6ba277.json
+++ b/change/change-be167829-f523-4d7e-8fe1-e50eac6ba277.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "cheat on optimization by leverage the fact that 'info' command is called before anything else ALWAYS in BXL",
+      "packageName": "lage",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { Logger } from "@lage-run/logger";
 import createLogger from "@lage-run/logger";
 import { initializeReporters } from "../initializeReporters.js";
@@ -140,7 +141,7 @@ export async function executeRemotely(options: ExecRemotelyOptions, command: Com
     process.exitCode = response.exitCode;
 
     // we will simulate file access even if exit code may be non-zero
-    await simulateFileAccess(logger, [...response.inputs, ...response.globalInputs], response.outputs);
+    await simulateFileAccess(logger, [...response.inputs, path.join(response.cwd, response.globalInputHashFile)], response.outputs);
   } else {
     process.exitCode = 1;
   }

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -141,7 +141,8 @@ export async function executeRemotely(options: ExecRemotelyOptions, command: Com
     process.exitCode = response.exitCode;
 
     // we will simulate file access even if exit code may be non-zero
-    await simulateFileAccess(logger, [...response.inputs, path.join(response.cwd, response.globalInputHashFile)], response.outputs);
+    const relativeGlobalInputsForTarget = path.relative(root, path.join(response.cwd, response.globalInputHashFile));
+    await simulateFileAccess(logger, [...response.inputs, relativeGlobalInputsForTarget], response.outputs);
   } else {
     process.exitCode = 1;
   }

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -11,7 +11,7 @@ import fs from "fs";
 import { parse } from "shell-quote";
 
 import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
-import { Target, getStartTargetId, getTargetId } from "@lage-run/target-graph";
+import { type Target, getStartTargetId } from "@lage-run/target-graph";
 import { initializeReporters } from "../initializeReporters.js";
 import { TargetRunnerPicker } from "@lage-run/runners";
 import { getBinPaths } from "../../getBinPaths.js";

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -11,7 +11,7 @@ import fs from "fs";
 import { parse } from "shell-quote";
 
 import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
-import type { Target } from "@lage-run/target-graph";
+import { Target, getStartTargetId, getTargetId } from "@lage-run/target-graph";
 import { initializeReporters } from "../initializeReporters.js";
 import { TargetRunnerPicker } from "@lage-run/runners";
 import { getBinPaths } from "../../getBinPaths.js";
@@ -183,12 +183,16 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
       : ["lage.config.js"];
 
     for (const target of optimizedTargets) {
+      if (target.id === getStartTargetId()) {
+        continue;
+      }
+
       const targetGlobalInputsHash = target.environmentGlob
         ? globHashWithCache(target.environmentGlob, { cwd: root })
         : globHashWithCache(globalInputs, { cwd: root });
 
-      const targetGlobalInputsHashFile = getGlobalInputHashFilePath(target);
-      const targetGlobalInputsHashFileDir = path.join(target.cwd, path.dirname(targetGlobalInputsHashFile));
+      const targetGlobalInputsHashFile = path.join(target.cwd, getGlobalInputHashFilePath(target));
+      const targetGlobalInputsHashFileDir = path.dirname(targetGlobalInputsHashFile);
 
       // Make sure the directory exists
       if (!fs.existsSync(targetGlobalInputsHashFileDir)) {

--- a/packages/cli/src/commands/server/lageService.ts
+++ b/packages/cli/src/commands/server/lageService.ts
@@ -352,6 +352,7 @@ export async function createLageService({
           {
             packageName: results.packageName,
             task: results.task,
+            cwd: results.cwd,
             exitCode: results.exitCode,
             inputs: results.inputs,
             outputs: results.outputs,

--- a/packages/cli/src/commands/targetHashFilePath.ts
+++ b/packages/cli/src/commands/targetHashFilePath.ts
@@ -1,0 +1,9 @@
+import path from "path";
+
+export function getHashFilePath(target: { task: string }) {
+  return path.join(`node_modules/.lage/hash_${target.task}`);
+}
+
+export function getGlobalInputHashFilePath(target: { task: string }) {
+  return path.join(`node_modules/.lage/global_inputs_hash_${target.task}`);
+}

--- a/packages/hasher/src/index.ts
+++ b/packages/hasher/src/index.ts
@@ -1,3 +1,5 @@
 export { TargetHasher } from "./TargetHasher.js";
 export { PackageTree } from "./PackageTree.js";
 export { getInputFiles } from "./getInputFiles.js";
+export { FileHasher } from "./FileHasher.js";
+export { hashStrings } from "./hashStrings.js";

--- a/packages/rpc/proto/lage/v1/lage.proto
+++ b/packages/rpc/proto/lage/v1/lage.proto
@@ -13,13 +13,14 @@ message RunTargetRequest {
 message RunTargetResponse {
   string id = 1;
   optional string package_name = 2;
-  string task = 3;
-  int32 exit_code = 4;
-  repeated string inputs = 5;
-  repeated string outputs = 6;
-  string stdout = 7;
-  string stderr = 8;
-  repeated string global_inputs = 9;
+  string cwd = 3;
+  string task = 4;
+  int32 exit_code = 5;
+  repeated string inputs = 6;
+  repeated string outputs = 7;
+  string stdout = 8;
+  string stderr = 9;
+  string global_input_hash_file = 10;
 }
 
 message PingRequest {}

--- a/packages/rpc/src/gen/lage/v1/lage_pb.ts
+++ b/packages/rpc/src/gen/lage/v1/lage_pb.ts
@@ -85,39 +85,44 @@ export class RunTargetResponse extends Message<RunTargetResponse> {
   packageName?: string;
 
   /**
-   * @generated from field: string task = 3;
+   * @generated from field: string cwd = 3;
+   */
+  cwd = "";
+
+  /**
+   * @generated from field: string task = 4;
    */
   task = "";
 
   /**
-   * @generated from field: int32 exit_code = 4;
+   * @generated from field: int32 exit_code = 5;
    */
   exitCode = 0;
 
   /**
-   * @generated from field: repeated string inputs = 5;
+   * @generated from field: repeated string inputs = 6;
    */
   inputs: string[] = [];
 
   /**
-   * @generated from field: repeated string outputs = 6;
+   * @generated from field: repeated string outputs = 7;
    */
   outputs: string[] = [];
 
   /**
-   * @generated from field: string stdout = 7;
+   * @generated from field: string stdout = 8;
    */
   stdout = "";
 
   /**
-   * @generated from field: string stderr = 8;
+   * @generated from field: string stderr = 9;
    */
   stderr = "";
 
   /**
-   * @generated from field: repeated string global_inputs = 9;
+   * @generated from field: string global_input_hash_file = 10;
    */
-  globalInputs: string[] = [];
+  globalInputHashFile = "";
 
   constructor(data?: PartialMessage<RunTargetResponse>) {
     super();
@@ -129,13 +134,14 @@ export class RunTargetResponse extends Message<RunTargetResponse> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "package_name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
-    { no: 3, name: "task", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 4, name: "exit_code", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 5, name: "inputs", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 6, name: "outputs", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 7, name: "stdout", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 8, name: "stderr", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 9, name: "global_inputs", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 3, name: "cwd", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "task", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "exit_code", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 6, name: "inputs", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 7, name: "outputs", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 8, name: "stdout", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 9, name: "stderr", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 10, name: "global_input_hash_file", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RunTargetResponse {


### PR DESCRIPTION
This PR reduces the cost of BuildXL's hashing. Since it doesn't know anything about env glob and how it is being reused across pips. This is a lage (JS task runner) concept. So, it naively executes a hash on each file. We can salvage this perf optimization by just taking control the hashing of those entries and just pass it as an input file. Since each target can possibly get its own env glob pattern... we are going to output a global_inputs_hash file per target, but the calculations are cached internally to make it fast.

We are leveraging the "info" command to generate these since this is a guaranteed command that is run all the time by the buildxl. Note cached hits from BXL means that it doesn't even interact with lage exec call for that pip. That means we cannot prepopulate things at the exec calls. the "info" the best place to generate these as a prep step. We will only do this for the `--server` case since normal execs don't need this (it is only needed to optimize for buildxl)

This pull request introduces several optimizations and improvements to the `lage` project, focusing on enhancing the efficiency of the BuildXL runs and improving the handling of global input hashes. The most important changes include adding new functionalities to handle global input hashes, refactoring existing methods, and updating the protobuf definitions to accommodate new fields.

### Enhancements to BuildXL Optimizations:
* Added logic to generate and use global input hash files for targets in the `infoAction` function. This optimization helps speed up BuildXL runs by avoiding repeated file reads. (`packages/cli/src/commands/info/action.ts`, `[[1]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fR155-R206)`, `[[2]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fR248-R251)`, `[[3]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL200-L202)`, `[[4]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL218-R276)`)
* Introduced the `getGlobalInputHashFilePath` function to determine the path for global input hash files. (`packages/cli/src/commands/targetHashFilePath.ts`, `[packages/cli/src/commands/targetHashFilePath.tsR1-R9](diffhunk://#diff-ba547c11c29e2e99e83302c76c27d57b07cbbb5722b6eedd4c3caef01b3aaf51R1-R9)`)

### Refactoring and Code Improvements:
* Refactored the `generateCommand` function to use the new `shouldRunWorkersAsService` helper function, improving code readability and maintainability. (`packages/cli/src/commands/info/action.ts`, `[[1]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL200-L202)`, `[[2]](diffhunk://#diff-5d45065c5d72c3b1acb9f00b687053c6c6f987fa9f3f390d01e1c7a243d3df9fL218-R276)`)
* Added the `FileHasher` and `hashStrings` exports to the `hasher` package to support hash generation for global inputs. (`packages/hasher/src/index.ts`, `[packages/hasher/src/index.tsR4-R5](diffhunk://#diff-1ca6c8a7c411a9c12ff5236babab9eb2e3d60c4f4772b8562f5beae74e9ce6d5R4-R5)`)

### Protobuf and RPC Updates:
* Updated the `RunTargetResponse` message in the protobuf definition to include the `cwd` and `global_input_hash_file` fields, ensuring that the necessary data is transmitted during remote procedure calls. (`packages/rpc/proto/lage/v1/lage.proto`, `[packages/rpc/proto/lage/v1/lage.protoL16-R23](diffhunk://#diff-1cf9ffd1076b73fb018e4d7df07389a990b983465f604d6d956b1a7f18b859c2L16-R23)`)
* Adjusted the generated TypeScript classes to reflect the changes in the protobuf definitions, ensuring proper handling of the new fields. (`packages/rpc/src/gen/lage/v1/lage_pb.ts`, `[[1]](diffhunk://#diff-1caefe9c23e7418845c96bfe307a41be1429c6dbfe8431be5a50bc27bf01ff8eL88-R125)`, `[[2]](diffhunk://#diff-1caefe9c23e7418845c96bfe307a41be1429c6dbfe8431be5a50bc27bf01ff8eL132-R144)`)

### Additional Changes:
* Imported the `path` module in `executeRemotely.ts` to handle file paths for global input hashes. (`packages/cli/src/commands/exec/executeRemotely.ts`, `[packages/cli/src/commands/exec/executeRemotely.tsR1](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bR1)`)
* Updated the `createLageService` function to handle global input hash files and ensure the correct paths are used during task execution. (`packages/cli/src/commands/server/lageService.ts`, `[[1]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L4-R4)`, `[[2]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R19)`, `[[3]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L165-L168)`, `[[4]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2L236-R243)`, `[[5]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R257)`, `[[6]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R271-R272)`, `[[7]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R319-R326)`, `[[8]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R339-R346)`, `[[9]](diffhunk://#diff-637e91c79aff43e711921eecd75f940dcc04834d68306ff53e84933591e001c2R355-R360)`)