### PR TITLE
Rename getFileFromVersion to getFileFromRef

### DIFF
--- a/change/change-f72753ad-c1dd-402e-98fd-64f851d133b3.json
+++ b/change/change-f72753ad-c1dd-402e-98fd-64f851d133b3.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "patch",
-      "comment": "Rename getFileFromVersion to getFileFromRef",
+      "comment": "Rename `getFileFromVersion` to `getFileFromRef`. Also add `getCatalogVersion` option `allowNotFound`.",
       "packageName": "workspace-tools",
       "email": "elcraig@microsoft.com",
       "dependentChangeType": "patch"

--- a/change/change-f72753ad-c1dd-402e-98fd-64f851d133b3.json
+++ b/change/change-f72753ad-c1dd-402e-98fd-64f851d133b3.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Rename getFileFromVersion to getFileFromRef",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -133,6 +133,7 @@ export function getCatalogVersion(params: {
     name: string;
     version: string;
     catalogs: Catalogs | undefined;
+    allowNotFound?: boolean;
 }): string | undefined;
 
 // Warning: (ae-forgotten-export) The symbol "GetChangedPackagesOptions" needs to be exported by the entry point index.d.ts

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -233,7 +233,7 @@ export function getFileAddedHash(options: {
 export function getFileAddedHash(filename: string, cwd: string): string | undefined;
 
 // @public
-export function getFileFromVersion(params: {
+export function getFileFromRef(params: {
     filePath: string;
     ref: string;
 } & GitCommonOptions): string | undefined;

--- a/packages/workspace-tools/src/__tests__/git/getFileFromRef.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getFileFromRef.test.ts
@@ -3,12 +3,12 @@ import { cleanupFixtures, setupFixture } from "../setupFixture.js";
 import fs from "fs";
 import path from "path";
 import { git as _git, type GitOptions } from "../../git/git.js";
-import { getFileFromVersion } from "../../git/gitUtilities.js";
+import { getFileFromRef } from "../../git/gitUtilities.js";
 
 /** Call git helper but throw on error by default */
 const git = (args: string[], opts: GitOptions) => _git(args, { throwOnError: true, ...opts });
 
-describe("getFileFromVersion", () => {
+describe("getFileFromRef", () => {
   afterAll(() => {
     cleanupFixtures();
   });
@@ -30,11 +30,11 @@ describe("getFileFromVersion", () => {
     git(["commit", "-m", "second commit"], { cwd });
 
     // Should get the old version from the first commit
-    const result = getFileFromVersion({ filePath: "test.txt", ref: firstCommit, cwd });
+    const result = getFileFromRef({ filePath: "test.txt", ref: firstCommit, cwd });
     expect(result).toBe("version 1");
 
     // Should get the new version from HEAD
-    const resultHead = getFileFromVersion({ filePath: "test.txt", ref: "HEAD", cwd });
+    const resultHead = getFileFromRef({ filePath: "test.txt", ref: "HEAD", cwd });
     expect(resultHead).toBe("version 2");
   });
 
@@ -53,11 +53,11 @@ describe("getFileFromVersion", () => {
     git(["commit", "-m", "modify file on feature"], { cwd });
 
     // Should get the main version using branch ref
-    const result = getFileFromVersion({ filePath: "file.txt", ref: "main", cwd });
+    const result = getFileFromRef({ filePath: "file.txt", ref: "main", cwd });
     expect(result).toBe("main content");
 
     // Should get the feature version using branch ref
-    const resultFeature = getFileFromVersion({ filePath: "file.txt", ref: "feature", cwd });
+    const resultFeature = getFileFromRef({ filePath: "file.txt", ref: "feature", cwd });
     expect(resultFeature).toBe("feature content");
   });
 
@@ -77,7 +77,7 @@ describe("getFileFromVersion", () => {
     git(["commit", "-m", "add test.txt"], { cwd });
 
     // File doesn't exist at first commit
-    const result = getFileFromVersion({ filePath: "test.txt", ref: firstCommit, cwd });
+    const result = getFileFromRef({ filePath: "test.txt", ref: firstCommit, cwd });
     expect(result).toBeUndefined();
   });
 
@@ -88,7 +88,7 @@ describe("getFileFromVersion", () => {
     git(["add", "test.txt"], { cwd });
     git(["commit", "-m", "commit"], { cwd });
 
-    const result = getFileFromVersion({ filePath: "test.txt", ref: "nonexistent-ref", cwd });
+    const result = getFileFromRef({ filePath: "test.txt", ref: "nonexistent-ref", cwd });
     expect(result).toBeUndefined();
   });
 
@@ -100,7 +100,7 @@ describe("getFileFromVersion", () => {
     git(["add", "."], { cwd });
     git(["commit", "-m", "add nested file"], { cwd });
 
-    const result = getFileFromVersion({ filePath: "subdir/nested.txt", ref: "HEAD", cwd });
+    const result = getFileFromRef({ filePath: "subdir/nested.txt", ref: "HEAD", cwd });
     expect(result).toBe("nested content");
   });
 });

--- a/packages/workspace-tools/src/__tests__/workspaces/getCatalogVersion.test.ts
+++ b/packages/workspace-tools/src/__tests__/workspaces/getCatalogVersion.test.ts
@@ -86,6 +86,40 @@ describe("getCatalogVersion", () => {
     );
   });
 
+  describe("with allowNotFound: true", () => {
+    const allowNotFound = true;
+
+    it("returns undefined if no catalogs defined", () => {
+      const result = getCatalogVersion({ name: "react", version: "catalog:", catalogs: undefined, allowNotFound });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined if package not found in catalog", () => {
+      const result = getCatalogVersion({ name: "vue", version: "catalog:", catalogs: defaultCatalogs, allowNotFound });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined if default catalog version used but no default catalog defined", () => {
+      const result = getCatalogVersion({
+        name: "react",
+        version: "catalog:",
+        catalogs: { named: namedCatalogs.named },
+        allowNotFound,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined if named catalog version used but no named catalogs defined", () => {
+      const result = getCatalogVersion({
+        name: "react",
+        version: "catalog:react17",
+        catalogs: defaultCatalogs,
+        allowNotFound,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
   it("returns workspace: catalog version", () => {
     // This is not supported by pnpm as of writing, but it would have already errored on install
     const catalogs: Catalogs = {

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -591,7 +591,7 @@ export function listAllTrackedFiles(
  * Get the content of a file at a specific git ref (commit, branch, tag, etc).
  * Returns undefined if the file doesn't exist at that ref or the command fails.
  */
-export function getFileFromVersion(
+export function getFileFromRef(
   params: {
     /** Repo-relative path to the file with *forward* slashes */
     filePath: string;

--- a/packages/workspace-tools/src/git/gitUtilities.ts
+++ b/packages/workspace-tools/src/git/gitUtilities.ts
@@ -593,7 +593,7 @@ export function listAllTrackedFiles(
  */
 export function getFileFromRef(
   params: {
-    /** Repo-relative path to the file with *forward* slashes */
+    /** cwd-relative path to the file with *forward* slashes */
     filePath: string;
     /** git ref (branch, tag, commit SHA, etc) to get the file content from */
     ref: string;

--- a/packages/workspace-tools/src/workspaces/getCatalogVersion.ts
+++ b/packages/workspace-tools/src/workspaces/getCatalogVersion.ts
@@ -15,28 +15,36 @@ export function isCatalogVersion(version: string): boolean {
  *
  * Throws an error if there's anything invalid about the catalog spec (no catalogs defined,
  * no matching catalog, catalog doesn't contain `name`, recursive catalog version).
+ * If `allowNotFound` is true, it will return undefined if no match instead.
  *
  * Returns undefined if the version doesn't start with `catalog:`.
  * @see https://pnpm.io/catalogs
  * @see https://yarnpkg.com/features/catalogs
  *
- * @param name - Dependency package name
- * @param version - Dependency version spec, e.g. `catalog:my-catalog` or `catalog:`,
- * or some non-catalog spec like `^1.2.3`
  * @returns Actual version spec from the catalog, or undefined if not a catalog version
+ * (or undefined if `allowNotFound` is true and the package isn't in the catalog)
  */
 export function getCatalogVersion(params: {
+  /** Dependency package name */
   name: string;
+  /**
+   * Dependency version spec, e.g. `catalog:my-catalog` or `catalog:`, or some non-catalog
+   * spec like `^1.2.3`
+   */
   version: string;
   catalogs: Catalogs | undefined;
+  allowNotFound?: boolean;
 }): string | undefined {
-  const { name, version, catalogs } = params;
+  const { name, version, catalogs, allowNotFound } = params;
 
   if (!isCatalogVersion(version)) {
     return undefined;
   }
 
   if (!catalogs) {
+    if (allowNotFound) {
+      return undefined;
+    }
     throw new Error(`Dependency "${name}" uses a catalog version "${version}" but no catalogs are defined.`);
   }
 
@@ -54,12 +62,15 @@ export function getCatalogVersion(params: {
         : catalogs.default;
   const catalogNameStr = catalogName ? `catalogs.${catalogName}` : "the default catalog";
 
-  if (!checkCatalog) {
+  if (!checkCatalog && !allowNotFound) {
     throw new Error(`Dependency "${name}" uses a catalog version "${version}" but ${catalogNameStr} is not defined.`);
   }
 
-  const actualSpec = checkCatalog[name];
+  const actualSpec = checkCatalog?.[name];
   if (!actualSpec) {
+    if (allowNotFound) {
+      return undefined;
+    }
     throw new Error(
       `Dependency "${name}" uses a catalog version "${version}", but ${catalogNameStr} doesn't define a version for "${name}".`
     );


### PR DESCRIPTION
Rename the new `getFileFromVersion` to `getFileFromRef`. This is a breaking change, but not a big deal since the version was literally released a couple hours ago.