### PR TITLE
Deeply enumerate directories

### DIFF
--- a/change/change-672053aa-a723-4880-8042-24fe2631cf65.json
+++ b/change/change-672053aa-a723-4880-8042-24fe2631cf65.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "make sure to touch / probe all directories deeply",
+      "packageName": "@lage-run/cli",
+      "email": "kchau@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/exec/executeRemotely.ts
+++ b/packages/cli/src/commands/exec/executeRemotely.ts
@@ -142,7 +142,7 @@ export async function executeRemotely(options: ExecRemotelyOptions, command: Com
 
     // we will simulate file access even if exit code may be non-zero
     const relativeGlobalInputsForTarget = path.relative(root, path.join(response.cwd, response.globalInputHashFile));
-    await simulateFileAccess(logger, [...response.inputs, relativeGlobalInputsForTarget], response.outputs);
+    await simulateFileAccess(logger, root, [...response.inputs, relativeGlobalInputsForTarget], response.outputs);
   } else {
     process.exitCode = 1;
   }

--- a/packages/cli/tests/simulateFileAccess.test.ts
+++ b/packages/cli/tests/simulateFileAccess.test.ts
@@ -1,0 +1,164 @@
+import { simulateFileAccess } from "../src/commands/exec/simulateFileAccess";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+jest.mock("fs");
+
+// Mock the logger
+const mockSilly = jest.fn();
+const mockLogger = {
+  silly: mockSilly,
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  verbose: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe("simulateFileAccess", () => {
+  let mockRoot: string;
+  let mockOpenSync: jest.SpyInstance;
+  let mockCloseSync: jest.SpyInstance;
+  let mockUtimesSync: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockRoot = path.join(os.tmpdir(), "lage-test-root");
+
+    mockOpenSync = jest.spyOn(fs, "openSync").mockReturnValue(123);
+    mockCloseSync = jest.spyOn(fs, "closeSync").mockImplementation(() => {});
+    mockUtimesSync = jest.spyOn(fs, "utimesSync").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should probe files and their parent directories for inputs", async () => {
+    // Nested directory structure with a file at the deepest level
+    const inputs = ["packages/a/src/components/Button.tsx", "packages/b/dist/index.js"];
+    const outputs: string[] = [];
+
+    await simulateFileAccess(mockLogger, mockRoot, inputs, outputs);
+
+    // Verify the files were probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src/components/Button.tsx"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b/dist/index.js"), "r");
+
+    // Verify all parent directories were probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src/components"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b/dist"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b"), "r");
+
+    // Verify close was called the same number of times as open
+    expect(mockCloseSync).toHaveBeenCalledTimes(mockOpenSync.mock.calls.length);
+  });
+
+  test("should handle deeply nested directories", async () => {
+    // Very deep nesting with a single file at the deepest level
+    const inputs = ["level1/level2/level3/level4/level5/file.txt"];
+    const outputs: string[] = [];
+
+    await simulateFileAccess(mockLogger, mockRoot, inputs, outputs);
+
+    // Verify the file was probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4/level5/file.txt"), "r");
+
+    // Verify all parent directories were probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4/level5"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1"), "r");
+  });
+
+  test("should update timestamps for output files and their directories", async () => {
+    const inputs: string[] = [];
+    const outputs = ["dist/bundles/main.js", "dist/types/index.d.ts"];
+
+    await simulateFileAccess(mockLogger, mockRoot, inputs, outputs);
+
+    // Verify timestamps were updated for output files
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/bundles/main.js"), expect.any(Date), expect.any(Date));
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/types/index.d.ts"), expect.any(Date), expect.any(Date));
+
+    // Verify timestamps were updated for all parent directories
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/bundles"), expect.any(Date), expect.any(Date));
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/types"), expect.any(Date), expect.any(Date));
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist"), expect.any(Date), expect.any(Date));
+  });
+
+  test("should handle mixed inputs and outputs with overlapping directories", async () => {
+    const inputs = ["src/components/Button.tsx", "src/utils/helpers.ts"];
+    const outputs = ["dist/components/Button.js", "dist/utils/helpers.js"];
+
+    await simulateFileAccess(mockLogger, mockRoot, inputs, outputs);
+
+    // Verify both input and output files were handled correctly
+    // Input files should be opened and closed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/components/Button.tsx"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/utils/helpers.ts"), "r");
+
+    // Input directories should be opened and closed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/components"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/utils"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src"), "r");
+
+    // Output files should have timestamps updated
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/components/Button.js"), expect.any(Date), expect.any(Date));
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/utils/helpers.js"), expect.any(Date), expect.any(Date));
+
+    // Output directories should have timestamps updated
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/components"), expect.any(Date), expect.any(Date));
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/utils"), expect.any(Date), expect.any(Date));
+    expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist"), expect.any(Date), expect.any(Date));
+  });
+
+  test("should handle errors during file operations", async () => {
+    // Restore original mocks to allow error simulation
+    mockOpenSync.mockRestore();
+
+    // Set up a mock that fails for a specific file path
+    const failingPath = path.join(mockRoot, "src/components/Missing.tsx");
+    jest.spyOn(fs, "openSync").mockImplementation((filePath, mode) => {
+      if (filePath === failingPath) {
+        throw new Error("ENOENT: File not found");
+      }
+      return 123;
+    });
+
+    const inputs = [
+      "src/components/Button.tsx",
+      "src/components/Missing.tsx", // This file will cause an error
+    ];
+    const outputs: string[] = [];
+
+    // Function should not throw even when file operations fail
+    await expect(simulateFileAccess(mockLogger, mockRoot, inputs, outputs)).resolves.not.toThrow();
+
+    // Verify that other operations still proceed despite errors
+    expect(fs.openSync).toHaveBeenCalledWith(path.join(mockRoot, "src/components/Button.tsx"), "r");
+    expect(fs.openSync).toHaveBeenCalledWith(failingPath, "r");
+  });
+
+  test("should handle empty directories with only a single file", async () => {
+    // Create a test case where the input list contains only directories and a single file
+    const inputs = ["empty-dir-1/", "empty-dir-2/", "empty-dir-3/single-file.txt"];
+    const outputs: string[] = [];
+
+    await simulateFileAccess(mockLogger, mockRoot, inputs, outputs);
+
+    // Verify all directories were probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-1/"), "r");
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-2/"), "r");
+
+    // Verify the file was probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-3/single-file.txt"), "r");
+
+    // Verify parent directory was also probed
+    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-3"), "r");
+  });
+});


