### PR TITLE
Change lage-npm update strategy, update beachball config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,11 +13,5 @@
     "**/yarn/yarn.js": true,
     "**/docs/build": true,
     "**/*.code-search": true
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
   }
 }

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,19 +1,18 @@
 // @ts-check
 /** @type {import('beachball').BeachballConfig}*/
-module.exports = {
-  groupChanges: true,
+const config = {
   access: "public",
-  ignorePatterns: [
-    "benchmark/**",
-    ".*ignore",
-    ".github/**",
-    "beachball.config.js",
-    "decks/**",
-    "docs/**",
-    "jasmine.json",
-    "packages/*/jest.config.js",
-    "packages/*/tests/**",
-    // This one is especially important (otherwise dependabot would be blocked by change file requirements)
-    "yarn.lock",
-  ],
+  groupChanges: true,
+  changelog: {
+    groups: [
+      {
+        // roll up all changes to the lage changelog (packages still have individual changelogs too)
+        masterPackageName: "lage",
+        include: ["packages/*"],
+        changelogPath: "packages/lage",
+      },
+    ],
+  },
+  ignorePatterns: [".*ignore", "jest.config.js", "**/__*/**/*", "**/tests/**/*"],
 };
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fast-glob": "3.3.3",
     "gh-pages": "^5.0.0",
     "husky": "^9.1.5",
-    "lage-npm": "npm:lage@2.14.6",
+    "lage-npm": "npm:lage@<2.14.8",
     "lint-staged": "^16.0.0",
     "patch-package": "^8.0.0",
     "prettier": "^3.0.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,9 +19,12 @@
   ],
   "customManagers": [
     {
+      // Handle updates for the lage-npm dev dep: it's set to the version < the current one because
+      // otherwise yarn v4 dedupes it with the local version, which won't work if the local version
+      // hasn't been built yet.
       "customType": "regex",
       "managerFilePatterns": ["/^package.json$/"],
-      "matchStrings": ["lage-npm\": \"lage@(?<currentValue>[~^]?\\d+\\.\\d+\\.\\d+)"],
+      "matchStrings": ["lage-npm\": \"lage@(?<currentValue>[<]\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "lage-npm",
       "packageNameTemplate": "lage",
       "datasourceTemplate": "npm",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,7 +1694,7 @@ __metadata:
     fast-glob: "npm:3.3.3"
     gh-pages: "npm:^5.0.0"
     husky: "npm:^9.1.5"
-    lage-npm: "npm:lage@2.14.6"
+    lage-npm: "npm:lage@<2.14.8"
     lint-staged: "npm:^16.0.0"
     patch-package: "npm:^8.0.0"
     prettier: "npm:^3.0.0"
@@ -6135,9 +6135,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lage-npm@npm:lage@2.14.6":
-  version: 2.14.6
-  resolution: "lage@npm:2.14.6"
+"lage-npm@npm:lage@<2.14.8":
+  version: 2.14.7
+  resolution: "lage@npm:2.14.7"
   dependencies:
     fsevents: "npm:~2.3.2"
     glob-hasher: "npm:^1.4.2"
@@ -6147,7 +6147,7 @@ __metadata:
   bin:
     lage: dist/lage.js
     lage-server: dist/lage-server.js
-  checksum: 10c0/a82eea9da0af944c20faa3eb010f396e7780e958dd57710423442af3a161415d229143aa227d3f251d67ae1709774324809ca46df4832dcdadfa499dcbf28683
+  checksum: 10c0/f320432a42b97042c28dde39634b1639f72694e13a32ac1788ccad51caa2e59ee7cd661823ce2581da9b9328aefa0716023bad13af26c500b60840580a504ef2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Yarn v4 apparently dedupes `"lage-npm": "npm:lage@x.y.z"` (where `x.y.z` is the current version) with the local version of lage, which won't work if it hasn't been built yet. Switch the semver range to `<x.y.z`.

Also update the beachball config to roll all updates into the `lage` changelog.