### PR TITLE
Minor target graph updates and tests

### DIFF
--- a/change/change-a96d6666-dc87-4136-9071-5bf9220119e5.json
+++ b/change/change-a96d6666-dc87-4136-9071-5bf9220119e5.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update WorkspaceTargetGraphBuilder usage",
+      "packageName": "@lage-run/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "none",
+      "comment": "comment",
+      "packageName": "@lage-run/runners",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "minor",
+      "comment": "Use object params for WorkspaceTargetGraphBuilder signature and update phantom targets check",
+      "packageName": "@lage-run/target-graph",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/run/createTargetGraph.ts
+++ b/packages/cli/src/commands/run/createTargetGraph.ts
@@ -56,7 +56,7 @@ export async function createTargetGraph(options: CreateTargetGraphOptions): Prom
     priorities,
   } = options;
 
-  const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, enableTargetConfigMerging, enablePhantomTargetOptimization);
+  const builder = new WorkspaceTargetGraphBuilder({ root, packageInfos, enableTargetConfigMerging, enablePhantomTargetOptimization });
 
   const packages = getFilteredPackages({
     root,

--- a/packages/runners/src/NpmScriptRunner.ts
+++ b/packages/runners/src/NpmScriptRunner.ts
@@ -49,6 +49,8 @@ export class NpmScriptRunner implements TargetRunner {
 
   public async shouldRun(target: Target): Promise<boolean> {
     // By convention, do not run anything if there is no script for this task defined in package.json (counts as "success")
+    //
+    // TODO: In theory this could be entirely handled by TargetFactory (see comment on getTargetType there).
     const task = this.getTargetTask(target);
     const packageJsonPath = path.join(target.cwd, "package.json");
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));

--- a/packages/target-graph/src/TargetFactory.ts
+++ b/packages/target-graph/src/TargetFactory.ts
@@ -1,9 +1,9 @@
-import type { StagedTargetConfig, TargetConfig } from "./types/TargetConfig.js";
-import type { Target } from "./types/Target.js";
 import type { PackageInfos } from "workspace-tools";
-
-import { getPackageAndTask, getStagedTargetId, getTargetId } from "./targetId.js";
+import { builtInTargetTypes } from "./builtInTargetTypes.js";
 import { getWeight } from "./getWeight.js";
+import { getPackageAndTask, getStagedTargetId, getTargetId } from "./targetId.js";
+import type { Target } from "./types/Target.js";
+import type { StagedTargetConfig, TargetConfig } from "./types/TargetConfig.js";
 
 export interface TargetFactoryOptions {
   root: string;
@@ -12,6 +12,7 @@ export interface TargetFactoryOptions {
 }
 
 export class TargetFactory {
+  /** All scripts found in any package (not counting the root package) */
   private packageScripts: Set<string> = new Set<string>();
 
   constructor(private options: TargetFactoryOptions) {
@@ -24,78 +25,79 @@ export class TargetFactory {
   }
 
   private getTargetType(task: string, config: TargetConfig): string {
-    if (!config.type) {
-      if (this.packageScripts.has(task)) {
-        return "npmScript";
-      } else {
-        return "noop";
-      }
-    }
-
-    return config.type;
+    // If the target doesn't define a type, return npmScript if any package in the repo has that script.
+    //
+    // TODO: This is a bit silly that we check all the scripts in the repo rather than verifying
+    // the actual package, since we do have that info. Checking here would allow removing the
+    // extra file read for script existence check in NpmScriptRunner, and potentially allow
+    // the target graph optimization step to be moved into this package (maybe under a flag).
+    //
+    // Edge cases if this is tried in the future:
+    // - For global targets, we might need to look at the root package.json, which isn't included in
+    //   packageInfos and would have to be plumbed through or read separately.
+    // - In NpmScriptRunner (runners package) there's an alternate way of specifying the script via
+    //   NpmScriptRunnerOptions.script. The best approach to avoid losing type safety might be to
+    //   move the <Type>TargetOptions types for built-in runners to this package--the parts of this
+    //   package used by WorkspaceTargetGraphBuilder already have other built-in runner logic despite
+    //   the theoretical division.
+    return config.type || (this.packageScripts.has(task) ? builtInTargetTypes.npmScript : builtInTargetTypes.noop);
   }
 
   /**
    * Creates a package task `Target`
    */
   public createPackageTarget(packageName: string, task: string, config: TargetConfig): Target {
-    const { resolve } = this.options;
-    const { options, deps, dependsOn, cache, inputs, priority, maxWorkers, environmentGlob, weight } = config;
-    const cwd = resolve(packageName);
-
     const targetType = this.getTargetType(task, config);
 
-    const target = {
+    const target: Target = {
       id: getTargetId(packageName, task),
       label: `${packageName} - ${task}`,
       type: targetType,
       packageName,
       task,
-      cache: cache !== false,
-      cwd,
-      depSpecs: dependsOn ?? deps ?? [],
+      cache: config.cache !== false,
+      cwd: this.options.resolve(packageName),
+      depSpecs: config.dependsOn ?? config.deps ?? [],
       dependencies: [],
       dependents: [],
-      inputs,
-      outputs: targetType === "noop" ? [] : config.outputs,
-      priority,
-      maxWorkers,
-      environmentGlob,
+      inputs: config.inputs,
+      outputs: targetType === builtInTargetTypes.noop ? [] : config.outputs,
+      priority: config.priority,
+      maxWorkers: config.maxWorkers,
+      environmentGlob: config.environmentGlob,
       weight: 1,
-      options,
+      options: config.options,
       shouldRun: true,
     };
 
-    target.weight = getWeight(target, weight, maxWorkers);
+    target.weight = getWeight(target, config.weight, config.maxWorkers);
 
     return target;
   }
 
   public createGlobalTarget(id: string, config: TargetConfig): Target {
-    const { root } = this.options;
-    const { options, deps, dependsOn, cache, inputs, outputs, priority, maxWorkers, environmentGlob, weight } = config;
     const { task } = getPackageAndTask(id);
-    const target = {
+    const target: Target = {
       id,
       label: id,
       type: this.getTargetType(task, config),
       task,
-      cache: cache !== false,
-      cwd: root,
-      depSpecs: dependsOn ?? deps ?? [],
+      cache: config.cache !== false,
+      cwd: this.options.root,
+      depSpecs: config.dependsOn ?? config.deps ?? [],
       dependencies: [],
       dependents: [],
-      inputs,
-      outputs,
-      priority,
-      maxWorkers,
-      environmentGlob,
+      inputs: config.inputs,
+      outputs: config.outputs,
+      priority: config.priority,
+      maxWorkers: config.maxWorkers,
+      environmentGlob: config.environmentGlob,
       weight: 1,
-      options,
+      options: config.options,
       shouldRun: true,
     };
 
-    target.weight = getWeight(target, weight, maxWorkers);
+    target.weight = getWeight(target, config.weight, config.maxWorkers);
 
     return target;
   }
@@ -104,36 +106,28 @@ export class TargetFactory {
    * Creates a target that operates on files that are "staged" (changed in git vs `--since`)
    */
   public createStagedTarget(task: string, config: StagedTargetConfig, changedFiles: string[]): Target {
-    const { root } = this.options;
-    const { dependsOn, priority } = config;
-
     // Clone & modify the options to include the changed files as taskArgs
     const options = { ...config.options };
 
-    switch (config.type) {
-      case "noop":
-        break;
-
-      default:
-        options.taskArgs = options.taskArgs ?? [];
-        options.taskArgs.push(...changedFiles);
-        break;
+    if (config.type !== builtInTargetTypes.noop) {
+      // Clone any taskArgs and add the staged files
+      options.taskArgs = [...(options.taskArgs ?? []), ...changedFiles];
     }
 
     const id = getStagedTargetId(task);
-    const target = {
+    const target: Target = {
       id,
       label: id,
       type: config.type,
       task,
       cache: false,
-      cwd: root,
-      depSpecs: dependsOn ?? [],
+      cwd: this.options.root,
+      depSpecs: config.dependsOn ?? [],
       dependencies: [],
       dependents: [],
       inputs: [],
       outputs: [],
-      priority,
+      priority: config.priority,
       maxWorkers: 1,
       environmentGlob: [],
       weight: 1,

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -1,20 +1,16 @@
-import { createDependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
-import { getPackageAndTask, getStagedTargetId, getTargetId } from "./targetId.js";
-import { expandDepSpecs } from "./expandDepSpecs.js";
-
+import * as mergicianModule from "mergician";
+import pLimit from "p-limit";
 import path from "path";
-
-import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
-import type { PackageInfos } from "workspace-tools";
+import { createDependencyMap, type DependencyMap, type PackageInfos } from "workspace-tools";
+import { builtInTargetTypes } from "./builtInTargetTypes.js";
+import { expandDepSpecs } from "./expandDepSpecs.js";
+import { TargetFactory } from "./TargetFactory.js";
+import { TargetGraphBuilder } from "./TargetGraphBuilder.js";
+import { getPackageAndTask, getStagedTargetId, getTargetId } from "./targetId.js";
+import type { Priority } from "./types/Priority.js";
 import type { Target } from "./types/Target.js";
 import type { TargetConfig } from "./types/TargetConfig.js";
 import type { TargetGraph } from "./types/TargetGraph.js";
-import { TargetGraphBuilder } from "./TargetGraphBuilder.js";
-import { TargetFactory } from "./TargetFactory.js";
-import pLimit from "p-limit";
-import * as mergicianModule from "mergician";
-import type { Priority } from "./types/Priority.js";
-import { builtInTargetTypes } from "./builtInTargetTypes.js";
 
 // mergician is a dual-mode library with CJS and ESM export but a single .d.ts file.
 // Without type="module" on this packge.json typescript gets confused. See: https://github.com/microsoft/TypeScript/issues/50466
@@ -57,26 +53,28 @@ export class WorkspaceTargetGraphBuilder {
 
   /**
    * Initializes the builder with package infos
-   * @param root the root directory of the monorepo
-   * @param packageInfos the package infos for the monorepo
    */
   constructor(
-    root: string,
-    private packageInfos: PackageInfos,
-    private enableTargetConfigMerging: boolean,
-    private enablePhantomTargetOptimization: boolean
+    private options: {
+      /** Root directory of the monorepo */
+      root: string;
+      /** Package infos for the monorepo */
+      packageInfos: PackageInfos;
+      enableTargetConfigMerging: boolean;
+      enablePhantomTargetOptimization: boolean;
+    }
   ) {
-    this.dependencyMap = createDependencyMap(packageInfos, { withDevDependencies: true, withPeerDependencies: false });
+    this.dependencyMap = createDependencyMap(options.packageInfos, { withDevDependencies: true, withPeerDependencies: false });
     this.graphBuilder = new TargetGraphBuilder();
     this.targetFactory = new TargetFactory({
-      root,
-      packageInfos,
+      root: options.root,
+      packageInfos: options.packageInfos,
       resolve(packageName: string) {
-        try {
-          return path.dirname(packageInfos[packageName].packageJsonPath);
-        } catch (e) {
-          throw new Error(`Cannot open package.json file for ${packageName}`);
+        const pkg = options.packageInfos[packageName];
+        if (!pkg?.packageJsonPath) {
+          throw new Error(`Package "${packageName}" not found`);
         }
+        return path.dirname(pkg.packageJsonPath);
       },
     });
   }
@@ -101,7 +99,7 @@ export class WorkspaceTargetGraphBuilder {
 
       this.processStagedConfig(target, config, changedFiles);
     } else {
-      const packages = Object.keys(this.packageInfos);
+      const packages = Object.keys(this.options.packageInfos);
 
       for (const packageName of packages) {
         const task = id;
@@ -131,7 +129,7 @@ export class WorkspaceTargetGraphBuilder {
    */
   private determineFinalTargetConfig(targetId: string, config: TargetConfig): TargetConfig {
     let finalConfig = config;
-    if (this.enableTargetConfigMerging && this.targetConfigMap.has(targetId)) {
+    if (this.options.enableTargetConfigMerging && this.targetConfigMap.has(targetId)) {
       const existingConfig = this.targetConfigMap.get(targetId)!;
       finalConfig = this.deepCloneTargetConfig(existingConfig, config);
     }
@@ -209,14 +207,14 @@ export class WorkspaceTargetGraphBuilder {
    * @param priorities the set of global priorities for the workspace.
    */
   public async build(tasks: string[], scope?: string[], priorities?: Priority[]): Promise<TargetGraph> {
-    scope ||= Object.keys(this.packageInfos);
+    scope ||= Object.keys(this.options.packageInfos);
 
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(
       this.graphBuilder.targets,
       this.dependencyMap,
-      this.packageInfos,
-      this.enablePhantomTargetOptimization
+      this.options.packageInfos,
+      this.options.enablePhantomTargetOptimization
     );
 
     for (const [from, to] of fullDependencies) {

--- a/packages/target-graph/src/__tests__/TargetFactory.test.ts
+++ b/packages/target-graph/src/__tests__/TargetFactory.test.ts
@@ -1,23 +1,33 @@
 import path from "path";
-import { TargetFactory } from "../TargetFactory.js";
+import type { PackageInfo } from "workspace-tools";
+import { TargetFactory, type TargetFactoryOptions } from "../TargetFactory.js";
 
 describe("TargetFactory", () => {
-  it("should give a type of 'npmScript' if one of the packages contain that script", () => {
+  const root = path.resolve("/fake/root");
+
+  /** Make packages from a mapping of package name to scripts */
+  function makePackages(packages: Record<string, Record<string, string>>): Record<string, PackageInfo> {
+    const result: Record<string, PackageInfo> = {};
+    for (const [name, scripts] of Object.entries(packages)) {
+      result[name] = {
+        name,
+        version: "1.0.0",
+        packageJsonPath: path.join(root, name, "package.json"),
+        scripts,
+      };
+    }
+    return result;
+  }
+
+  const resolve: TargetFactoryOptions["resolve"] = (packageName) => path.join(root, packageName);
+
+  it("should give a type of 'npmScript' if the package contains that script", () => {
     const factory = new TargetFactory({
-      root: "root",
-      packageInfos: {
-        a: {
-          name: "a",
-          packageJsonPath: "root/a/package.json",
-          version: "1.0.0",
-          scripts: {
-            build: "echo build",
-          },
-        },
-      },
-      resolve(packageName) {
-        return path.join("root", packageName);
-      },
+      root,
+      packageInfos: makePackages({
+        a: { build: "echo build" },
+      }),
+      resolve,
     });
 
     const target = factory.createPackageTarget("a", "build", {
@@ -27,39 +37,54 @@ describe("TargetFactory", () => {
     expect(target.type).toBe("npmScript");
   });
 
-  it("should give a type of 'noop' if one of the packages contain that script", () => {
+  it("should give a type of 'npmScript' if a different package contains that script", () => {
     const factory = new TargetFactory({
-      root: "root",
-      packageInfos: {
-        a: {
-          name: "a",
-          packageJsonPath: "root/a/package.json",
-          version: "1.0.0",
-          scripts: {
-            build: "echo build",
-          },
-        },
-        b: {
-          name: "b",
-          packageJsonPath: "root/a/package.json",
-          version: "1.0.0",
-          scripts: {
-            build: "echo build",
-          },
-          dependencies: {
-            a: "1.0.0",
-          },
-        },
-      },
-      resolve(packageName) {
-        return path.join("root", packageName);
-      },
+      root,
+      packageInfos: makePackages({
+        a: { test: "echo test" },
+        b: { build: "echo build" },
+      }),
+      resolve,
     });
 
-    const target = factory.createPackageTarget("a", "unknown", {
+    const target = factory.createPackageTarget("a", "build", {
       dependsOn: ["^build"],
     });
 
+    expect(target.type).toBe("npmScript");
+  });
+
+  it("should give a type of 'noop' if no packages contain that script", () => {
+    const factory = new TargetFactory({
+      root,
+      packageInfos: makePackages({
+        a: { test: "echo test" },
+        b: { build: "echo build" },
+      }),
+      resolve,
+    });
+
+    const target = factory.createPackageTarget("a", "lint", {
+      dependsOn: ["^lint"],
+    });
+
     expect(target.type).toBe("noop");
+  });
+
+  it("uses type npmScript for global target with matching script in some package", () => {
+    const factory = new TargetFactory({
+      root,
+      packageInfos: makePackages({
+        a: { build: "echo build" },
+        b: { test: "echo test" },
+      }),
+      resolve,
+    });
+
+    const target = factory.createPackageTarget("root", "test", {
+      dependsOn: ["^test"],
+    });
+
+    expect(target.type).toBe("npmScript");
   });
 });

--- a/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
@@ -1,23 +1,42 @@
+import path from "path";
 import type { PackageInfos } from "workspace-tools";
 import { WorkspaceTargetGraphBuilder } from "../WorkspaceTargetGraphBuilder.js";
 import type { TargetGraph } from "../types/TargetGraph.js";
 
+const root = path.resolve("/fake/root");
+
 function createPackageInfo(packages: { [id: string]: string[] }) {
   const packageInfos: PackageInfos = {};
-  Object.keys(packages).forEach((id) => {
+  for (const [id, deps] of Object.entries(packages)) {
     packageInfos[id] = {
-      packageJsonPath: `/path/to/${id}/package.json`,
+      packageJsonPath: path.join(root, `packages/${id}/package.json`),
       name: id,
       version: "1.0.0",
-      dependencies: packages[id].reduce((acc, dep) => {
-        return { ...acc, [dep]: "*" };
-      }, {}),
+      dependencies: Object.fromEntries(deps.map((dep) => [dep, "*"])),
     };
-  });
-
+  }
   return packageInfos;
 }
 
+function createPackageInfoWithScripts(packages: { [id: string]: { deps: string[]; scripts: string[] } }) {
+  const packageInfos: PackageInfos = {};
+  for (const [id, { deps, scripts }] of Object.entries(packages)) {
+    packageInfos[id] = {
+      packageJsonPath: path.join(root, `packages/${id}/package.json`),
+      name: id,
+      version: "1.0.0",
+      dependencies: Object.fromEntries(deps.map((dep) => [dep, "*"])),
+      devDependencies: {},
+      scripts: Object.fromEntries(scripts.map((script) => [script, `echo ${script}`])),
+    };
+  }
+  return packageInfos;
+}
+
+/**
+ * Get the graph from the target dependencies (in the form of `[dependsOn, target]`
+ * (for running order, think of it as `[first, second]`)
+ */
 function getGraphFromTargets(targetGraph: TargetGraph) {
   const graph: [string, string][] = [];
   for (const target of targetGraph.targets.values()) {
@@ -25,20 +44,22 @@ function getGraphFromTargets(targetGraph: TargetGraph) {
       graph.push([dep, target.id]);
     }
   }
-
   return graph;
 }
 
 describe("workspace target graph builder", () => {
   it("should build a target based on a simple package graph and task graph", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
     });
@@ -55,32 +76,25 @@ describe("workspace target graph builder", () => {
       expect.objectContaining({ id: "b#build", priority: 100 }),
     ]);
 
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#build",
-        ],
-        [
-          "b#build",
-          "a#build",
-        ],
-        [
-          "__start",
-          "b#build",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#build"],
+      ["b#build", "a#build"],
+      ["__start", "b#build"],
+    ]);
   });
 
   it("should generate target graphs for tasks that do not depend on each other", async () => {
-    const root = "/repos/a";
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("test");
     await builder.addTargetConfig("lint");
 
@@ -88,38 +102,27 @@ describe("workspace target graph builder", () => {
 
     // includes the pseudo-target for the "start" target
     expect(targetGraph.targets.size).toBe(5);
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#test",
-        ],
-        [
-          "__start",
-          "b#test",
-        ],
-        [
-          "__start",
-          "a#lint",
-        ],
-        [
-          "__start",
-          "b#lint",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#test"],
+      ["__start", "b#test"],
+      ["__start", "a#lint"],
+      ["__start", "b#lint"],
+    ]);
   });
 
   it("should generate targetGraph with some specific package task target dependencies, running against all packages", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
       c: ["b"],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
 
     await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
@@ -130,38 +133,27 @@ describe("workspace target graph builder", () => {
     });
 
     const targetGraph = await builder.build(["build"]);
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#build",
-        ],
-        [
-          "__start",
-          "b#build",
-        ],
-        [
-          "__start",
-          "c#build",
-        ],
-        [
-          "b#build",
-          "c#build",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#build"],
+      ["__start", "b#build"],
+      ["__start", "c#build"],
+      ["b#build", "c#build"],
+    ]);
   });
 
   it("should generate targetGraph with some specific package task target dependencies, running against a specific package", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
       c: ["b"],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
 
     await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
@@ -172,30 +164,25 @@ describe("workspace target graph builder", () => {
     });
 
     const targetGraph = await builder.build(["build"], ["a", "b"]);
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#build",
-        ],
-        [
-          "__start",
-          "b#build",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#build"],
+      ["__start", "b#build"],
+    ]);
   });
 
   it("should generate targetGraph with transitive dependencies", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: ["c"],
       c: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
 
     await builder.addTargetConfig("bundle", {
       dependsOn: ["^^transpile"],
@@ -204,35 +191,16 @@ describe("workspace target graph builder", () => {
     await builder.addTargetConfig("transpile");
 
     const targetGraph = await builder.build(["bundle"], ["a"]);
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#bundle",
-        ],
-        [
-          "b#transpile",
-          "a#bundle",
-        ],
-        [
-          "c#transpile",
-          "a#bundle",
-        ],
-        [
-          "__start",
-          "b#transpile",
-        ],
-        [
-          "__start",
-          "c#transpile",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#bundle"],
+      ["b#transpile", "a#bundle"],
+      ["c#transpile", "a#bundle"],
+      ["__start", "b#transpile"],
+      ["__start", "c#transpile"],
+    ]);
   });
 
   it("should generate target graph for a general task on a specific target", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: [],
       b: [],
@@ -240,7 +208,12 @@ describe("workspace target graph builder", () => {
       common: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
 
     await builder.addTargetConfig("build", {
       dependsOn: ["common#copy", "^build"],
@@ -250,53 +223,30 @@ describe("workspace target graph builder", () => {
     await builder.addTargetConfig("common#build");
 
     const targetGraph = await builder.build(["build"]);
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#build",
-        ],
-        [
-          "common#copy",
-          "a#build",
-        ],
-        [
-          "__start",
-          "b#build",
-        ],
-        [
-          "common#copy",
-          "b#build",
-        ],
-        [
-          "__start",
-          "c#build",
-        ],
-        [
-          "common#copy",
-          "c#build",
-        ],
-        [
-          "__start",
-          "common#build",
-        ],
-        [
-          "__start",
-          "common#copy",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#build"],
+      ["common#copy", "a#build"],
+      ["__start", "b#build"],
+      ["common#copy", "b#build"],
+      ["__start", "c#build"],
+      ["common#copy", "c#build"],
+      ["__start", "common#build"],
+      ["__start", "common#copy"],
+    ]);
   });
 
   it("should build a target graph with global task as a dependency", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("build", {
       dependsOn: ["^build", "#global:task"],
     });
@@ -307,45 +257,28 @@ describe("workspace target graph builder", () => {
 
     const targetGraph = await builder.build(["build"]);
 
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#build",
-        ],
-        [
-          "b#build",
-          "a#build",
-        ],
-        [
-          "#global:task",
-          "a#build",
-        ],
-        [
-          "__start",
-          "b#build",
-        ],
-        [
-          "#global:task",
-          "b#build",
-        ],
-        [
-          "__start",
-          "#global:task",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#build"],
+      ["b#build", "a#build"],
+      ["#global:task", "a#build"],
+      ["__start", "b#build"],
+      ["#global:task", "b#build"],
+      ["__start", "#global:task"],
+    ]);
   });
 
   it("should build a target graph with global task on its own", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("build", {
       dependsOn: ["^build", "#global:task"],
     });
@@ -356,25 +289,21 @@ describe("workspace target graph builder", () => {
 
     const targetGraph = await builder.build(["global:task"]);
 
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "#global:task",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([["__start", "#global:task"]]);
   });
 
   it("should build a target graph without including global task", async () => {
-    const root = "/repos/a";
-
     const packageInfos = createPackageInfo({
       a: ["b"],
       b: [],
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("build", {
       dependsOn: ["^build"],
     });
@@ -385,34 +314,26 @@ describe("workspace target graph builder", () => {
 
     const targetGraph = await builder.build(["build"]);
 
-    expect(getGraphFromTargets(targetGraph)).toMatchInlineSnapshot(`
-      [
-        [
-          "__start",
-          "a#build",
-        ],
-        [
-          "b#build",
-          "a#build",
-        ],
-        [
-          "__start",
-          "b#build",
-        ],
-      ]
-    `);
+    expect(getGraphFromTargets(targetGraph)).toEqual([
+      ["__start", "a#build"],
+      ["b#build", "a#build"],
+      ["__start", "b#build"],
+    ]);
   });
 
-  it("should not create phantom transitive deps for packages missing a script", async () => {
-    const root = "/repos/a";
-
+  it("preserves graph edges even with missing package scripts by default (enablePhantomTargetOptimization: false)", async () => {
     // "app" has emitDeclarations in scripts, "dep" does not
     const packageInfos = createPackageInfoWithScripts({
-      app: { deps: ["dep"], scripts: ["transpile", "typecheck", "emitDeclarations"] },
       dep: { deps: [], scripts: ["transpile", "typecheck"] },
+      app: { deps: ["dep"], scripts: ["transpile", "typecheck", "emitDeclarations"] },
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("transpile");
     await builder.addTargetConfig("emitDeclarations", {
       dependsOn: ["typecheck"],
@@ -424,27 +345,105 @@ describe("workspace target graph builder", () => {
     const targetGraph = await builder.build(["typecheck"], ["app"]);
     const graph = getGraphFromTargets(targetGraph);
 
-    // app#typecheck should depend on app#transpile (same-package dep)
-    expect(graph).toContainEqual(["app#transpile", "app#typecheck"]);
+    // Even though dep doesn't have an emitDeclarations script, the graph edge from dep#emitDeclarations to app#typecheck
+    // is preserved by default (this appears to be the original intended behavior).
+    expect(graph).toContainEqual(["dep#emitDeclarations", "app#typecheck"]);
 
-    // app#typecheck should depend on dep#transpile (via ^^transpile, dep has the script)
-    expect(graph).toContainEqual(["dep#transpile", "app#typecheck"]);
-
-    // app#typecheck should NOT depend on dep#typecheck — dep doesn't have emitDeclarations,
-    // so the phantom dep#emitDeclarations should not create a transitive link
-    expect(graph).not.toContainEqual(["dep#typecheck", "app#typecheck"]);
+    expect(graph).toEqual([
+      ["__start", "app#typecheck"],
+      ["dep#emitDeclarations", "app#typecheck"],
+      ["app#transpile", "app#typecheck"],
+      ["dep#transpile", "app#typecheck"],
+      ["__start", "dep#emitDeclarations"],
+      ["dep#typecheck", "dep#emitDeclarations"],
+      ["__start", "app#transpile"],
+      ["__start", "dep#transpile"],
+      ["__start", "dep#typecheck"],
+      ["dep#transpile", "dep#typecheck"],
+    ]);
   });
 
-  it("should preserve ^^ deps for non-npmScript typed targets even without scripts entry", async () => {
-    const root = "/repos/a";
+  it("should not create phantom transitive deps for packages missing a target with enablePhantomTargetOptimization: true", async () => {
+    // "app" has emitDeclarations in scripts, "dep" does not
+    const packageInfos = createPackageInfoWithScripts({
+      dep: { deps: [], scripts: ["transpile", "typecheck"] },
+      app: { deps: ["dep"], scripts: ["transpile", "typecheck", "emitDeclarations"] },
+    });
 
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: true,
+    });
+    await builder.addTargetConfig("transpile");
+    await builder.addTargetConfig("emitDeclarations", {
+      dependsOn: ["typecheck"],
+    });
+    await builder.addTargetConfig("typecheck", {
+      dependsOn: ["^^emitDeclarations", "transpile", "^^transpile"],
+    });
+
+    const targetGraph = await builder.build(["typecheck"], ["app"]);
+    const graph = getGraphFromTargets(targetGraph);
+    expect(graph).toEqual([
+      ["__start", "app#typecheck"],
+      // app#typecheck should depend on app#transpile (same-package dep)
+      ["app#transpile", "app#typecheck"],
+      // app#typecheck should depend on dep#transpile (via ^^transpile, dep has the script)
+      ["dep#transpile", "app#typecheck"],
+      ["__start", "app#transpile"],
+      ["__start", "dep#transpile"],
+    ]);
+
+    // app#typecheck should NOT depend on dep#emitDeclarations — dep doesn't have emitDeclarations,
+    // so the phantom dep#emitDeclarations should not create a transitive link
+    expect(graph).not.toContainEqual(["dep#emitDeclarations", "app#typecheck"]);
+  });
+
+  it("preserves indirect links", async () => {
+    const packageInfos = createPackageInfoWithScripts({
+      a: { deps: ["b"], scripts: ["build"] },
+      b: { deps: ["c"], scripts: [] },
+      c: { deps: [], scripts: ["build"] },
+    });
+
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
+    await builder.addTargetConfig("build", {
+      dependsOn: ["^build"],
+    });
+
+    const targetGraph = await builder.build(["build"]);
+    const graph = getGraphFromTargets(targetGraph);
+    // This will be reduced by optimizeTargetGraph to have a#build depend on c#build
+    // via b#build which turns into a no-op (shouldRun=>false because script isn't defined)
+    expect(graph).toEqual([
+      ["__start", "a#build"],
+      ["b#build", "a#build"],
+      ["__start", "b#build"],
+      ["c#build", "b#build"],
+      ["__start", "c#build"],
+    ]);
+  });
+
+  it("should preserve ^^ deps for non-npmScript typed targets", async () => {
     // "dep" doesn't have "customTask" in scripts, but it's configured as a worker type
     const packageInfos = createPackageInfoWithScripts({
       app: { deps: ["dep"], scripts: ["build"] },
       dep: { deps: [], scripts: ["build"] },
     });
 
-    const builder = new WorkspaceTargetGraphBuilder(root, packageInfos, false, false);
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
     await builder.addTargetConfig("customTask", {
       type: "worker",
     });
@@ -455,24 +454,12 @@ describe("workspace target graph builder", () => {
     const targetGraph = await builder.build(["build"], ["app"]);
     const graph = getGraphFromTargets(targetGraph);
 
-    // app#build should depend on dep#customTask even though dep doesn't have it in scripts,
-    // because the target has an explicit non-npmScript type ("worker")
-    expect(graph).toContainEqual(["dep#customTask", "app#build"]);
+    expect(graph).toEqual([
+      ["__start", "app#build"],
+      // app#build should depend on dep#customTask even though dep doesn't have it in scripts,
+      // because the target has an explicit non-npmScript type ("worker")
+      ["dep#customTask", "app#build"],
+      ["__start", "dep#customTask"],
+    ]);
   });
 });
-
-function createPackageInfoWithScripts(packages: { [id: string]: { deps: string[]; scripts: string[] } }) {
-  const packageInfos: PackageInfos = {};
-  Object.keys(packages).forEach((id) => {
-    const { deps, scripts } = packages[id];
-    packageInfos[id] = {
-      packageJsonPath: `/path/to/${id}/package.json`,
-      name: id,
-      version: "1.0.0",
-      dependencies: deps.reduce((acc, dep) => ({ ...acc, [dep]: "*" }), {}),
-      devDependencies: {},
-      scripts: scripts.reduce((acc, script) => ({ ...acc, [script]: `echo ${script}` }), {}),
-    };
-  });
-  return packageInfos;
-}

--- a/packages/target-graph/src/expandDepSpecs.ts
+++ b/packages/target-graph/src/expandDepSpecs.ts
@@ -1,6 +1,5 @@
 import type { Target } from "./types/Target.js";
-import type { DependencyMap } from "workspace-tools/lib/graph/createDependencyMap.js";
-import type { PackageInfos } from "workspace-tools";
+import type { PackageInfos, DependencyMap } from "workspace-tools";
 import { getPackageAndTask, getStartTargetId, getTargetId } from "./targetId.js";
 import { builtInTargetTypes } from "./builtInTargetTypes.js";
 
@@ -17,7 +16,9 @@ import { builtInTargetTypes } from "./builtInTargetTypes.js";
  *
  * Returns true if the target should be EXCLUDED from dependency expansion.
  */
-function isPhantomTarget(targetId: string, task: string, targets: Map<string, Target>, packageInfos: PackageInfos): boolean {
+function isPhantomTarget(params: { targetId: string; task: string; targets: Map<string, Target>; packageInfos: PackageInfos }): boolean {
+  const { targetId, task, targets, packageInfos } = params;
+
   const target = targets.get(targetId);
 
   // Only npmScript targets can be phantom — other types (worker, noop, etc.)
@@ -26,11 +27,9 @@ function isPhantomTarget(targetId: string, task: string, targets: Map<string, Ta
     return false;
   }
 
-  const pkgScripts = packageInfos[target.packageName]?.scripts;
-  // If the package has a scripts section but doesn't include this task, it's a phantom target.
-  // If the package has no scripts section at all (e.g., in unit tests), we include the target
-  // for backward compatibility.
-  return !!pkgScripts && !pkgScripts[task];
+  // If the package scripts don't include this task, it's a phantom target.
+  const pkg = packageInfos[target.packageName];
+  return !pkg?.scripts?.[task];
 }
 
 /**
@@ -46,8 +45,6 @@ export function expandDepSpecs(
 
   /**
    * Adds a dependency in the form of [from, to] to the dependency list.
-   * @param from
-   * @param to
    */
   const addDependency = (from: string, to: string) => {
     dependencies.push([from, to]);
@@ -111,7 +108,7 @@ export function expandDepSpecs(
         const dependencyTargetIds = findDependenciesByTask(depTask, targetDependencies);
         for (const from of dependencyTargetIds) {
           // Skip phantom targets: packages that don't define this task as a real npm script.
-          if (!enablePhantomTargetOptimization || !isPhantomTarget(from, depTask, targets, packageInfos)) {
+          if (!enablePhantomTargetOptimization || !isPhantomTarget({ targetId: from, task: depTask, targets, packageInfos })) {
             addDependency(from, to);
           }
         }
@@ -122,7 +119,7 @@ export function expandDepSpecs(
         const dependencyTargetIds = findDependenciesByTask(depTask, targetDependencies);
         for (const from of dependencyTargetIds) {
           // Skip phantom targets: packages that don't define this task as a real npm script.
-          if (!enablePhantomTargetOptimization || !isPhantomTarget(from, depTask, targets, packageInfos)) {
+          if (!enablePhantomTargetOptimization || !isPhantomTarget({ targetId: from, task: depTask, targets, packageInfos })) {
             addDependency(from, to);
           }
         }


### PR DESCRIPTION
- Use object params for `WorkspaceTargetGraphBuilder` signature, mainly for clarity of the multiple boolean params
- Simplify some logic in that class and `TargetFactory`
- Update phantom targets check to consider no `scripts` as phantom
- Add more tests for `WorkspaceTargetGraphBuilder`. It turns out the test added in #1031 didn't properly cover the new flag (it was not setting the flag and was checking for absence of the wrong dep pair), so I updated the test to set the flag and verify the whole graph, and added a separate test for the old behavior.

This change started with a big rabbit hole after noticing that `NpmScriptRunner` reads package.json to check if a script is defined, which seems rather silly when we already have the scripts info at `TargetFactory`/`WorkspaceTargetGraphBuilder` time (with a couple caveats). I ended up reverting the attempts at fixing that and just documenting the findings and edge cases in TODO comments for now, but this is an interesting optimization opportunity for the future.