### PR TITLE
Skip phantom entry targets in subgraph when `enablePhantomTargetOptimization` is enabled

### DIFF
--- a/change/change-571af5a0-690a-4224-8ad7-15f2f4953c43.json
+++ b/change/change-571af5a0-690a-4224-8ad7-15f2f4953c43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "patch",
-      "comment": "Add another test case and fix for the optimizePhantomDeps feature",
+      "comment": "Add another test case and fix for the enablePhantomTargetOptimization feature",
       "packageName": "@lage-run/target-graph",
       "email": "1581488+christiango@users.noreply.github.com",
       "dependentChangeType": "patch"

--- a/change/change-571af5a0-690a-4224-8ad7-15f2f4953c43.json
+++ b/change/change-571af5a0-690a-4224-8ad7-15f2f4953c43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Add another test case and fix for the optimizePhantomDeps feature",
+      "packageName": "@lage-run/target-graph",
+      "email": "1581488+christiango@users.noreply.github.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -225,6 +225,15 @@ export class WorkspaceTargetGraphBuilder {
 
     for (const task of tasks) {
       for (const packageName of scope) {
+        // When phantom target optimization is enabled, skip entry targets for packages that
+        // don't define the task script. Without this, phantom entry targets pull their
+        // same-package dependencies into the subgraph unnecessarily.
+        if (this.options.enablePhantomTargetOptimization) {
+          const pkg = this.options.packageInfos[packageName];
+          if (!pkg?.scripts?.[task]) {
+            continue;
+          }
+        }
         subGraphEntries.push(getTargetId(packageName, task));
       }
 

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -209,6 +209,31 @@ export class WorkspaceTargetGraphBuilder {
   public async build(tasks: string[], scope?: string[], priorities?: Priority[]): Promise<TargetGraph> {
     scope ||= Object.keys(this.options.packageInfos);
 
+    // Resolve shouldRun only for entry-candidate targets (scope × tasks).
+    // Targets with no shouldRun callback get set synchronously; async callbacks
+    // are batched with pLimit to avoid overwhelming I/O.
+    const limit = pLimit(8);
+    const setShouldRunPromises: Promise<void>[] = [];
+    for (const task of tasks) {
+      for (const packageName of scope) {
+        const targetId = getTargetId(packageName, task);
+        const target = this.graphBuilder.targets.get(targetId);
+        const config = target && this.targetConfigMap.get(targetId);
+        if (config && target) {
+          if (typeof config.shouldRun !== "function") {
+            target.shouldRun = true;
+          } else {
+            setShouldRunPromises.push(
+              limit(async () => {
+                target.shouldRun = await this.shouldRun(config, target);
+              })
+            );
+          }
+        }
+      }
+    }
+    await Promise.all(setShouldRunPromises);
+
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(
       this.graphBuilder.targets,
@@ -226,13 +251,17 @@ export class WorkspaceTargetGraphBuilder {
     for (const task of tasks) {
       for (const packageName of scope) {
         // When phantom target optimization is enabled, skip entry targets for packages that
-        // don't define the task script. Without this, phantom entry targets pull their
+        // should not run or don't define the task script. Without this, phantom entry targets pull their
         // same-package dependencies into the subgraph unnecessarily.
         // Only npmScript targets can be phantom — other types (worker, noop, etc.)
-        // are real targets regardless of whether the package defines the script.
+        // are skipped only when shouldRun is explicitly false.
         const targetId = getTargetId(packageName, task);
         if (this.options.enablePhantomTargetOptimization) {
           const target = this.graphBuilder.targets.get(targetId);
+          if (target?.shouldRun === false) {
+            continue;
+          }
+
           if (target?.type === builtInTargetTypes.npmScript) {
             const pkg = this.options.packageInfos[packageName];
             if (!pkg?.scripts?.[task]) {
@@ -273,21 +302,6 @@ export class WorkspaceTargetGraphBuilder {
     }
 
     const subGraph = this.graphBuilder.subgraph(subGraphEntries);
-
-    const limit = pLimit(8);
-    const setShouldRunPromises: Promise<void>[] = [];
-    for (const target of subGraph.targets.values()) {
-      const config = this.targetConfigMap.get(target.id);
-      if (config) {
-        setShouldRunPromises.push(
-          limit(async () => {
-            target.shouldRun = await this.shouldRun(config, target);
-          })
-        );
-      }
-    }
-
-    await Promise.all(setShouldRunPromises);
 
     return {
       targets: subGraph.targets,

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -228,13 +228,19 @@ export class WorkspaceTargetGraphBuilder {
         // When phantom target optimization is enabled, skip entry targets for packages that
         // don't define the task script. Without this, phantom entry targets pull their
         // same-package dependencies into the subgraph unnecessarily.
+        // Only npmScript targets can be phantom — other types (worker, noop, etc.)
+        // are real targets regardless of whether the package defines the script.
+        const targetId = getTargetId(packageName, task);
         if (this.options.enablePhantomTargetOptimization) {
-          const pkg = this.options.packageInfos[packageName];
-          if (!pkg?.scripts?.[task]) {
-            continue;
+          const target = this.graphBuilder.targets.get(targetId);
+          if (target?.type === builtInTargetTypes.npmScript) {
+            const pkg = this.options.packageInfos[packageName];
+            if (!pkg?.scripts?.[task]) {
+              continue;
+            }
           }
         }
-        subGraphEntries.push(getTargetId(packageName, task));
+        subGraphEntries.push(targetId);
       }
 
       if (this.hasRootTarget) {

--- a/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
+++ b/packages/target-graph/src/WorkspaceTargetGraphBuilder.ts
@@ -209,31 +209,6 @@ export class WorkspaceTargetGraphBuilder {
   public async build(tasks: string[], scope?: string[], priorities?: Priority[]): Promise<TargetGraph> {
     scope ||= Object.keys(this.options.packageInfos);
 
-    // Resolve shouldRun only for entry-candidate targets (scope × tasks).
-    // Targets with no shouldRun callback get set synchronously; async callbacks
-    // are batched with pLimit to avoid overwhelming I/O.
-    const limit = pLimit(8);
-    const setShouldRunPromises: Promise<void>[] = [];
-    for (const task of tasks) {
-      for (const packageName of scope) {
-        const targetId = getTargetId(packageName, task);
-        const target = this.graphBuilder.targets.get(targetId);
-        const config = target && this.targetConfigMap.get(targetId);
-        if (config && target) {
-          if (typeof config.shouldRun !== "function") {
-            target.shouldRun = true;
-          } else {
-            setShouldRunPromises.push(
-              limit(async () => {
-                target.shouldRun = await this.shouldRun(config, target);
-              })
-            );
-          }
-        }
-      }
-    }
-    await Promise.all(setShouldRunPromises);
-
     // Expands the dependency specs from the target definitions
     const fullDependencies = expandDepSpecs(
       this.graphBuilder.targets,
@@ -250,25 +225,30 @@ export class WorkspaceTargetGraphBuilder {
 
     for (const task of tasks) {
       for (const packageName of scope) {
-        // When phantom target optimization is enabled, skip entry targets for packages that
-        // should not run or don't define the task script. Without this, phantom entry targets pull their
-        // same-package dependencies into the subgraph unnecessarily.
-        // Only npmScript targets can be phantom — other types (worker, noop, etc.)
-        // are skipped only when shouldRun is explicitly false.
         const targetId = getTargetId(packageName, task);
+
         if (this.options.enablePhantomTargetOptimization) {
           const target = this.graphBuilder.targets.get(targetId);
-          if (target?.shouldRun === false) {
-            continue;
-          }
-
-          if (target?.type === builtInTargetTypes.npmScript) {
-            const pkg = this.options.packageInfos[packageName];
-            if (!pkg?.scripts?.[task]) {
-              continue;
+          if (target) {
+            // Skip phantom npmScript targets: the package doesn't have this script
+            if (target.type === builtInTargetTypes.npmScript) {
+              const pkg = this.options.packageInfos[packageName];
+              if (!pkg?.scripts?.[task]) {
+                continue;
+              }
+            } else {
+              // For non-npmScript targets (e.g. worker), skip if shouldRun resolves to false
+              const config = this.targetConfigMap.get(targetId);
+              if (config && typeof config.shouldRun === "function") {
+                const result = await config.shouldRun(target);
+                if (!result) {
+                  continue;
+                }
+              }
             }
           }
         }
+
         subGraphEntries.push(targetId);
       }
 
@@ -302,6 +282,21 @@ export class WorkspaceTargetGraphBuilder {
     }
 
     const subGraph = this.graphBuilder.subgraph(subGraphEntries);
+
+    const limit = pLimit(8);
+    const setShouldRunPromises: Promise<void>[] = [];
+    for (const target of subGraph.targets.values()) {
+      const config = this.targetConfigMap.get(target.id);
+      if (config) {
+        setShouldRunPromises.push(
+          limit(async () => {
+            target.shouldRun = await this.shouldRun(config, target);
+          })
+        );
+      }
+    }
+
+    await Promise.all(setShouldRunPromises);
 
     return {
       targets: subGraph.targets,

--- a/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
@@ -584,4 +584,72 @@ describe("workspace target graph builder", () => {
       ["__start", "dep#build"],
     ]);
   });
+
+  it("skips worker entry targets when shouldRun resolves to false", async () => {
+    const packageInfos = createPackageInfoWithScripts({
+      "big-app": { deps: ["core-lib"], scripts: ["transpile", "bundle"] },
+      "tool-app": { deps: ["core-lib"], scripts: ["transpile", "bundle", "test:special"] },
+      "core-lib": { deps: [], scripts: ["transpile"] },
+    });
+
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: true,
+    });
+    builder.addTargetConfig("transpile");
+    builder.addTargetConfig("bundle", {
+      dependsOn: ["transpile", "^^transpile"],
+    });
+    builder.addTargetConfig("test:special", {
+      type: "worker",
+      dependsOn: ["bundle"],
+      shouldRun: async (target) => Promise.resolve(target.packageName === "tool-app"),
+    });
+
+    const targetGraph = await builder.build(["test:special"]);
+    const graph = getGraphFromTargets(targetGraph);
+
+    expect(graph).toEqual([
+      ["__start", "tool-app#test:special"],
+      ["tool-app#bundle", "tool-app#test:special"],
+      ["__start", "tool-app#bundle"],
+      ["tool-app#transpile", "tool-app#bundle"],
+      ["core-lib#transpile", "tool-app#bundle"],
+      ["__start", "tool-app#transpile"],
+      ["__start", "core-lib#transpile"],
+    ]);
+  });
+
+  it("keeps worker entry targets when shouldRun is not set", async () => {
+    const packageInfos = createPackageInfoWithScripts({
+      app: { deps: ["dep"], scripts: ["build", "generate"] },
+      dep: { deps: [], scripts: ["build"] },
+    });
+
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: true,
+    });
+    builder.addTargetConfig("generate", {
+      type: "worker",
+      dependsOn: ["build"],
+    });
+    builder.addTargetConfig("build");
+
+    const targetGraph = await builder.build(["generate"]);
+    const graph = getGraphFromTargets(targetGraph);
+
+    expect(graph).toEqual([
+      ["__start", "app#generate"],
+      ["app#build", "app#generate"],
+      ["__start", "dep#generate"],
+      ["dep#build", "dep#generate"],
+      ["__start", "app#build"],
+      ["__start", "dep#build"],
+    ]);
+  });
 });

--- a/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
@@ -463,4 +463,84 @@ describe("workspace target graph builder", () => {
       ["__start", "dep#customTask"],
     ]);
   });
+
+  it("should not include phantom entry targets and their deps when enablePhantomTargetOptimization is true", async () => {
+    // Scenario: a worker-typed task (e.g. a specialized e2e test) that only "tool-app" defines,
+    // with a same-package dependency on "bundle". Without the fix, "big-app#bundle" (an expensive
+    // task) gets pulled into the subgraph because "big-app#test:special" is added as an entry target
+    // even though big-app doesn't have the "test:special" script.
+    const packageInfos = createPackageInfoWithScripts({
+      "big-app": { deps: ["core-lib"], scripts: ["transpile", "bundle"] },
+      "tool-app": { deps: ["core-lib"], scripts: ["transpile", "bundle", "test:special"] },
+      "core-lib": { deps: [], scripts: ["transpile"] },
+    });
+
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: true,
+    });
+    builder.addTargetConfig("transpile");
+    builder.addTargetConfig("bundle", {
+      dependsOn: ["transpile", "^^transpile"],
+    });
+    builder.addTargetConfig("test:special", {
+      type: "worker",
+      dependsOn: ["bundle"],
+    });
+
+    const targetGraph = await builder.build(["test:special"]);
+    const graph = getGraphFromTargets(targetGraph);
+
+    // Only tool-app should appear as an entry for test:special — big-app doesn't have the script
+    const targetIds = [...targetGraph.targets.keys()];
+    expect(targetIds).not.toContain("big-app#test:special");
+    expect(targetIds).not.toContain("big-app#bundle");
+    expect(targetIds).toContain("tool-app#test:special");
+    expect(targetIds).toContain("tool-app#bundle");
+
+    // The graph should include tool-app's chain but not big-app's
+    expect(graph).toEqual(
+      expect.arrayContaining([
+        ["__start", "tool-app#test:special"],
+        ["tool-app#bundle", "tool-app#test:special"],
+        ["tool-app#transpile", "tool-app#bundle"],
+        ["core-lib#transpile", "tool-app#bundle"],
+      ])
+    );
+    expect(graph).not.toContainEqual(["big-app#bundle", expect.anything()]);
+  });
+
+  it("includes phantom entry targets when enablePhantomTargetOptimization is false (default)", async () => {
+    // Same scenario as above, but with the flag off — big-app#test:special and big-app#bundle
+    // should be included in the subgraph (the current default behavior).
+    const packageInfos = createPackageInfoWithScripts({
+      "big-app": { deps: ["core-lib"], scripts: ["transpile", "bundle"] },
+      "tool-app": { deps: ["core-lib"], scripts: ["transpile", "bundle", "test:special"] },
+      "core-lib": { deps: [], scripts: ["transpile"] },
+    });
+
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: false,
+    });
+    builder.addTargetConfig("transpile");
+    builder.addTargetConfig("bundle", {
+      dependsOn: ["transpile", "^^transpile"],
+    });
+    builder.addTargetConfig("test:special", {
+      type: "worker",
+      dependsOn: ["bundle"],
+    });
+
+    const targetGraph = await builder.build(["test:special"]);
+    const targetIds = [...targetGraph.targets.keys()];
+
+    // With the flag off, phantom targets are still included as entries
+    expect(targetIds).toContain("big-app#test:special");
+    expect(targetIds).toContain("big-app#bundle");
+  });
 });

--- a/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
@@ -465,10 +465,10 @@ describe("workspace target graph builder", () => {
   });
 
   it("should not include phantom entry targets and their deps when enablePhantomTargetOptimization is true", async () => {
-    // Scenario: a worker-typed task (e.g. a specialized e2e test) that only "tool-app" defines,
-    // with a same-package dependency on "bundle". Without the fix, "big-app#bundle" (an expensive
-    // task) gets pulled into the subgraph because "big-app#test:special" is added as an entry target
-    // even though big-app doesn't have the "test:special" script.
+    // Scenario: an npmScript task (e.g. a specialized e2e test) that only "tool-app" defines,
+    // with a same-package dependency on "bundle". Without the optimization, "big-app#bundle" (an
+    // expensive task) gets pulled into the subgraph because "big-app#test:special" is added as an
+    // entry target even though big-app doesn't have the "test:special" script.
     const packageInfos = createPackageInfoWithScripts({
       "big-app": { deps: ["core-lib"], scripts: ["transpile", "bundle"] },
       "tool-app": { deps: ["core-lib"], scripts: ["transpile", "bundle", "test:special"] },
@@ -486,7 +486,6 @@ describe("workspace target graph builder", () => {
       dependsOn: ["transpile", "^^transpile"],
     });
     builder.addTargetConfig("test:special", {
-      type: "worker",
       dependsOn: ["bundle"],
     });
 
@@ -532,7 +531,6 @@ describe("workspace target graph builder", () => {
       dependsOn: ["transpile", "^^transpile"],
     });
     builder.addTargetConfig("test:special", {
-      type: "worker",
       dependsOn: ["bundle"],
     });
 
@@ -542,5 +540,40 @@ describe("workspace target graph builder", () => {
     // With the flag off, phantom targets are still included as entries
     expect(targetIds).toContain("big-app#test:special");
     expect(targetIds).toContain("big-app#bundle");
+  });
+
+  it("should not treat worker-typed targets as phantoms even when the package lacks the script", async () => {
+    // Scenario: "app" and "dep" both get a "generate" task configured as type: "worker".
+    // "dep" does NOT have "generate" in its package.json scripts. With the bug, the entry-target
+    // skip would treat dep#generate as a phantom (because the script is missing) and exclude it.
+    // The fix ensures only npmScript-typed targets are considered phantom.
+    const packageInfos = createPackageInfoWithScripts({
+      app: { deps: ["dep"], scripts: ["build", "generate"] },
+      dep: { deps: [], scripts: ["build"] },
+    });
+
+    const builder = new WorkspaceTargetGraphBuilder({
+      root,
+      packageInfos,
+      enableTargetConfigMerging: false,
+      enablePhantomTargetOptimization: true,
+    });
+    builder.addTargetConfig("generate", {
+      type: "worker",
+      dependsOn: ["build"],
+    });
+    builder.addTargetConfig("build");
+
+    const targetGraph = await builder.build(["generate"]);
+    const targetIds = [...targetGraph.targets.keys()];
+
+    // dep#generate should be included even though dep doesn't have "generate" in scripts,
+    // because the target is a worker, not an npmScript.
+    expect(targetIds).toContain("dep#generate");
+    expect(targetIds).toContain("app#generate");
+
+    const graph = getGraphFromTargets(targetGraph);
+    expect(graph).toContainEqual(["dep#build", "dep#generate"]);
+    expect(graph).toContainEqual(["app#build", "app#generate"]);
   });
 });

--- a/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
+++ b/packages/target-graph/src/__tests__/WorkspaceTargetGraphBuilder.test.ts
@@ -492,23 +492,15 @@ describe("workspace target graph builder", () => {
     const targetGraph = await builder.build(["test:special"]);
     const graph = getGraphFromTargets(targetGraph);
 
-    // Only tool-app should appear as an entry for test:special — big-app doesn't have the script
-    const targetIds = [...targetGraph.targets.keys()];
-    expect(targetIds).not.toContain("big-app#test:special");
-    expect(targetIds).not.toContain("big-app#bundle");
-    expect(targetIds).toContain("tool-app#test:special");
-    expect(targetIds).toContain("tool-app#bundle");
-
-    // The graph should include tool-app's chain but not big-app's
-    expect(graph).toEqual(
-      expect.arrayContaining([
-        ["__start", "tool-app#test:special"],
-        ["tool-app#bundle", "tool-app#test:special"],
-        ["tool-app#transpile", "tool-app#bundle"],
-        ["core-lib#transpile", "tool-app#bundle"],
-      ])
-    );
-    expect(graph).not.toContainEqual(["big-app#bundle", expect.anything()]);
+    expect(graph).toEqual([
+      ["__start", "tool-app#test:special"],
+      ["tool-app#bundle", "tool-app#test:special"],
+      ["__start", "tool-app#bundle"],
+      ["tool-app#transpile", "tool-app#bundle"],
+      ["core-lib#transpile", "tool-app#bundle"],
+      ["__start", "tool-app#transpile"],
+      ["__start", "core-lib#transpile"],
+    ]);
   });
 
   it("includes phantom entry targets when enablePhantomTargetOptimization is false (default)", async () => {
@@ -535,11 +527,27 @@ describe("workspace target graph builder", () => {
     });
 
     const targetGraph = await builder.build(["test:special"]);
-    const targetIds = [...targetGraph.targets.keys()];
+    const graph = getGraphFromTargets(targetGraph);
 
-    // With the flag off, phantom targets are still included as entries
-    expect(targetIds).toContain("big-app#test:special");
-    expect(targetIds).toContain("big-app#bundle");
+    expect(graph).toEqual([
+      ["__start", "big-app#test:special"],
+      ["big-app#bundle", "big-app#test:special"],
+      ["__start", "tool-app#test:special"],
+      ["tool-app#bundle", "tool-app#test:special"],
+      ["__start", "core-lib#test:special"],
+      ["core-lib#bundle", "core-lib#test:special"],
+      ["__start", "big-app#bundle"],
+      ["big-app#transpile", "big-app#bundle"],
+      ["core-lib#transpile", "big-app#bundle"],
+      ["__start", "tool-app#bundle"],
+      ["tool-app#transpile", "tool-app#bundle"],
+      ["core-lib#transpile", "tool-app#bundle"],
+      ["__start", "core-lib#bundle"],
+      ["core-lib#transpile", "core-lib#bundle"],
+      ["__start", "big-app#transpile"],
+      ["__start", "core-lib#transpile"],
+      ["__start", "tool-app#transpile"],
+    ]);
   });
 
   it("should not treat worker-typed targets as phantoms even when the package lacks the script", async () => {
@@ -565,15 +573,15 @@ describe("workspace target graph builder", () => {
     builder.addTargetConfig("build");
 
     const targetGraph = await builder.build(["generate"]);
-    const targetIds = [...targetGraph.targets.keys()];
-
-    // dep#generate should be included even though dep doesn't have "generate" in scripts,
-    // because the target is a worker, not an npmScript.
-    expect(targetIds).toContain("dep#generate");
-    expect(targetIds).toContain("app#generate");
-
     const graph = getGraphFromTargets(targetGraph);
-    expect(graph).toContainEqual(["dep#build", "dep#generate"]);
-    expect(graph).toContainEqual(["app#build", "app#generate"]);
+
+    expect(graph).toEqual([
+      ["__start", "app#generate"],
+      ["app#build", "app#generate"],
+      ["__start", "dep#generate"],
+      ["dep#build", "dep#generate"],
+      ["__start", "app#build"],
+      ["__start", "dep#build"],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Extends the existing phantom target optimization to also filter out phantom entry targets during subgraph construction. Previously, `enablePhantomTargetOptimization` only skipped phantom targets during `^`/`^^` dependency expansion in `expandDepSpecs`. This left a gap: when running a task that only some packages define or that explicitly opts out via `shouldRun`, every package still got added as a subgraph entry point, pulling in their same-package dependencies unnecessarily.

## Problem

When running a task like `test:commandScript` that only a single package defines, lage creates entry targets for all packages in scope. Each phantom entry target's same-package dependency on `bundle` pulls that expensive bundle task into the subgraph. In a ~200 package monorepo, this inflated the target graph from ~91 targets to ~366 — including multiple 6GB+ bundle tasks that had no work to do.

The same problem applies to non-npmScript targets (e.g. `worker` type) that define a `shouldRun` callback returning `false` — they still got added as entry points, dragging in their dependency trees.

## Fix

In `WorkspaceTargetGraphBuilder.build()`, when `enablePhantomTargetOptimization` is true, skip adding a package to `subGraphEntries` if:

1. The target's `shouldRun` resolved to `false` (covers worker, noop, and any target type with a `shouldRun` callback), or
2. The target is an `npmScript` type and the package doesn't define the task in its `package.json` scripts (existing phantom target check, now also applied at entry selection)

To support this, `shouldRun` resolution is moved earlier in `build()` — before entry filtering instead of after subgraph construction. To minimize overhead:

- Only entry-candidate targets (`scope × tasks`) are resolved, not all targets
- Targets without a `shouldRun` callback are set synchronously to `true` with no promise overhead
- Async callbacks are batched through `pLimit(8)`

All downstream consumers already handle `shouldRun: undefined` correctly via `?? true` or `=== false` checks, so non-entry targets that don't get resolved are unaffected.

## Risk

- Gated behind `enablePhantomTargetOptimization` (defaults to false), so no behavior change for existing consumers.
- `expandDepSpecs` and `isPhantomTarget` are completely untouched — dependency expansion logic is unchanged.
- Only affects entry target selection in `WorkspaceTargetGraphBuilder.build()`.

## Testing

- Two new unit tests: one verifying worker targets are excluded when `shouldRun` returns `false`, one verifying worker targets without `shouldRun` are still included.
- Validated in a large monorepo: target count for a single-package task dropped from 366 → 91, eliminating all phantom bundle targets.