### PR TITLE
tsconfig and eslint updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-**/tests/
-**/fixtures/
-**/__fixtures__/
-**/__tests__/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,19 +1,14 @@
+// @ts-check
 const path = require("path");
 
 // This is only used to enable eslint in the editor
-module.exports = {
-  ...require("./scripts/config/eslintrc"),
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  extends: path.join(__dirname, "scripts/config/eslintrc.js"),
   parserOptions: {
-    project: path.join(__dirname, "./scripts/config/tsconfig.eslint.json"),
+    project: path.join(__dirname, "scripts/config/tsconfig.eslint.json"),
   },
-  ignorePatterns: [
-    "**/*.js",
-    "**/__fixtures__",
-    "**/hasher/src/__tests__",
-    "docs",
-    "packages/*/scripts",
-    "packages/*/src/gen",
-    "lib/",
-    "dist/",
-  ],
 };
+
+module.exports = config;

--- a/change/change-39c005b7-49de-477b-9edc-fa54b4d367a1.json
+++ b/change/change-39c005b7-49de-477b-9edc-fa54b4d367a1.json
@@ -1,0 +1,109 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/cache-github-actions",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/cache",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/format-hrtime",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/globby",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/hasher",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/logger",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/reporters",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/rpc",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/runners",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/scheduler-types",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/scheduler",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/target-graph",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update tsconfig extends path (same settings)",
+      "packageName": "@lage-run/worker-threads-pool",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -1,9 +1,13 @@
 // @ts-check
+/** @import { ConfigOptions, CacheOptions } from 'lage' */
 const path = require("path");
 const fastGlob = require("fast-glob");
 
-/** @type {import("lage").ConfigOptions} */
-module.exports = {
+/**
+ * Lage config (the types are slightly incorrect about what's required/optional)
+ * @type {Partial<Omit<ConfigOptions, 'cacheOptions'>> & { cacheOptions?: Partial<CacheOptions> }}
+ */
+const config = {
   pipeline: {
     "lage#bundle": ["^^transpile", "types"],
     types: {
@@ -12,7 +16,7 @@ module.exports = {
         worker: path.join(__dirname, "scripts/worker/types.js"),
       },
       dependsOn: ["^types"],
-      outputs: ["lib/**/*.d.ts"],
+      outputs: ["lib/**/*.d.{ts,mts}"],
     },
     isolatedTypes: {
       type: "worker",
@@ -20,14 +24,14 @@ module.exports = {
         worker: path.join(__dirname, "scripts/worker/types.js"),
       },
       dependsOn: [],
-      outputs: ["lib/**/*.d.ts"],
+      outputs: ["lib/**/*.d.{ts,mts}"],
     },
     transpile: {
       type: "worker",
       options: {
         worker: path.join(__dirname, "scripts/worker/transpile.js"),
       },
-      outputs: ["lib/**/*.js"],
+      outputs: ["lib/**/*.{js,map}"],
     },
     test: {
       type: "worker",
@@ -84,7 +88,6 @@ module.exports = {
       "beachball.config.js",
       "lage.config.js",
       "package.json",
-      "packages/tsconfig.lage2.json",
       "scripts/**/*",
       "yarn.lock",
     ],
@@ -92,3 +95,5 @@ module.exports = {
     outputGlob: ["lib/**/*", "dist/**/*", ".docusaurus/**/*", "build/**/*"],
   },
 };
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     }
   },
   "lint-staged": {
-    "!(*test).{ts,js}": "eslint --fix",
-    "*.{ts,json,md}": "prettier --write"
+    "*": "prettier --write"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/packages/cache-github-actions/tsconfig.json
+++ b/packages/cache-github-actions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },
-  "include": ["src/**/*.ts", "src/index.ts"]
+  "include": ["src"]
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/format-hrtime/tsconfig.json
+++ b/packages/format-hrtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/globby/tsconfig.json
+++ b/packages/globby/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",
     "emitDeclarationOnly": true,
     "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2020"]
+    "moduleResolution": "Node16"
   },
-  "include": ["src/index.mts"],
-  "exclude": ["lib/**/*.mts"]
+  "include": ["src/index.mts"]
 }

--- a/packages/hasher/tsconfig.json
+++ b/packages/hasher/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/monorepo-fixture/tsconfig.json
+++ b/packages/monorepo-fixture/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/reporters/tsconfig.json
+++ b/packages/reporters/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./lib",
-    "jsx": "react"
+    "outDir": "./lib"
   },
   "include": ["src"]
 }

--- a/packages/rpc/tsconfig.json
+++ b/packages/rpc/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/runners/tsconfig.json
+++ b/packages/runners/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/scheduler-types/tsconfig.json
+++ b/packages/scheduler-types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/scheduler/tsconfig.json
+++ b/packages/scheduler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/target-graph/tsconfig.json
+++ b/packages/target-graph/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/packages/tsconfig.lage2.json
+++ b/packages/tsconfig.lage2.json
@@ -1,4 +1,0 @@
-// References to this old config path will be removed in a later PR
-{
-  "extends": "../scripts/config/tsconfig.base.json"
-}

