### PR TITLE
Exclude tasks that should not run from the dep graph

### DIFF
--- a/change/change-64a60bc2-b0f9-434b-8ce5-47a7d48f3c1b.json
+++ b/change/change-64a60bc2-b0f9-434b-8ce5-47a7d48f3c1b.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Exclude tasks that should not run from the dep graph",
+      "packageName": "@lage-run/cli",
+      "email": "dobes@formative.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "Exclude tasks that should not run from the dep graph",
+      "packageName": "@lage-run/target-graph",
+      "email": "dobes@formative.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/info/action.ts
+++ b/packages/cli/src/commands/info/action.ts
@@ -11,9 +11,9 @@ import fs from "fs";
 import { parse } from "shell-quote";
 
 import type { ReporterInitOptions } from "../../types/ReporterInitOptions.js";
-import { type Target, getStartTargetId } from "@lage-run/target-graph";
+import { type Target, getStartTargetId, type TargetConfig } from "@lage-run/target-graph";
 import { initializeReporters } from "../initializeReporters.js";
-import { TargetRunnerPicker } from "@lage-run/runners";
+import { TargetRunnerPicker, type TargetRunnerPickerOptions } from "@lage-run/runners";
 import { getBinPaths } from "../../getBinPaths.js";
 import { runnerPickerOptions } from "../../runnerPickerOptions.js";
 import { parseServerOption } from "../parseServerOption.js";
@@ -22,6 +22,7 @@ import { glob } from "@lage-run/globby";
 import { FileHasher } from "@lage-run/hasher/lib/FileHasher.js";
 import { hashStrings } from "@lage-run/hasher";
 import { getGlobalInputHashFilePath } from "../targetHashFilePath.js";
+import { shouldRun } from "../shouldRun";
 
 interface InfoActionOptions extends ReporterInitOptions {
   dependencies: boolean;
@@ -109,6 +110,8 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
 
   const { tasks, taskArgs } = filterArgsForTasks(command.args);
 
+  const pickerOptions = runnerPickerOptions(options.nodeArg, config.npmClient, taskArgs);
+
   const targetGraph = await createTargetGraph({
     logger,
     root,
@@ -123,6 +126,7 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
     tasks,
     packageInfos,
     priorities: config.priorities,
+    shouldRun: shouldRun(pickerOptions),
   });
 
   const scope = getFilteredPackages({
@@ -136,8 +140,6 @@ export async function infoAction(options: InfoActionOptions, command: Command) {
     repoWideChanges: config.repoWideChanges,
     sinceIgnoreGlobs: options.ignore.concat(config.ignore),
   });
-
-  const pickerOptions = runnerPickerOptions(options.nodeArg, config.npmClient, taskArgs);
 
   const runnerPicker = new TargetRunnerPicker(pickerOptions);
 

--- a/packages/cli/src/commands/shouldRun.ts
+++ b/packages/cli/src/commands/shouldRun.ts
@@ -1,0 +1,22 @@
+import type { Target, TargetConfig } from "@lage-run/target-graph";
+import { TargetRunner, TargetRunnerPicker, TargetRunnerPickerOptions } from "@lage-run/runners";
+
+// Generate a shouldRun function we can provide to the graph builder to prune tasks
+// This allows the runners configured in the project to return whether the task should
+// run.  If a task should not run, it also should not cause anything it depends on to
+// run.
+export function shouldRun(pickerOptions: TargetRunnerPickerOptions) {
+  const picker = new TargetRunnerPicker(pickerOptions);
+  return async (config: TargetConfig, target: Target) => {
+    if (typeof config.shouldRun === "function" && !await config.shouldRun(target)) {
+      return false;
+    }
+
+    const runner = await picker.pick(target);
+    if(!runner?.shouldRun(target)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/tests/WorkspaceTargetGraphBuilder.test.ts
@@ -39,7 +39,7 @@ describe("workspace target graph builder", () => {
     });
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
     });
 
@@ -81,8 +81,8 @@ describe("workspace target graph builder", () => {
     });
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
-    builder.addTargetConfig("test");
-    builder.addTargetConfig("lint");
+    await builder.addTargetConfig("test");
+    await builder.addTargetConfig("lint");
 
     const targetGraph = await builder.build(["test", "lint"]);
 
@@ -121,11 +121,11 @@ describe("workspace target graph builder", () => {
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
 
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
     });
 
-    builder.addTargetConfig("a#build", {
+    await builder.addTargetConfig("a#build", {
       dependsOn: [],
     });
 
@@ -163,11 +163,11 @@ describe("workspace target graph builder", () => {
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
 
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
     });
 
-    builder.addTargetConfig("a#build", {
+    await builder.addTargetConfig("a#build", {
       dependsOn: [],
     });
 
@@ -197,11 +197,11 @@ describe("workspace target graph builder", () => {
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
 
-    builder.addTargetConfig("bundle", {
+    await builder.addTargetConfig("bundle", {
       dependsOn: ["^^transpile"],
     });
 
-    builder.addTargetConfig("transpile");
+    await builder.addTargetConfig("transpile");
 
     const targetGraph = await builder.build(["bundle"], ["a"]);
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
@@ -242,12 +242,12 @@ describe("workspace target graph builder", () => {
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
 
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["common#copy", "^build"],
     });
 
-    builder.addTargetConfig("common#copy");
-    builder.addTargetConfig("common#build");
+    await builder.addTargetConfig("common#copy");
+    await builder.addTargetConfig("common#build");
 
     const targetGraph = await builder.build(["build"]);
     expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
@@ -297,11 +297,11 @@ describe("workspace target graph builder", () => {
     });
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["^build", "#global:task"],
     });
 
-    builder.addTargetConfig("#global:task", {
+    await builder.addTargetConfig("#global:task", {
       dependsOn: [],
     });
 
@@ -346,11 +346,11 @@ describe("workspace target graph builder", () => {
     });
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["^build", "#global:task"],
     });
 
-    builder.addTargetConfig("#global:task", {
+    await builder.addTargetConfig("#global:task", {
       dependsOn: [],
     });
 
@@ -375,11 +375,11 @@ describe("workspace target graph builder", () => {
     });
 
     const builder = new WorkspaceTargetGraphBuilder(root, packageInfos);
-    builder.addTargetConfig("build", {
+    await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
     });
 
-    builder.addTargetConfig("#global:task", {
+    await builder.addTargetConfig("#global:task", {
       dependsOn: [],
     });
 


### PR DESCRIPTION
If a task should not run, it shouldn't generate dependencies, either.

For example if we have a task "bundle" which depends on "build", running the "bundle" task should not run "build" in workspaces that do not have a "bundle" task in them.
