### PR TITLE
Clarify docs on reporters and cacheOptions, and add ConfigFileOptions type

### DIFF
--- a/change/change-ea4a584b-f24f-41fc-9855-6943262ee2ba.json
+++ b/change/change-ea4a584b-f24f-41fc-9855-6943262ee2ba.json
@@ -1,0 +1,24 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Export ConfigFileOptions type, and improve init command's generated config",
+      "packageName": "@lage-run/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Add ConfigFileOptions type",
+      "packageName": "@lage-run/config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "none",
+      "comment": "Update readme",
+      "packageName": "lage",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/docs/docs/guides/installation.md
+++ b/docs/docs/guides/installation.md
@@ -60,13 +60,25 @@ Next, add scripts inside the workspace root `package.json` to run `lage`. For ex
 Create a file `lage.config.js` at the workspace root, and configure task dependencies using the `pipeline`. For example:
 
 ```js title="/lage.config.js"
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   pipeline: {
     build: ["^build"],
     test: ["build"],
     lint: []
+  },
+  // Update these according to your repo's build setup
+  cacheOptions: {
+    // Generated files in each package that will be saved into the cache
+    // (relative to package root; folders must end with **/*)
+    outputGlob: ["lib/**/*"],
+    // Changes to any of these files/globs will invalidate the cache (relative to repo root;
+    // folders must end with **/*). This should include your lock file and any other repo-wide
+    // configs or scripts that are outside a package but could invalidate previous output.
+    environmentGlob: ["package.json", "yarn.lock", "lage.config.js"]
   }
 };
+module.exports = config;
 ```
 
 See the [Pipelines page](./pipeline.md) for more info about this syntax.

