### PR TITLE
[draft] Call read/readdir when simulating file accesses

### DIFF
--- a/packages/cli/src/commands/exec/simulateFileAccess.ts
+++ b/packages/cli/src/commands/exec/simulateFileAccess.ts
@@ -20,12 +20,21 @@ export async function simulateFileAccess(logger: Logger, root: string, inputs: s
 
   const inputDirectories = new Set<string>();
 
-  // probe input files
+  // read input files
   let fd: number;
+  let buffer: Buffer = Buffer.alloc(1);
   for (const input of inputs) {
     try {
-      fd = fs.openSync(path.join(root, input), "r");
-      fs.closeSync(fd);
+      let inputPath = path.join(root, input);
+      if (!fs.lstatSync(inputPath).isDirectory()) {
+        fd = fs.openSync(inputPath, "r");
+        // Simulate a file content read by reading 1 byte of the opened file handle
+        fs.readSync(fd, buffer, 0, 1, 0);
+        fs.closeSync(fd);
+      }
+      else {
+        inputDirectories.add(inputPath);
+      }
     } catch (e) {
       // ignore
     }
@@ -36,8 +45,8 @@ export async function simulateFileAccess(logger: Logger, root: string, inputs: s
 
   for (const directory of inputDirectories) {
     try {
-      fd = fs.openSync(path.join(root, directory), "r");
-      fs.closeSync(fd);
+      // Simulate enumerating a directory
+      fs.readdirSync(path.join(root, directory));
     } catch (e) {
       // ignore
     }

--- a/packages/cli/tests/simulateFileAccess.test.ts
+++ b/packages/cli/tests/simulateFileAccess.test.ts
@@ -14,19 +14,28 @@ const mockLogger = {
   error: jest.fn(),
   verbose: jest.fn(),
   debug: jest.fn(),
+  // Add required Logger properties for type compatibility
+  reporters: [],
+  log: jest.fn(),
+  stream: () => () => {},
+  addReporter: jest.fn(),
 };
 
 describe("simulateFileAccess", () => {
   let mockRoot: string;
   let mockOpenSync: jest.SpyInstance;
+  let mockReadSync: jest.SpyInstance;
   let mockCloseSync: jest.SpyInstance;
+  let mockReaddirSync: jest.SpyInstance;
   let mockUtimesSync: jest.SpyInstance;
 
   beforeEach(() => {
     mockRoot = path.join(os.tmpdir(), "lage-test-root");
 
     mockOpenSync = jest.spyOn(fs, "openSync").mockReturnValue(123);
+    mockReadSync = jest.spyOn(fs, "readSync").mockImplementation(() => 1);
     mockCloseSync = jest.spyOn(fs, "closeSync").mockImplementation(() => {});
+    mockReaddirSync = jest.spyOn(fs, "readdirSync").mockImplementation(() => []);
     mockUtimesSync = jest.spyOn(fs, "utimesSync").mockImplementation(() => {});
   });
 
@@ -44,17 +53,16 @@ describe("simulateFileAccess", () => {
     // Verify the files were probed
     expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src/components/Button.tsx"), "r");
     expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b/dist/index.js"), "r");
-
-    // Verify all parent directories were probed
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src/components"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b/dist"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b"), "r");
-
-    // Verify close was called the same number of times as open
+    expect(mockReadSync).toHaveBeenCalledTimes(mockOpenSync.mock.calls.length);
     expect(mockCloseSync).toHaveBeenCalledTimes(mockOpenSync.mock.calls.length);
+
+    // Verify all parent directories were probed using readdirSync
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src/components"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a/src"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/a"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "packages"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b/dist"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "packages/b"));
   });
 
   test("should handle deeply nested directories", async () => {
@@ -67,12 +75,12 @@ describe("simulateFileAccess", () => {
     // Verify the file was probed
     expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4/level5/file.txt"), "r");
 
-    // Verify all parent directories were probed
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4/level5"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "level1"), "r");
+    // Verify all parent directories were probed using readdirSync
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4/level5"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3/level4"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2/level3"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "level1/level2"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "level1"));
   });
 
   test("should update timestamps for output files and their directories", async () => {
@@ -102,10 +110,10 @@ describe("simulateFileAccess", () => {
     expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/components/Button.tsx"), "r");
     expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/utils/helpers.ts"), "r");
 
-    // Input directories should be opened and closed
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/components"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src/utils"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "src"), "r");
+    // Input directories should be probed using readdirSync
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "src/components"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "src/utils"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "src"));
 
     // Output files should have timestamps updated
     expect(mockUtimesSync).toHaveBeenCalledWith(path.join(mockRoot, "dist/components/Button.js"), expect.any(Date), expect.any(Date));
@@ -120,6 +128,7 @@ describe("simulateFileAccess", () => {
   test("should handle errors during file operations", async () => {
     // Restore original mocks to allow error simulation
     mockOpenSync.mockRestore();
+    mockReadSync.mockRestore();
 
     // Set up a mock that fails for a specific file path
     const failingPath = path.join(mockRoot, "src/components/Missing.tsx");
@@ -129,6 +138,8 @@ describe("simulateFileAccess", () => {
       }
       return 123;
     });
+    jest.spyOn(fs, "readSync").mockImplementation(() => 1);
+    jest.spyOn(fs, "closeSync").mockImplementation(() => {});
 
     const inputs = [
       "src/components/Button.tsx",
@@ -151,14 +162,14 @@ describe("simulateFileAccess", () => {
 
     await simulateFileAccess(mockLogger, mockRoot, inputs, outputs);
 
-    // Verify all directories were probed
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-1/"), "r");
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-2/"), "r");
+    // Verify all directories were enumerated using readdirSync
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-1/"));
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-2/"));
 
     // Verify the file was probed
     expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-3/single-file.txt"), "r");
 
-    // Verify parent directory was also probed
-    expect(mockOpenSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-3"), "r");
+    // Verify parent directory was also enumerated using readdirSync
+    expect(mockReaddirSync).toHaveBeenCalledWith(path.join(mockRoot, "empty-dir-3"));
   });
 });


### PR DESCRIPTION
Calling open produces only a probe, but with the server process we want the inputs to be considered as a read for a file or an enumerate for a directory. For files, this change will read 1 byte from the provided file to produce a read, and will call readdir on a directory to produce an enumeration.

Tests not working yet.