### PR TITLE
Restrict yarn dependency settings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,13 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
+# Disable build scripts except for the packages listed in package.json dependenciesMeta
+enableScripts: false
+
+# Ban pulling in packages newer than 3 days, except those specifically listed
+npmMinimalAgeGate: 3d
+npmPreapprovedPackages: ["beachball"]
+
 plugins:
   # See plugin page for latest version: https://github.com/ecraig12345/yarn-plugins/tree/main/plugins/engines
   # (Please revert yarn's automatic formatting changes to this file if updating the plugin...)


### PR DESCRIPTION
Updates to the yarn config:
- Disable build scripts by default. 
- Ban pulling in packages newer than 3 days except those specifically listed. This works even for lock file updates.