### PR TITLE
Simplify scripts and improve internal types

### DIFF
--- a/change/change-a1057346-1fa6-441e-b15a-c3a9963c7e7f.json
+++ b/change/change-a1057346-1fa6-441e-b15a-c3a9963c7e7f.json
@@ -1,0 +1,102 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/cache-github-actions",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/cache",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/format-hrtime",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/hasher",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/logger",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/reporters",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/rpc",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/runners",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/scheduler-types",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/scheduler",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/target-graph",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Update scripts",
+      "packageName": "@lage-run/worker-threads-pool",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -10,7 +10,7 @@ const fastGlob = require("fast-glob");
 const config = {
   pipeline: {
     "lage#bundle": ["^^transpile", "types"],
-    // Note that transpile/types/bundle are overridden later for the @lage-run/globby package
+    // Note that transpile/types are overridden later for the @lage-run/globby package
     types: {
       type: "worker",
       options: {
@@ -37,7 +37,7 @@ const config = {
     test: {
       type: "worker",
       weight: (target) => {
-        return fastGlob.sync("tests/**/*.test.ts", { cwd: target.cwd }).length;
+        return fastGlob.sync("src/__tests__/**/*.test.ts", { cwd: target.cwd }).length;
       },
       options: {
         worker: path.join(__dirname, "scripts/worker/jest.js"),

--- a/packages/cache-github-actions/package.json
+++ b/packages/cache-github-actions/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
+    "types": "yarn run -T tsc",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,8 +17,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/format-hrtime/package.json
+++ b/packages/format-hrtime/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {

--- a/packages/monorepo-fixture/package.json
+++ b/packages/monorepo-fixture/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
+    "types": "yarn run -T tsc",
     "lint": "monorepo-scripts lint"
   },
   "devDependencies": {

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
+    "types": "yarn run -T tsc",
     "lint": "buf lint",
     "generate": "buf generate"
   },

--- a/packages/runners/package.json
+++ b/packages/runners/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/scheduler-types/package.json
+++ b/packages/scheduler-types/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
+    "types": "yarn run -T tsc",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/target-graph/package.json
+++ b/packages/target-graph/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/packages/worker-threads-pool/package.json
+++ b/packages/worker-threads-pool/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "yarn types && yarn transpile",
     "transpile": "monorepo-scripts transpile",
-    "types": "monorepo-scripts tsc",
-    "test": "monorepo-scripts jest",
+    "types": "yarn run -T tsc",
+    "test": "yarn run -T jest",
     "lint": "monorepo-scripts lint"
   },
   "dependencies": {

--- a/scripts/bin/monorepo-scripts.js
+++ b/scripts/bin/monorepo-scripts.js
@@ -2,62 +2,18 @@
 const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
-const { findPackageRoot, findProjectRoot } = require("workspace-tools");
-
-const projectRoot = findProjectRoot(process.cwd());
 
 const [command, ...spawnArgs] = process.argv.slice(2);
-const spawnCommand = findCommand(command);
 
-let cp;
-if (spawnCommand.endsWith(".js")) {
-  console.log(`Running ${command} as: node ${spawnCommand} ${spawnArgs.join(" ")}`);
-  cp = spawn(process.execPath, [spawnCommand, ...spawnArgs], {
+const commandPath = path.resolve(__dirname, `../commands/${command}.js`);
+if (fs.existsSync(commandPath)) {
+  const cp = spawn(process.execPath, [commandPath, ...spawnArgs], {
     stdio: "inherit",
+  });
+  cp.on("exit", (code) => {
+    process.exitCode = code || 0;
   });
 } else {
-  console.log(`Running ${command} as: ${spawnCommand} ${spawnArgs.join(" ")}`);
-  cp = spawn(spawnCommand, spawnArgs, {
-    stdio: "inherit",
-    shell: true,
-  });
-}
-
-cp.on("exit", (code) => {
-  process.exitCode = code || 0;
-});
-
-function findCommand(/** @type {string} */ command) {
-  // Try to find a command under monorepo-scripts/commands
-  const commandPath = path.resolve(__dirname, "../commands", `${command}.js`);
-  if (fs.existsSync(commandPath)) {
-    return commandPath;
-  }
-
-  // Try to find command in package's own node_modules, then scripts/node_modules, then root node_modules
-  for (const basePath of [findPackageRoot(process.cwd()), findPackageRoot(__dirname), projectRoot]) {
-    if (basePath) {
-      const binPath = getBinPath(basePath, command);
-      if (binPath) {
-        return binPath;
-      }
-    }
-  }
-
-  console.error("Could not find command: " + command);
+  console.error(`Command not found (under scripts/commands): ${command}`);
   process.exit(1);
-}
-
-function getBinPath(/** @type {string | undefined} */ packagePath, /** @type {string | undefined} */ command) {
-  if (!packagePath || !command) {
-    return undefined;
-  }
-
-  const binPath = path.join(packagePath, "node_modules/.bin", process.platform === "win32" ? `${command}.cmd` : command);
-
-  if (fs.existsSync(binPath)) {
-    return binPath;
-  }
-
-  return undefined;
 }

--- a/scripts/commands/lint.js
+++ b/scripts/commands/lint.js
@@ -9,7 +9,7 @@ const lintWorker = require("../worker/lint");
   }
 
   return lintWorker({
-    target: { packageName: packageInfo.name, cwd: path.dirname(packageInfo.packageJsonPath), task: "lint" },
+    target: { packageName: packageInfo.name, cwd: path.dirname(packageInfo.packageJsonPath) },
     taskArgs: process.argv.slice(2),
   });
 })().catch((error) => {

--- a/scripts/commands/transpile.js
+++ b/scripts/commands/transpile.js
@@ -11,6 +11,8 @@ const { getPackageInfo } = require("workspace-tools");
 
   await transpileWorker({
     target: { packageName: packageJson.name, cwd: packageRoot },
+    // no CLI args are respected for the swc wrapper
+    taskArgs: [],
   });
 })().catch((error) => {
   process.exitCode = 1;

--- a/scripts/config/jest.config.js
+++ b/scripts/config/jest.config.js
@@ -27,6 +27,7 @@ moduleNameMapper["^(\\.{1,2}/.*)\\.js$"] = "$1";
 /** @type {import("jest").Config} */
 const config = {
   clearMocks: true,
+  passWithNoTests: true,
   extensionsToTreatAsEsm: [".ts"],
   testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
   testPathIgnorePatterns: ["/node_modules/"],

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -4,11 +4,7 @@
     "emitDeclarationOnly": false,
     "noEmit": true,
     "paths": {
-      // Special path mappings to avoid relative references in individual files
-      "@/TargetGraph": ["../packages/target-graph/src/index.ts"],
-      "@/TargetRunner": ["../packages/runners/src/types/TargetRunner.ts"],
-      "@/WorkerRunner": ["../packages/runners/src/WorkerRunner.ts"],
-      // Required for above types to resolve @lage-run/target-graph if not built yet
+      // Required for resolution of @lage-run/target-graph by references in types.ts if not built yet
       "@lage-run/target-graph": ["../packages/target-graph/src/index.ts"]
     }
   },

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,0 +1,16 @@
+import type { WorkerRunnerOptions as BaseWorkerRunnerOptions } from "../packages/runners/src/WorkerRunner.js";
+import type { TargetRunnerOptions } from "../packages/runners/src/types/TargetRunner.js";
+import type { Target } from "../packages/target-graph/src/index.js";
+
+/**
+ * Actual complete worker runner options.
+ * TODO: a type like this should be exported from the runners package and used elsewhere...
+ */
+export type WorkerRunnerOptions = BaseWorkerRunnerOptions & TargetRunnerOptions;
+
+/**
+ * Subset of options needed by the worker functions that are reused by `commands/*.js`.
+ */
+export type BasicWorkerRunnerOptions = Pick<WorkerRunnerOptions, "taskArgs"> & {
+  target: Pick<Target, "packageName" | "cwd">;
+};

--- a/scripts/worker/depcheck.js
+++ b/scripts/worker/depcheck.js
@@ -1,4 +1,4 @@
-/** @import { TargetRunnerOptions } from "@/TargetRunner" */
+/** @import { WorkerRunnerOptions } from "../types.js" */
 const depcheck = require("depcheck");
 const path = require("path");
 const { findProjectRoot } = require("workspace-tools");
@@ -17,7 +17,7 @@ const extraIgnoreMatches = {
 };
 
 /**
- * @param {TargetRunnerOptions} data
+ * @param {WorkerRunnerOptions} data
  */
 async function depcheckWorker({ target }) {
   if (!target.packageName) return;

--- a/scripts/worker/jest.js
+++ b/scripts/worker/jest.js
@@ -1,17 +1,30 @@
-/** @import { TargetRunnerOptions } from "@/TargetRunner" */
+/** @import { WorkerRunnerOptions } from "../types.js" */
+const fs = require("fs");
 const { runCLI } = require("jest");
+const path = require("path");
 
 /**
- * @param {TargetRunnerOptions} data
+ * This worker is used for `lage run test`, in place of the per-package `test` script.
+ *
+ * Note that if running `test` for an individual package, it will use that package's `test` script instead
+ * (typically `yarn run -T jest`).
+ *
+ * @param {WorkerRunnerOptions} data
  */
 async function jest({ target, weight }) {
+  if (!fs.existsSync(path.join(target.cwd, "jest.config.js"))) {
+    console.log("No jest.config.js found - skipping");
+    return;
+  }
+
   console.log(`Running ${target.id}, maxWorkers: ${weight}`);
 
   const { results } = await runCLI(
     {
+      // Instead of adding more options here, prefer adding them to jest.config.js unless they're truly
+      // specific to running in this lage worker context.
       maxWorkers: weight,
       rootDir: target.cwd,
-      passWithNoTests: true,
       verbose: true,
       _: [],
       $0: "",

--- a/scripts/worker/transpile.js
+++ b/scripts/worker/transpile.js
@@ -1,4 +1,4 @@
-/** @import { Target } from "@/TargetGraph" */
+/** @import { BasicWorkerRunnerOptions } from "../types.js" */
 const fs = require("fs");
 const path = require("path");
 const fsPromises = require("fs/promises");
@@ -8,9 +8,13 @@ const { findProjectRoot } = require("workspace-tools");
 const root = findProjectRoot(process.cwd());
 
 /**
- * The type here should be `WorkerRunnerOptions & TargetRunnerOptions`, but we only specify the
- * needed properties so the runner function can be reused by commands/transpile.js.
- * @param {{ target: Pick<Target, 'packageName' | 'cwd'> }} data
+ * This worker is used for `lage run transpile`, in place of the per-package `transpile` script
+ * (except for `@lage-run/globby`, which per lage.config.js uses its custom `transpile` script).
+ *
+ * Since this worker function has some extra logic to use swc, it's reused by the per-package `transpile` script
+ * (`monorepo-scripts transpile` which runs commands/transpile.js) to avoid duplication.
+ *
+ * @param {BasicWorkerRunnerOptions} data
  */
 async function transpile({ target }) {
   if (target.packageName?.includes("docs")) {
@@ -20,6 +24,7 @@ async function transpile({ target }) {
   // Start from the src directory to avoid unnecessary transpilation of scripts etc
   const srcDir = path.join(target.cwd, "src");
   if (!fs.existsSync(srcDir)) {
+    console.log("No src directory found - skipping");
     return;
   }
 


### PR DESCRIPTION
Update package.json `types` and `test` scripts to run the relevant binaries directly (`yarn run -T tsc/jest`), rather than via `monorepo-scripts`. This removes an extra layer of command resolution.

Add a new file `scripts/types.ts` which re-exports the full types for the worker functions, instead of the `@/Whatever` aliases I added previously.

Add comments on each worker function explaining when it is and is not used.