### PR DESCRIPTION
This pull request includes several changes to the `@lage-run/cli` package, primarily focusing on enhancing the `simulateFileAccess` function to handle directory probing more thoroughly and adding corresponding tests. The most important changes include updating the function to probe all directories deeply, modifying the function signature to accept a root directory, and adding comprehensive tests to ensure the function works as expected.

Enhancements to `simulateFileAccess` function:

* [`packages/cli/src/commands/exec/executeRemotely.ts`](diffhunk://#diff-930be17d1ef5b16a8986a15af1a19fe24c197583c29c0ddfec89fef77db68d6bL145-R145): Updated the call to `simulateFileAccess` to include the `root` directory parameter.
* [`packages/cli/src/commands/exec/simulateFileAccess.ts`](diffhunk://#diff-a64d42a21b4a23e64cc599f6474a562f49878a8f925ca5b207e0643f99f3f168L4-R20): Modified the `simulateFileAccess` function to accept a `root` parameter and added a helper function to get all directory parts up to the root. This ensures that all directories are probed deeply. [[1]](diffhunk://#diff-a64d42a21b4a23e64cc599f6474a562f49878a8f925ca5b207e0643f99f3f168L4-R20) [[2]](diffhunk://#diff-a64d42a21b4a23e64cc599f6474a562f49878a8f925ca5b207e0643f99f3f168L22-R34) [[3]](diffhunk://#diff-a64d42a21b4a23e64cc599f6474a562f49878a8f925ca5b207e0643f99f3f168L38-R51)

Testing improvements:

* [`packages/cli/tests/simulateFileAccess.test.ts`](diffhunk://#diff-2797fe06e0077356acd6d7656421b55a526ea7141f82e081803f29421cd953b8R1-R164): Added comprehensive tests for the `simulateFileAccess` function, covering various scenarios such as deeply nested directories, mixed inputs and outputs, and error handling during file operations.

Configuration update:

* [`change/change-672053aa-a723-4880-8042-24fe2631cf65.json`](diffhunk://#diff-4820d6c36aec42ea4eaa21ced774fa72d693993b0e30e3641367dc3db66da2b7R1-R11): Added a patch change entry to ensure all directories are deeply probed.BuildXL expects more enumerations to help it cache.