### PR TITLE
Update to latest backfill cache to support caching files with . in the name

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -22,7 +22,7 @@
     "@lage-run/config": "workspace:^",
     "@lage-run/logger": "workspace:^",
     "@lage-run/target-graph": "workspace:^",
-    "backfill-cache": "5.11.1",
+    "backfill-cache": "5.11.2",
     "backfill-config": "6.7.1",
     "backfill-logger": "5.4.0",
     "glob-hasher": "^1.4.2"

--- a/packages/cache/tests/BackfillCacheProvider.test.ts
+++ b/packages/cache/tests/BackfillCacheProvider.test.ts
@@ -22,7 +22,11 @@ describe("BackfillCacheProvider", () => {
       logger,
       root: monorepo.root,
       cacheOptions: {
-        outputGlob: ["output.txt"],
+        outputGlob: [
+          "output.txt",
+          // Backfill had a bug where it did not copy folders over with a . in the name, adding this as a test case
+          ".react-router/**",
+        ],
       },
     };
 
@@ -44,13 +48,15 @@ describe("BackfillCacheProvider", () => {
 
     await monorepo.writeFiles({
       [path.join(cacheDir, hash, "output.txt")]: "output",
+      [path.join(cacheDir, hash, ".react-router", "routes.d.ts")]: "route type info",
     });
 
     const fetchResult = await provider.fetch(hash, target);
 
-    const contents = await monorepo.readFiles(["packages/a/output.txt"]);
+    const contents = await monorepo.readFiles(["packages/a/output.txt", "packages/a/.react-router/routes.d.ts"]);
 
     expect(contents["packages/a/output.txt"]).toBe("output");
+    expect(contents["packages/a/.react-router/routes.d.ts"]).toBe("route type info");
     expect(fetchResult).toBeTruthy();
 
     await monorepo.cleanup();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,7 +1558,7 @@ __metadata:
     "@lage-run/monorepo-fixture": "workspace:^"
     "@lage-run/monorepo-scripts": "workspace:^"
     "@lage-run/target-graph": "workspace:^"
-    backfill-cache: "npm:5.11.1"
+    backfill-cache: "npm:5.11.2"
     backfill-config: "npm:6.7.1"
     backfill-logger: "npm:5.4.0"
     glob-hasher: "npm:^1.4.2"
@@ -3018,9 +3018,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"backfill-cache@npm:5.11.1":
-  version: 5.11.1
-  resolution: "backfill-cache@npm:5.11.1"
+"backfill-cache@npm:5.11.2":
+  version: 5.11.2
+  resolution: "backfill-cache@npm:5.11.2"
   dependencies:
     "@azure/storage-blob": "npm:^12.15.0"
     backfill-config: "npm:^6.7.1"
@@ -3030,7 +3030,7 @@ __metadata:
     globby: "npm:^11.0.0"
     p-limit: "npm:^3.0.0"
     tar-fs: "npm:^2.1.0"
-  checksum: 10c0/a8c12e7ab2b01b04a83dc12810148d97ed40c942f74620127b5c45c9cb47f5f7a96da9609ec563f234091241e86436681d7bc3238a19a8b0b25c8e3471c593b9
+  checksum: 10c0/2e57b265d3e63aa426dbd4ac41f91725f9fc002dcc11126dd3573e59f2fd5e0001ad5a16fb16ad1107904ef8a584f45645b580a5f399822f691828073c5d433d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We've found in projects that use react-router the lage cache is not copying over the .react-router folder with the types causing frustrating build errors. This ended up being a change in backfill cache that was published yesterday. This PR updates to the latest version of backfill cache while also adding a test to ensure the correct behavior in the future.