### PR TITLE
Bundle the runner files

### DIFF
--- a/change/change-44af009f-b251-4b1a-812e-73910ea14b02.json
+++ b/change/change-44af009f-b251-4b1a-812e-73910ea14b02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Bundle the runner files",
+      "packageName": "lage",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Instead of manually copying the runner files, it's safer to include them as esbuild bundle entries, in case they reference any other files in the future.