### PR TITLE
Show target.id in error about missing inputs

### DIFF
--- a/packages/hasher/src/TargetHasher.ts
+++ b/packages/hasher/src/TargetHasher.ts
@@ -170,7 +170,7 @@ export class TargetHasher {
 
     if (target.cwd === root && target.cache) {
       if (!target.inputs) {
-        throw new Error("Root-level targets must have `inputs` defined if it has cache enabled.");
+        throw new Error(`Missing inputs on target ${target.id}; cannot cache.`);
       }
 
       const files = await globAsync(target.inputs, { cwd: root });


### PR DESCRIPTION
I got this error and had no idea what target it was complaining about.