--- a/docs/docs/guides/pipeline.md
+++ b/docs/docs/guides/pipeline.md
@@ -22,13 +22,15 @@ Futhermore, the developer is expected to keep track of an **implicit** graph of 
 To define the task dependency graph, use the `pipeline` key in `lage.config.js`. For example, this is the default generated configuration when you run `npx lage init`:
 
 ```js title="/lage.config.js"
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   pipeline: {
     build: ["^build"],
     test: ["build"],
     lint: []
   }
 };
+module.exports = config;
 ```
 
 Each key is a **task name**, and each value is an array of **task dependencies** (or an [advanced configuration](#advanced-pipeline-configuration) object).
@@ -130,7 +132,7 @@ Optionally, you can use an object for advanced pipeline task target configuratio
 See the [`TargetConfig` source](https://github.com/microsoft/lage/blob/master/packages/target-graph/src/types/TargetConfig.ts) for full details. There are also some examples in [lage's own config](https://github.com/microsoft/lage/blob/master/lage.config.js).
 
 ```js
-/** @type {import("lage").ConfigOptions} */
+/** @type {import("lage").ConfigFileOptions} */
 const config = {
   pipeline: {
     build: {
@@ -157,7 +159,7 @@ By default, tasks have `type: "npmScript"`, meaning they correspond to a script 
 Usually, the only reason you'd need to explicitly specify this type is
 
 ```js
-/** @type {import("lage").ConfigOptions} */
+/** @type {import("lage").ConfigFileOptions} */
 const config = {
   pipeline: {
     // "transpile" is a worker task for most packages
@@ -188,7 +190,7 @@ A task can be configured with `type: "noop"` to indicate that it does not corres
 This example (modified from lage's own configuration) defines a `build` "meta-task" that depends the `transpile` and `types` tasks which correspond , but does not correspond to any actual script in the packages.
 
 ```js
-/** @type {import("lage").ConfigOptions} */
+/** @type {import("lage").ConfigFileOptions} */
 const config = {
   pipeline: {
     transpile: [],

--- a/docs/docs/guides/priority.md
+++ b/docs/docs/guides/priority.md
@@ -13,7 +13,8 @@ Lage provides the following options to customize the task priority. The higher t
 As of `lage` v2, you can now configure the priority inside the target pipeline configuration:
 
 ```js
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   pipeline: {
     build: ["^build"],
     test: ["build"],
@@ -23,6 +24,7 @@ module.exports = {
     }
   }
 };
+module.exports = config;
 ```
 
 ## Legacy (v1 + v2) configuration
@@ -30,7 +32,8 @@ module.exports = {
 To manually pick a package task to be higher priority, simply add a [`priorities` configuration](../reference/config.md) in `lage.config.js`:
 
 ```js
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   priorities: [
     {
       package: "foo",
@@ -39,4 +42,5 @@ module.exports = {
     }
   ]
 };
+module.exports = config;
 ```

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -16,17 +16,28 @@ npx lage init
 
 ## Customize `lage.config.js`
 
-The `init` command will also generate a default `lage.config.js`. This will likely need to be modified. In particular, pay attention to the `pipeline`
-configuration:
+The `init` command will also generate a default `lage.config.js`. This will likely need to be modified.
 
 ```js title="/lage.config.js"
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   pipeline: {
     build: ["^build"],
     test: ["build"],
     lint: []
+  },
+  // Update these according to your repo's build setup
+  cacheOptions: {
+    // Generated files in each package that will be saved into the cache
+    // (relative to package root; folders must end with **/*)
+    outputGlob: ["lib/**/*"],
+    // Changes to any of these files/globs will invalidate the cache (relative to repo root;
+    // folders must end with **/*). This should include your lock file and any other repo-wide
+    // configs or scripts that are outside a package but could invalidate previous output.
+    environmentGlob: ["package.json", "yarn.lock", "lage.config.js"]
   }
 };
+module.exports = config;
 ```
 
 ## Customize workspace (root level) `package.json`

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -189,7 +189,7 @@ Valid values are `silly`, `verbose`, `info`, `warn`, `error`. If `error` is pass
 
 By default, `lage` will interweave all the `stdout` and `stderr` from all active targets as they are running.
 
-Use the `--grouped` This may become a mess, so `lage` can group output messages together. These messages will only be displayed when the target is completed:
+The `--grouped` option can be used to group messages by target (package). The messages will only be displayed when the target is completed.
 
 ```
 lage build --verbose --grouped
@@ -199,24 +199,37 @@ lage build --verbose --grouped
 
 `lage` comes with various reporters which take the logged messages of the target runs, format them, and display them.
 
-You can pick the reporter by passing the `--reporter` flag:
+You can pick the reporter by passing the `--reporter` flag. This can be specified more than once, though it only makes sense to have a single reporter for console logging (others could log to a file).
 
 ```
 lage build --reporter json
 ```
 
-Available built-in reporters are: `default`, `azureDevops`, `fancy`, `json`, `npmLog`, `verboseFileLog` (or `vfl`), and `profile`. By default the log messages are formatted with the `default` reporter. The `profile` reporter is typically activated with the `--profile` option.
+Available reporters:
+
+<!-- prettier-ignore -->
+| Name | Internal class | Description |
+| ---- | ----- | ----------- |
+| `default`/not specified | `BasicReporter` or `LogReporter` | Usually if running in an interactive terminal, shows progress but not the names of currently running targets (unless progress is disabled or verbose or grouped are enabled). Otherwise, uses `npmLog`. |
+| `fancy` | `ProgressReporter` | Shows progress including the names of currently running targets, but is slower. This was the default in v2 prior to 2.14.16. |
+| `npmLog` (`old`) | `LogReporter` | This is the reporter from lage v1. It logs tasks without progress info. |
+| `azureDevops` (`adoLog`) | `AdoReporter` | Logs tasks  |
+| `json` | `JsonReporter` | Write logs to the console in JSON format |
+| `verboseFileLog` (`vfl`) | `VerboseFileLogReporter` | Writes to a file specified with `--log-file` |
+| `profile` | `ChromeTraceEventsReporter` | Writes a Chrome dev tools profile file. Typically enabled with `--profile` (use `--profile=filename` to customize the name). |
 
 #### Custom reporters
 
 You can also create and use your own custom reporters. Define them in your `lage.config.js`:
 
 ```javascript
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   reporters: {
     myReporter: "./reporters/my-custom-reporter.js"
   }
 };
+module.exports = config;
 ```
 
 The passed-in javascript file must be from a proper ESM module or `.mjs` file.

--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -9,11 +9,21 @@ Create a `lage.config.js` file at the workspace root and place all your configur
 A short example:
 
 ```js title="/lage.config.js"
-/** @type {import("lage").ConfigOptions} */
+/** @type {import("lage").ConfigFileOptions} */
 const config = {
   pipeline: {
     build: ["^build"],
     test: ["build"]
+  },
+  // Update these according to your repo's build setup
+  cacheOptions: {
+    // Generated files in each package that will be saved into the cache
+    // (relative to package root; folders must end with **/*)
+    outputGlob: ["lib/**/*"],
+    // Changes to any of these files/globs will invalidate the cache (relative to repo root;
+    // folders must end with **/*). This should include your lock file and any other repo-wide
+    // configs or scripts that are outside a package but could invalidate previous output.
+    environmentGlob: ["package.json", "yarn.lock", "lage.config.js"]
   }
 };
 module.exports = config;
@@ -32,7 +42,7 @@ This example demonstrates many of the available options, including some advanced
 ```js twoslash title="/lage.config.js"
 /// <reference types="node" />
 // ---cut---
-/** @type {import("lage").ConfigOptions} */
+/** @type {import("lage").ConfigFileOptions} */
 const config = {
   pipeline: {
     build: ["^build"],

--- a/packages/cli/src/commands/init/action.ts
+++ b/packages/cli/src/commands/init/action.ts
@@ -1,50 +1,67 @@
 /* eslint-disable no-console -- logger doesn't work in this context */
 import { readConfigFile } from "@lage-run/config";
+import { getPackageInfo, getWorkspaceManagerAndRoot, type WorkspaceManager } from "workspace-tools";
 import fs from "fs";
 import path from "path";
 import execa from "execa";
 
-type WorkspaceManager = "rush" | "pnpm" | "yarn" | "npm";
-
 export async function initAction(): Promise<void> {
   const cwd = process.cwd();
 
-  const config = await readConfigFile(cwd);
+  const managerAndRoot = getWorkspaceManagerAndRoot(cwd);
+  if (!managerAndRoot) {
+    console.error("lage only works with workspaces - make sure you are using yarn workspaces, npm workspaces, pnpm workspaces, or rush");
+    process.exitCode = 1;
+    return;
+  }
+
+  const { manager: workspaceManager, root } = managerAndRoot;
+  const config = await readConfigFile(root);
   if (config) {
-    console.error("lage is already initialized in this workspace");
+    console.error("lage is already initialized in this repo");
     process.exitCode = 1;
     return;
   }
 
   console.info("Installing lage and creating a default configuration file");
 
-  let workspaceManager: WorkspaceManager = "yarn";
+  const isMetaManager = workspaceManager === "rush" || workspaceManager === "lerna";
+  const npmClientLine = isMetaManager ? "" : `npmClient: "${workspaceManager}",`;
+  const lockFile = isMetaManager
+    ? ""
+    : workspaceManager === "yarn"
+      ? "yarn.lock"
+      : workspaceManager === "pnpm"
+        ? "pnpm-lock.yaml"
+        : "package-lock.json";
 
-  try {
-    workspaceManager = whichWorkspaceManager(cwd);
-  } catch (e) {
-    console.error(
-      "lage requires you to be using a workspace - make sure you are using yarn workspaces, npm workspaces, pnpm workspaces, or rush"
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  const pipeline = {
+  const configContent = `// @ts-check
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
+  // Define your tasks and their dependencies here
+  pipeline: {
     build: ["^build"],
     test: ["build"],
     lint: [],
-  };
+  },
+  ${npmClientLine}
+  // Update these according to your repo's build setup
+  cacheOptions: {
+    // Generated files in each package that will be saved into the cache
+    // (relative to package root; folders must end with **/*)
+    outputGlob: ["lib/**/*"],
+    // Changes to any of these files/globs will invalidate the cache (relative to repo root;
+    // folders must end with **/*). This should include your lock file and any other repo-wide
+    // configs or scripts that are outside a package but could invalidate previous output.
+    environmentGlob: ${JSON.stringify(["package.json", lockFile, "lage.config.js"].filter(Boolean))},
+  },
+};
+module.exports = config;
+`;
 
-  const lageConfig = {
-    pipeline,
-    npmClient: workspaceManager === "yarn" ? "yarn" : "npm",
-  };
+  fs.writeFileSync(path.join(root, "lage.config.js"), configContent);
 
-  const lageConfigFile = path.join(cwd, "lage.config.js");
-  fs.writeFileSync(lageConfigFile, "module.exports = " + JSON.stringify(lageConfig, null, 2) + ";");
-
-  await installLage(cwd, workspaceManager, pipeline);
+  await installLage(root, workspaceManager, ["build", "test", "lint"]);
 
   console.info(`Lage is initialized! You can now run: ${getBuildCommand(workspaceManager)}`);
 }
@@ -57,39 +74,16 @@ function getBuildCommand(workspaceManager: WorkspaceManager) {
     case "pnpm":
       return "pnpm run lage build";
 
-    case "rush":
-    case "npm":
+    default:
       return "npm run lage build";
   }
 }
 
-function whichWorkspaceManager(cwd: string) {
-  const packageJson = readPackageJson(cwd);
-
-  if (fs.existsSync(path.join(cwd, "rush.json"))) {
-    return "rush";
-  }
-
-  if (fs.existsSync(path.join(cwd, "yarn.lock")) && packageJson.workspaces) {
-    return "yarn";
-  }
-
-  if (fs.existsSync(path.join(cwd, "pnpm-workspace.yaml"))) {
-    return "pnpm";
-  }
-
-  if (fs.existsSync(path.join(cwd, "package-lock.json")) && packageJson.workspaces) {
-    return "npm";
-  }
-
-  throw new Error("not a workspace");
-}
-
-async function installLage(cwd: string, workspaceManager: WorkspaceManager, pipeline: Record<string, string[]>) {
+async function installLage(cwd: string, workspaceManager: WorkspaceManager, scripts: string[]) {
   const lageVersion = getLageVersion();
   const packageJson = readPackageJson(cwd);
   packageJson.scripts ??= {};
-  for (const script of Object.keys(pipeline)) {
+  for (const script of scripts) {
     packageJson.scripts[script] = `lage ${script}`;
   }
 
@@ -107,11 +101,12 @@ async function installLage(cwd: string, workspaceManager: WorkspaceManager, pipe
 }
 
 function getLageVersion() {
-  const lagePackageJsonFile = require.resolve("../../package.json", {
-    paths: [__dirname],
-  });
-  const lagePackageJson = JSON.parse(fs.readFileSync(lagePackageJsonFile, "utf-8"));
-  return lagePackageJson.version;
+  // NOTE: this would give the wrong version prior to bundling of the `lage` package
+  const lagePackageInfo = getPackageInfo(__dirname);
+  if (!lagePackageInfo) {
+    throw new Error("Could not find lage package root");
+  }
+  return lagePackageInfo.version;
 }
 
 function writePackageJson(cwd: string, packageJson: any) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,3 @@
-export type { CacheOptions } from "@lage-run/config";
-export type { ConfigOptions } from "@lage-run/config";
-export type { Priority } from "@lage-run/config";
-export type { PipelineDefinition } from "@lage-run/config";
-export type { LoggerOptions } from "@lage-run/config";
+export type { CacheOptions, ConfigOptions, ConfigFileOptions, Priority, PipelineDefinition, LoggerOptions } from "@lage-run/config";
 export type { TargetRunnerPickerOptions } from "@lage-run/runners";
-export type { Target } from "@lage-run/target-graph";
-export type { TargetConfig } from "@lage-run/target-graph";
+export type { Target, TargetConfig } from "@lage-run/target-graph";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,7 +3,7 @@ export { getConcurrency } from "./getConcurrency.js";
 export { getMaxWorkersPerTask, getMaxWorkersPerTaskFromOptions } from "./getMaxWorkersPerTask.js";
 export { readConfigFile } from "./readConfigFile.js";
 export type { PipelineDefinition } from "./types/PipelineDefinition.js";
-export type { ConfigOptions } from "./types/ConfigOptions.js";
+export type { ConfigOptions, ConfigFileOptions } from "./types/ConfigOptions.js";
 export type { CacheOptions } from "./types/CacheOptions.js";
 export type { AzureCredentialName } from "./types/CacheOptions.js";
 export type { LoggerOptions } from "./types/LoggerOptions.js";

--- a/packages/config/src/types/ConfigOptions.ts
+++ b/packages/config/src/types/ConfigOptions.ts
@@ -6,6 +6,10 @@ import type { TargetRunnerPickerOptions } from "@lage-run/runners";
 
 export type NpmClient = "npm" | "yarn" | "pnpm";
 
+/**
+ * lage options including defaults (after the config file is read).
+ * For the object in a config file, use `ConfigFileOptions` instead.
+ */
 export interface ConfigOptions {
   /**
    * Defines the task pipeline (task names, dependencies, and optional custom target configuration).
@@ -92,3 +96,9 @@ export interface ConfigOptions {
    */
   reporters: Record<string, string>;
 }
+
+/** Options for a lage configuration file */
+export type ConfigFileOptions = Partial<Omit<ConfigOptions, "cacheOptions">> & {
+  /** Backfill cache options */
+  cacheOptions?: Partial<CacheOptions>;
+};

--- a/packages/lage/CHANGELOG.md
+++ b/packages/lage/CHANGELOG.md
@@ -67,6 +67,7 @@ Thu, 15 Jan 2026 23:24:00 GMT
 - `@lage-run/cli`
   - Update dependency workspace-tools to v0.40.0 (renovate@whitesourcesoftware.com)
   - Replace ProgressReporter as the default with a less fancy implementation (crhaglun@microsoft.com)
+    - This [improves performance](https://github.com/microsoft/lage/pull/967), but could be considered a **BREAKING CHANGE** if you'd like to see the package name which is currently being bundled. To restore the old behavior, use `--reporter=fancy`.
   - Add lint rule for no-floating-promises and fix several places (nemanjatesic@microsoft.com)
 - `@lage-run/config`
   - Update dependency workspace-tools to v0.40.0 (renovate@whitesourcesoftware.com)

--- a/packages/lage/README.md
+++ b/packages/lage/README.md
@@ -47,15 +47,27 @@ Next, add scripts inside the workspace root `package.json` to run `lage`. For ex
 }
 ```
 
-To specify that `test` depends on `build`, create a file `lage.config.js` at the repo root and add the following:
+To specify that `test` depends on `build`, create a file `lage.config.js` at the repo root and add the following. Also fill in the required `cacheOptions`.
 
 ```js
-module.exports = {
+/** @type {import("lage").ConfigFileOptions} */
+const config = {
   pipeline: {
     build: ["^build"],
     test: ["build"],
   },
+  // Update these according to your repo's build setup
+  cacheOptions: {
+    // Generated files in each package that will be saved into the cache
+    // (relative to package root; folders must end with **/*)
+    outputGlob: ["lib/**/*"],
+    // Changes to any of these files/globs will invalidate the cache (relative to repo root;
+    // folders must end with **/*). This should include your lock file and any other repo-wide
+    // configs or scripts that are outside a package but could invalidate previous output.
+    environmentGlob: ["package.json", "yarn.lock", "lage.config.js"],
+  },
 };
+module.exports = config;
 ```
 
 (You can find more details about this syntax in the [pipelines tutorial](https://microsoft.github.io/lage/docs/Tutorial/pipeline).)


### PR DESCRIPTION
Update the docs to list all the reporters and explain what they do.

Add a `ConfigFileOptions` type which properly documents what's required or optional. (For now, all of `cacheOptions` is optional, even though in reality the behavior is kind of nonsense without `outputGlob` and `environmentGlob`.)

Update the config examples in the docs to use the new type and include the required `cacheOptions`. Same with the config generated by `lage init`.