### PR TITLE
Defend against missing files in the hashing logic

### DIFF
--- a/change/change-501f9623-19ff-418f-b70c-61580dd1343c.json
+++ b/change/change-501f9623-19ff-418f-b70c-61580dd1343c.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Defend against missing files in the hashing logic",
+      "packageName": "@lage-run/hasher",
+      "email": "dobes@formative.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/hasher/src/FileHasher.ts
+++ b/packages/hasher/src/FileHasher.ts
@@ -100,7 +100,7 @@ export class FileHasher {
     const stats = globStat(files, { cwd: this.options.root }) ?? {};
 
     for (const file of files) {
-      const stat = stats[file];
+      const stat = stats[file] || { mtime: 0n, size: 0 };
 
       const info = this.#store[file];
       if (info && stat.mtime === info.mtime && stat.size == info.size) {
@@ -113,12 +113,24 @@ export class FileHasher {
     const updatedHashes = fastHash(updatedFiles, { cwd: this.options.root, concurrency: 4 }) ?? {};
 
     for (const [file, hash] of Object.entries(updatedHashes)) {
-      const stat = fs.statSync(path.join(this.options.root, file), { bigint: true });
-      this.#store[file] = {
-        mtime: stat.mtimeMs,
-        size: Number(stat.size),
-        hash: hash ?? "",
-      };
+      try {
+        const stat = fs.statSync(path.join(this.options.root, file), { bigint: true });
+        this.#store[file] = {
+          mtime: stat.mtimeMs,
+          size: Number(stat.size),
+          hash: hash ?? "",
+        };
+      } catch (e: any) {
+        if (e.code === "ENOENT") {
+          this.#store[file] = {
+            mtime: 0n,
+            size: 0,
+            hash: hash ?? "",
+          };
+        } else {
+          throw e;
+        }
+      }
       hashes[file] = hash ?? "";
     }
 


### PR DESCRIPTION
If a file is missing while calculating file hashes, use stub values instead of exiting with an error.

I added this because I was occasionally getting errors from this code about the file not being there and lage would exit, I think this may be caused by my changes in https://github.com/microsoft/lage/pull/867 , which allows inputs to specify exact files rather than globs so there could be a file listed as an input that doesn't exist at the time of the build.