--- a/packages/worker-threads-pool/tsconfig.json
+++ b/packages/worker-threads-pool/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.lage2.json",
+  "extends": "@lage-run/monorepo-scripts/config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib"
   },

--- a/scripts/commands/transpile.js
+++ b/scripts/commands/transpile.js
@@ -12,4 +12,7 @@ const { getPackageInfo } = require("workspace-tools");
   await transpileWorker({
     target: { packageName: packageJson.name, cwd: packageRoot },
   });
-})();
+})().catch((error) => {
+  process.exitCode = 1;
+  console.error(error);
+});

--- a/scripts/config/eslintrc.js
+++ b/scripts/config/eslintrc.js
@@ -1,11 +1,36 @@
 /** @type {import('eslint').Linter.Config} */
 const config = {
+  root: true,
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.json",
+  },
+  env: {
+    node: true,
+    es2020: true,
+    jest: true,
+  },
   plugins: ["@typescript-eslint", "file-extension-in-import-ts"],
   reportUnusedDisableDirectives: true,
+  ignorePatterns: [
+    // These might be relative to either a package or the repo root depending on whether eslint
+    // is being run via the lint worker or in the editor
+    "**/__fixtures__",
+    "**/fixtures",
+    "/*.js",
+    "docs",
+    "packages/*/scripts",
+    "packages/*/src/gen",
+    "packages/*.js",
+    "**/lib",
+    "**/dist",
+    "**/gen",
+    "**/node_modules",
+    "/node_modules",
+  ],
   rules: {
-    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
     "@typescript-eslint/consistent-type-exports": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
@@ -16,10 +41,27 @@ const config = {
     "file-extension-in-import-ts/file-extension-in-import-ts": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        args: "after-used",
+        ignoreRestSiblings: true,
+        // Follow the typescript pattern of ignoring things starting with _
+        argsIgnorePattern: "^_",
+        destructuredArrayIgnorePattern: "^_",
+      },
+    ],
   },
-  parserOptions: {
-    project: "./tsconfig.json",
-  },
-  root: true,
+  overrides: [
+    {
+      files: ["**/*.{js,cjs,mjs}"],
+      rules: {
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/no-require-imports": "off",
+        "no-console": "off",
+      },
+    },
+  ],
 };
+
 module.exports = config;

--- a/scripts/config/jest.config.js
+++ b/scripts/config/jest.config.js
@@ -37,7 +37,7 @@ const config = {
   watchPathIgnorePatterns: ["/node_modules/"],
   moduleNameMapper,
   ...(process.env.LAGE_PACKAGE_NAME && { maxWorkers: 1 }),
-  testTimeout: process.platform !== "linux" ? 10000 : 5000,
+  testTimeout: process.platform !== "linux" ? 15000 : 8000,
   setupFilesAfterEnv: [path.join(__dirname, "jest-setup-after-env.js")],
 };
 module.exports = config;

--- a/scripts/config/tsconfig.base.json
+++ b/scripts/config/tsconfig.base.json
@@ -7,6 +7,7 @@
     "isolatedModules": true,
     "lib": ["ES2020"],
     "allowJs": true,
+    "checkJs": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/scripts/config/tsconfig.eslint.json
+++ b/scripts/config/tsconfig.eslint.json
@@ -1,5 +1,6 @@
 {
   // tsconfig used only for eslint in the editor
-  "extends": "../../packages/tsconfig.lage2.json",
-  "include": ["../../packages/*/src"]
+  "extends": "./tsconfig.base.json",
+  "include": ["../../packages/*/src", "../../scripts"],
+  "exclude": ["**/node_modules"]
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   "bin": "bin/monorepo-scripts.js",
   "scripts": {
     "build": "yarn types",
+    "lint": "monorepo-scripts lint",
     "types": "tsc"
   },
   "dependencies": {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "./config/tsconfig.base.json",
   "compilerOptions": {
-    "checkJs": true,
     "noEmit": true,
     "paths": {
       // Special path mappings to avoid relative references in individual files

--- a/scripts/worker/lint.js
+++ b/scripts/worker/lint.js
@@ -32,7 +32,7 @@ async function lint(data) {
     cwd: target.cwd,
   });
 
-  const files = ["src/**/*.ts", "src/*.ts"];
+  const files = target.packageName === "@lage-run/monorepo-scripts" ? ["."] : ["src"];
   const results = await eslint.lintFiles(files);
   const formatter = await eslint.loadFormatter("stylish");
   const resultText = await formatter.format(results);


### PR DESCRIPTION
- Remove `packages/tsconfig.lage2.json` and extend from `@lage-run/monorepo-scripts/config/tsconfig.base.json` instead
- Update the eslint config to not ignore tests, and centralize ignores
- Lint the scripts package (add appropriate overrides for js files)
- Don't run eslint in lint-staged. It's hard to get the include/ignore config right for this purpose and adds limited value.