### PR TITLE
Test and debug config updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ profile*.json
 !.yarn/releases/
 temp
 *.tgz
+.claude/settings.local.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,9 +30,14 @@
       "request": "launch",
       "program": "${workspaceRoot}/scripts/debugTests.js",
       "cwd": "${fileDirname}",
-      "args": ["--runInBand", "--watch", "${fileBasename}"],
+      "args": ["${fileBasename}"],
+      "env": {
+        // read by jest config
+        "VS_CODE_DEBUG": "1"
+      },
       "sourceMaps": true,
       "outputCapture": "std",
+      // "runtimeVersion": "20",
       "console": "integratedTerminal"
     },
     {

--- a/lage.config.js
+++ b/lage.config.js
@@ -1,7 +1,20 @@
 // @ts-check
-/** @import { ConfigOptions, CacheOptions, NpmScriptTargetOptions, WorkerTargetOptions } from 'lage' */
+/** @import { ConfigOptions, CacheOptions, NpmScriptTargetOptions, TargetConfig, WorkerTargetOptions } from 'lage' */
+const os = require("os");
 const path = require("path");
 const fastGlob = require("fast-glob");
+
+/** @type {TargetConfig} */
+const baseTestTarget = {
+  type: "worker",
+  weight: (target) => {
+    return fastGlob.sync("src/__tests__/**/*.test.ts", { cwd: target.cwd }).length;
+  },
+  options: /** @satisfies {WorkerTargetOptions} */ ({
+    worker: path.join(__dirname, "scripts/worker/jest.js"),
+  }),
+  dependsOn: ["build"],
+};
 
 /**
  * Lage config (the types are slightly incorrect about what's required/optional)
@@ -34,16 +47,7 @@ const config = {
       }),
       outputs: ["lib/**/*.{js,map}"],
     },
-    test: {
-      type: "worker",
-      weight: (target) => {
-        return fastGlob.sync("src/__tests__/**/*.test.ts", { cwd: target.cwd }).length;
-      },
-      options: /** @satisfies {WorkerTargetOptions} */ ({
-        worker: path.join(__dirname, "scripts/worker/jest.js"),
-      }),
-      dependsOn: ["build"],
-    },
+    test: { ...baseTestTarget },
     build: {
       type: "noop",
       dependsOn: ["transpile", "types"],
@@ -73,8 +77,11 @@ const config = {
       }),
     },
     "@lage-run/e2e-tests#test": {
-      type: "npmScript",
+      ...baseTestTarget,
       dependsOn: ["^^transpile", "lage#bundle"],
+      // This runs last, so give it all available resources
+      weight: os.availableParallelism(),
+      priority: -9999,
     },
   },
   npmClient: "yarn",

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require("@lage-run/monorepo-scripts/config/jest.config.js");
 
 module.exports = {
   ...baseConfig,
-  testTimeout: baseConfig.testTimeout * 2,
+  testTimeout: baseConfig.testTimeout * 3,
 };

--- a/scripts/config/eslintrc.js
+++ b/scripts/config/eslintrc.js
@@ -73,6 +73,27 @@ const config = {
         "no-console": "off",
       },
     },
+    {
+      files: ["**/*.test.ts"],
+      rules: {
+        "no-restricted-properties": [
+          "error",
+          ...["describe", "it", "test"]
+            .map((func) => [
+              { object: func, property: "only", message: "Do not commit .only() tests" },
+              { object: func, property: "skip", message: "Do not commit .skip() tests (disable this rule if needed)" },
+            ])
+            .flat(),
+        ],
+        "no-restricted-syntax": [
+          "error",
+          {
+            message: "Do not commit disabled tests",
+            selector: "CallExpression[callee.name=/^(xdescribe|xit|xtest)$/]",
+          },
+        ],
+      },
+    },
   ],
 };
 

--- a/scripts/config/jest.config.js
+++ b/scripts/config/jest.config.js
@@ -2,8 +2,13 @@ const { findProjectRoot, getPackageInfos } = require("workspace-tools");
 const fs = require("fs");
 const path = require("path");
 
-const root = findProjectRoot(process.cwd()) ?? process.cwd();
-const swcOptions = JSON.parse(fs.readFileSync(path.join(root, ".swcrc"), "utf8"));
+const root = findProjectRoot(process.cwd());
+const swcOptions = {
+  ...JSON.parse(fs.readFileSync(path.join(root, ".swcrc"), "utf8")),
+  // inline sourcemaps are required when debugging in vs code
+  // (this env var is set in launch.json)
+  ...(process.env.VS_CODE_DEBUG && { sourceMaps: "inline" }),
+};
 const packages = getPackageInfos(root);
 
 const moduleNameMapper = /** @type {Record<string, string>} */ ({});
@@ -37,8 +42,9 @@ const config = {
   transformIgnorePatterns: ["/node_modules/", "\\.pnp\\.[^\\/]+$"],
   watchPathIgnorePatterns: ["/node_modules/"],
   moduleNameMapper,
-  ...(process.env.LAGE_PACKAGE_NAME && { maxWorkers: 1 }),
-  testTimeout: process.platform !== "linux" ? 15000 : 8000,
+  testTimeout: process.platform === "win32" ? 15000 : 8000,
   setupFilesAfterEnv: [path.join(__dirname, "jest-setup-after-env.js")],
+  // Don't set maxWorkers based on LAGE_PACKAGE_NAME because that's handled by workers/jest.js
+  // ...(process.env.LAGE_PACKAGE_NAME && { maxWorkers: 1 }),
 };
 module.exports = config;

--- a/scripts/debugTests.js
+++ b/scripts/debugTests.js
@@ -18,6 +18,7 @@ function start() {
     "--rootDir",
     packagePath,
     "--runInBand",
+    "--watch",
     "--testTimeout=999999999",
     ...args,
   ]);


### PR DESCRIPTION
Part of trying to make the tests more reliable... increase e2e test timeouts, ensure e2e tests run last, and increase their parallelism.

Also add eslint rules against `.only()` etc.