### PR TITLE
If target has no outputs set, and no global outputGlob set, assume no outputs

### DIFF
--- a/change/change-50d5ec94-8c4b-470b-be07-7bebaea6503f.json
+++ b/change/change-50d5ec94-8c4b-470b-be07-7bebaea6503f.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "If target has no outputs set, and no global outputGlob set, assume no outputs",
+      "packageName": "@lage-run/cache",
+      "email": "dobes@formative.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cache/src/providers/BackfillCacheProvider.ts
+++ b/packages/cache/src/providers/BackfillCacheProvider.ts
@@ -76,7 +76,7 @@ export class BackfillCacheProvider implements CacheProvider {
     const cacheStorage = this.getTargetCacheStorageProvider(target.cwd, hash);
 
     try {
-      await cacheStorage.put(hash, target.outputs ?? this.options.cacheOptions.outputGlob ?? ["**/*"]);
+      await cacheStorage.put(hash, target.outputs ?? this.options.cacheOptions.outputGlob ?? []);
     } catch (error) {
       let message;
 


### PR DESCRIPTION
Assuming that every file in the target directory is an output to be cached doesn't seem correct here - if they didn't specify outputs, assume there are none instead.
