### PR TITLE
Fix issue with noop tasks that depend on other noop tasks

### DIFF
--- a/change/change-8df26c07-7241-49f9-ab2b-72ef0e59f43f.json
+++ b/change/change-8df26c07-7241-49f9-ab2b-72ef0e59f43f.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix issue with noop tasks that depend on other noop tasks",
+      "packageName": "@lage-run/target-graph",
+      "email": "dobes@formative.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
If you had a runnable task that depended on a noop task that in turn depended on a noop task, that depended on a runnable task, the dependency between the two runnable tasks would not be preserved.  The logic that prunes out noop tasks in the dependency tree did not account for multiple levels of removal.
