### PR TITLE
Docs dep fixes

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "@mdx-js/react": "^3.1.0",
     "@tailwindcss/postcss": "^4.0.17",
     "@tsconfig/docusaurus": "^2.0.3",
+    "@types/node": "^18.0.0",
     "@types/react": "^18.0.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.0.1",
@@ -29,7 +30,10 @@
   },
   "resolutions": {
     "@algolia/autocomplete-js@npm:^1.8.2": "1.17.9",
-    "@cmfcmf/docusaurus-search-local@npm:1.2.0/cheerio": "1.0.0-rc.12"
+    "@cmfcmf/docusaurus-search-local@npm:1.2.0/cheerio": "1.0.0-rc.12",
+    "lodash-es@npm:4.17.21": "^4.17.23",
+    "@types/node@npm:*": "^18.0.0",
+    "@types/react@npm:*": "^18.0.0"
   },
   "rationale": {
     "dependencies": {
@@ -38,7 +42,8 @@
     },
     "resolutions": {
       "@algolia/autocomplete-js@npm:^1.8.2": "prevent pulling in tree that introduces versions inconsistent with @docsearch/react's old pinned deps",
-      "@cmfcmf/docusaurus-search-local@npm:1.2.0/cheerio": "docusaurus depends on a specific file path that was removed after this version"
+      "@cmfcmf/docusaurus-search-local@npm:1.2.0/cheerio": "docusaurus depends on a specific file path that was removed after this version",
+      "lodash-es@npm:4.17.21": "unpin to fix security issue"
     }
   },
   "browserslist": {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3179,6 +3179,7 @@ __metadata:
     "@mdx-js/react": "npm:^3.1.0"
     "@tailwindcss/postcss": "npm:^4.0.17"
     "@tsconfig/docusaurus": "npm:^2.0.3"
+    "@types/node": "npm:^18.0.0"
     "@types/react": "npm:^18.0.0"
     prism-react-renderer: "npm:^2.4.1"
     react: "npm:^18.0.1"
@@ -4283,19 +4284,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 25.2.0
-  resolution: "@types/node@npm:25.2.0"
-  dependencies:
-    undici-types: "npm:~7.16.0"
-  checksum: 10c0/89559ea0de5c8c2da051b384f2cd3161012446816e05d18841838f814e57eb1865f000622e903f08d14f5242736063ed4003a4a359730fdd367e35e2122a8fce
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^17.0.5":
   version: 17.0.45
   resolution: "@types/node@npm:17.0.45"
   checksum: 10c0/0db377133d709b33a47892581a21a41cd7958f22723a3cc6c71d55ac018121382de42fbfc7970d5ae3e7819dbe5f40e1c6a5174aedf7e7964e9cb8fa72b580b0
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.0.0":
+  version: 18.19.130
+  resolution: "@types/node@npm:18.19.130"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/22ba2bc9f8863101a7e90a56aaeba1eb3ebdc51e847cef4a6d188967ab1acbce9b4f92251372fd0329ecb924bbf610509e122c3dfe346c04dbad04013d4ad7d0
   languageName: node
   linkType: hard
 
@@ -4356,15 +4357,6 @@ __metadata:
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
   checksum: 10c0/1f7eee61981d2f807fa01a34a0ef98ebc0774023832b6611a69c7f28fdff01de5a38cabf399f32e376bf8099dcb7afaf724775bea9d38870224492bea4cb5737
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*":
-  version: 19.2.10
-  resolution: "@types/react@npm:19.2.10"
-  dependencies:
-    csstype: "npm:^3.2.2"
-  checksum: 10c0/17b96203a79ad3fa3cee8f1f1f324b93f005bc125755e29ac149402807275feaf3f00a4e65b8405f633923ac993da5737fd9800d27ee49911f3ed51dc27478f9
   languageName: node
   linkType: hard
 
@@ -9095,14 +9087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
-  languageName: node
-  linkType: hard
-
-"lodash-es@npm:^4.17.21":
+"lodash-es@npm:^4.17.21, lodash-es@npm:^4.17.23":
   version: 4.17.23
   resolution: "lodash-es@npm:4.17.23"
   checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
@@ -13491,10 +13476,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.16.0":
-  version: 7.16.0
-  resolution: "undici-types@npm:7.16.0"
-  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unpin `lodash-es` in docs package.json to fix security issue.

Add `@types/node@18` in docs, and add a resolution to point `@types/node@*` to 18.