### PR TITLE
Reporters should delete log entries when no longer needed

### DIFF
--- a/change/change-ef3b5023-097f-4343-88bd-3378615c8da9.json
+++ b/change/change-ef3b5023-097f-4343-88bd-3378615c8da9.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Reporters should delete log entries from memory when no longer needed",
+      "packageName": "@lage-run/reporters",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/reporters/etc/reporters.api.md
+++ b/packages/reporters/etc/reporters.api.md
@@ -92,33 +92,33 @@ export class GithubActionsReporter extends GroupedReporter {
 
 // @public
 abstract class GroupedReporter implements TargetReporter {
-    constructor(options: {
-        logLevel?: LogLevel;
-        grouped?: boolean;
-        logMemory?: boolean;
-        logStream?: Writable;
-    });
+    constructor(options: GroupedReporterOptions);
     protected abstract formatGroupEnd(): string;
     protected abstract formatGroupStart(packageName: string, task: string, status: string, duration?: [number, number]): string;
     // (undocumented)
-    log(entry: MaybeTargetLogEntry): boolean | void;
-    // (undocumented)
+    log(entry: MaybeTargetLogEntry): void;
     protected logEntries: Map<string, TargetLogEntry[]>;
-    protected logEntry(entry: MaybeTargetLogEntry): boolean | void;
+    protected logEntry(entry: TargetLogEntry): boolean | void;
     // (undocumented)
     protected logStream: Writable;
+    // Warning: (ae-forgotten-export) The symbol "GroupedReporterOptions" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    protected options: {
-        logLevel?: LogLevel;
-        grouped?: boolean;
-        logMemory?: boolean;
-        logStream?: Writable;
-    };
+    protected options: GroupedReporterOptions;
+    protected shouldLog(entry: MaybeTargetLogEntry): boolean;
     // (undocumented)
     summarize(schedulerRunSummary: SchedulerRunSummary): void;
     protected abstract writeFailures(failed: string[], targetRuns: Map<string, TargetRun<unknown>>): void;
     protected abstract writeSummaryFooter(): void;
     protected abstract writeSummaryHeader(): void;
+}
+
+// @public (undocumented)
+interface GroupedReporterOptions {
+    grouped?: boolean;
+    logLevel?: LogLevel;
+    logMemory?: boolean;
+    logStream?: Writable;
 }
 
 // @public
@@ -165,12 +165,7 @@ interface JsonReporterTaskStats {
 
 // @public
 export class LogReporter implements TargetReporter {
-    constructor(options: {
-        logLevel?: LogLevel;
-        grouped?: boolean;
-        logMemory?: boolean;
-        logStream?: Writable;
-    });
+    constructor(options: GroupedReporterOptions);
     // (undocumented)
     log(entry: MaybeTargetLogEntry): void;
     // (undocumented)

--- a/packages/reporters/src/BasicReporter.ts
+++ b/packages/reporters/src/BasicReporter.ts
@@ -5,7 +5,8 @@ import chalk from "chalk";
 import { formatHrtime } from "./formatDuration.js";
 import { fancyGradient, formatBytes, formatMemoryUsage, hrLine } from "./formatHelpers.js";
 import type { TargetReporter, MaybeTargetLogEntry, TargetLogEntry } from "./types/TargetReporter.js";
-import { isTargetLogEntry } from "./isTargetLogEntry.js";
+import { isTargetLogEntry, isTargetStatusData } from "./isTargetLogEntry.js";
+import { isCompletionStatus, type CompletionStatus } from "./isCompletionStatus.js";
 
 type CoarseStatus = "completed" | "running" | "pending";
 
@@ -18,9 +19,6 @@ const coarseStatus: Record<TargetStatus, CoarseStatus> = {
   pending: "pending",
   queued: "pending",
 };
-
-type CompletionStatus = "success" | "failed" | "skipped" | "aborted";
-const isCompletionStatus = (status: TargetStatus): status is CompletionStatus => coarseStatus[status] === "completed";
 
 const colors = {
   label: chalk.white,
@@ -53,7 +51,8 @@ const terminal = {
  * the names of running targets for efficiency.
  */
 export class BasicReporter implements TargetReporter {
-  private taskData = new Map<string, { target: Target; status: TargetStatus; logEntries: TargetLogEntry[] }>();
+  /** Mapping from targetId to status and log entries (the logs will be cleared for non-failed completed targets) */
+  private taskData = new Map<string, { status: TargetStatus; logEntries: TargetLogEntry[] }>();
   private updateTimer: NodeJS.Timeout | undefined;
   private startTimer: () => void;
   private logMemory: boolean;
@@ -93,19 +92,26 @@ export class BasicReporter implements TargetReporter {
     if (!isTargetLogEntry(entry) || entry.data.target.hidden) return;
     const data = entry.data;
 
-    let taskData = this.taskData.get(data.target.id);
+    const { target } = data;
+    let taskData = this.taskData.get(target.id);
     if (!taskData) {
-      taskData = { target: data.target, status: "pending", logEntries: [] };
-      this.taskData.set(data.target.id, taskData);
+      taskData = { status: "pending", logEntries: [] };
+      this.taskData.set(target.id, taskData);
     }
 
     this.startTimer();
     taskData.logEntries.push(entry);
 
-    if ("status" in data) {
-      taskData.status = data.status;
-      if (isCompletionStatus(data.status)) {
-        this.reportCompletion({ target: data.target, status: data.status, duration: data.duration, memoryUsage: data.memoryUsage });
+    if (isTargetStatusData(data)) {
+      const { status, duration, memoryUsage } = data;
+      taskData.status = status;
+      if (isCompletionStatus(status)) {
+        this.reportCompletion({ target, status, duration, memoryUsage });
+
+        // Free log entries for non-failed completed targets (only needed for failure reporting at summary time)
+        if (status !== "failed") {
+          taskData.logEntries = [];
+        }
       }
     }
   }

--- a/packages/reporters/src/GroupedReporter.ts
+++ b/packages/reporters/src/GroupedReporter.ts
@@ -1,5 +1,5 @@
 import { formatHrtime } from "./formatDuration.js";
-import { isTargetLogEntry, isTargetStatusLogEntry } from "./isTargetLogEntry.js";
+import { isTargetLogEntry, isTargetStatusData } from "./isTargetLogEntry.js";
 import { LogLevel } from "@lage-run/logger";
 import chalk from "chalk";
 import type { SchedulerRunSummary, TargetRun } from "@lage-run/scheduler-types";
@@ -8,6 +8,7 @@ import { slowestTargetRuns } from "./slowestTargetRuns.js";
 import { formatMemoryUsage } from "./formatHelpers.js";
 import { statusColorFn } from "./LogReporter.js";
 import type { MaybeTargetLogEntry, TargetLogEntry, TargetReporter } from "./types/TargetReporter.js";
+import { isNonFailureCompletionStatus } from "./isCompletionStatus.js";
 
 export const colors = {
   [LogLevel.info]: chalk.white,
@@ -38,69 +39,84 @@ function format(level: LogLevel, prefix: string, message: string): string {
   return `${logLevelLabel[level]}: ${prefix} ${message}\n`;
 }
 
+export interface GroupedReporterOptions {
+  /** Only report logs with this level or numerically lower/logically higher (default info) */
+  logLevel?: LogLevel;
+
+  /** Whether to group log entries by target */
+  grouped?: boolean;
+
+  /** Whether to capture and report main process memory usage on target completion */
+  logMemory?: boolean;
+
+  /** stream for testing (defaults to stdout) */
+  logStream?: Writable;
+}
+
 /**
  * Abstract reporter which optionally groups log entries by target.
  * If grouping is enabled, it only flushes a target's log entries when it completes.
  */
 export abstract class GroupedReporter implements TargetReporter {
   protected logStream: Writable;
+  /** Mapping from targetId log entries (the logs will be cleared for non-failed completed targets) */
   protected logEntries = new Map<string, TargetLogEntry[]>();
-  private readonly groupedEntries: Map<string, TargetLogEntry[]> = new Map<string, TargetLogEntry[]>();
 
-  constructor(
-    protected options: {
-      logLevel?: LogLevel;
-      grouped?: boolean;
-      /** Whether to capture and report main process memory usage on target completion */
-      logMemory?: boolean;
-      /** stream for testing */
-      logStream?: Writable;
-    }
-  ) {
-    options.logLevel = options.logLevel || LogLevel.info;
+  constructor(protected options: GroupedReporterOptions) {
+    options.logLevel ??= LogLevel.info;
     this.logStream = options.logStream || process.stdout;
   }
 
-  public log(entry: MaybeTargetLogEntry): boolean | void {
-    const isTargetLog = isTargetLogEntry(entry);
-    if (isTargetLog && entry.data.target.hidden) {
-      return;
-    }
-
-    if (isTargetLog) {
-      if (!this.logEntries.has(entry.data.target.id)) {
-        this.logEntries.set(entry.data.target.id, []);
-      }
-
-      this.logEntries.get(entry.data.target.id)!.push(entry);
-    }
-
-    if (this.options.logLevel! >= entry.level) {
-      if (this.options.grouped && isTargetLog) {
-        return this.logTargetEntryByGroup(entry);
-      }
-
-      return this.logEntry(entry);
-    }
-  }
-
-  /** Print the entry for a target */
-  protected logEntry(entry: MaybeTargetLogEntry): boolean | void {
-    const colorFn = colors[entry.level];
-
-    if (!isTargetLogEntry(entry)) {
-      if (entry.msg.trim()) {
+  public log(entry: MaybeTargetLogEntry): void {
+    if (isTargetLogEntry(entry)) {
+      if (entry.data.target.hidden) return;
+    } else {
+      // log generic entries (not related to target)
+      if (this.shouldLog(entry) && entry.msg.trim()) {
         this.logStream.write(format(entry.level, "", entry.msg));
       }
       return;
     }
+
+    // save the logs for errors (regardless of level)
+    const targetId = entry.data.target.id;
+    if (!this.logEntries.has(targetId)) {
+      this.logEntries.set(targetId, []);
+    }
+    this.logEntries.get(targetId)!.push(entry);
+
+    if (this.shouldLog(entry)) {
+      if (this.options.grouped) {
+        this.logTargetEntryByGroup(entry);
+      } else {
+        this.logEntry(entry);
+      }
+    }
+
+    // If it's a status message for non-failure completion, delete the target's entries to free memory
+    if (isTargetStatusData(entry.data) && isNonFailureCompletionStatus(entry.data.status)) {
+      this.logEntries.delete(targetId);
+    }
+  }
+
+  /**
+   * Whether the entry should be logged based solely on its level compared to the reporter's `logLevel`
+   * (does not consider `entry.target.hidden` or message presence)
+   */
+  protected shouldLog(entry: MaybeTargetLogEntry): boolean {
+    return this.options.logLevel! >= entry.level;
+  }
+
+  /** Print the entry for a target */
+  protected logEntry(entry: TargetLogEntry): boolean | void {
+    const colorFn = colors[entry.level];
 
     const data = entry.data;
     const { target } = data;
     const { packageName, task } = target;
     const prefix = this.options.grouped ? "" : getTaskLogPrefix(packageName ?? "<root>", task);
 
-    if (!isTargetStatusLogEntry(data)) {
+    if (!isTargetStatusData(data)) {
       return this.logStream.write(format(entry.level, prefix, colorFn("|  " + entry.msg)));
     }
 
@@ -144,15 +160,12 @@ export abstract class GroupedReporter implements TargetReporter {
     const target = data.target;
     const { id } = target;
 
-    this.groupedEntries.set(id, this.groupedEntries.get(id) || []);
-    this.groupedEntries.get(id)?.push(entry);
-
-    if (isTargetStatusLogEntry(data)) {
+    if (isTargetStatusData(data)) {
       if (data.status === "success" || data.status === "failed" || data.status === "skipped" || data.status === "aborted") {
         const { status, duration } = data;
         this.logStream.write(this.formatGroupStart(data.target.packageName ?? "<root>", data.target.task, status, duration));
 
-        const entries = this.groupedEntries.get(id)!;
+        const entries = this.logEntries.get(id)!;
         for (const targetEntry of entries) {
           this.logEntry(targetEntry);
         }

--- a/packages/reporters/src/LogReporter.ts
+++ b/packages/reporters/src/LogReporter.ts
@@ -1,5 +1,5 @@
 import { formatHrtime, hrtimeDiff } from "./formatDuration.js";
-import { isTargetLogEntry, isTargetStatusLogEntry } from "./isTargetLogEntry.js";
+import { isTargetLogEntry, isTargetStatusData } from "./isTargetLogEntry.js";
 import { LogLevel } from "@lage-run/logger";
 import chalk from "chalk";
 import type { Chalk } from "chalk";
@@ -9,6 +9,8 @@ import crypto from "crypto";
 import { fancyGradient, formatBytes, formatMemoryUsage, hrLine, stripAnsi } from "./formatHelpers.js";
 import { slowestTargetRuns } from "./slowestTargetRuns.js";
 import type { TargetLogEntry, MaybeTargetLogEntry, TargetReporter } from "./types/TargetReporter.js";
+import type { GroupedReporterOptions } from "./GroupedReporter.js";
+import { isCompletionStatus, isNonFailureCompletionStatus } from "./isCompletionStatus.js";
 
 /** Color scheme from lage v1's reporter and others derived from it */
 export const colors = {
@@ -54,6 +56,7 @@ function hashStringToNumber(str: string): number {
 
 const pkgNameToIndexInPkgColorArray = new Map<string, number>();
 
+/** Get the color for a package name per lage v1 package color logic */
 function getColorForPkg(pkg: string): Chalk {
   if (!pkgNameToIndexInPkgColorArray.has(pkg)) {
     const index = hashStringToNumber(pkg) % pkgColors.length;
@@ -74,56 +77,55 @@ function getTaskLogPrefix(pkg: string, task: string) {
  */
 export class LogReporter implements TargetReporter {
   private logStream: Writable;
+  /** Mapping from targetId log entries (the logs will be cleared for non-failed completed targets) */
   private logEntries = new Map<string, TargetLogEntry[]>();
 
-  constructor(
-    private options: {
-      logLevel?: LogLevel;
-      grouped?: boolean;
-      /** Whether to capture and report main process memory usage on target completion */
-      logMemory?: boolean;
-      /** stream for testing */
-      logStream?: Writable;
-    }
-  ) {
-    options.logLevel = options.logLevel || LogLevel.info;
+  constructor(private options: GroupedReporterOptions) {
+    options.logLevel ??= LogLevel.info;
     this.logStream = options.logStream || process.stdout;
   }
 
   public log(entry: MaybeTargetLogEntry): void {
-    // if "hidden", do not even attempt to record or report the entry
-    const isTargetLog = isTargetLogEntry(entry);
-    if (isTargetLog && entry.data.target.hidden) {
+    if (isTargetLogEntry(entry)) {
+      // if "hidden", do not even attempt to record or report the entry
+      if (entry.data.target.hidden) return;
+    } else {
+      // log generic entries (not related to target)
+      if (this.shouldLog(entry) && entry.msg) {
+        this.print(entry.msg);
+      }
       return;
     }
 
     // save the logs for errors
-    if (isTargetLog && entry.data.target.id) {
-      if (!this.logEntries.has(entry.data.target.id)) {
-        this.logEntries.set(entry.data.target.id, []);
-      }
-      this.logEntries.get(entry.data.target.id)!.push(entry);
+    const targetId = entry.data.target.id;
+    if (!this.logEntries.has(targetId)) {
+      this.logEntries.set(targetId, []);
     }
+    this.logEntries.get(targetId)!.push(entry);
 
-    // if loglevel is not high enough, do not report the entry
-    if (this.options.logLevel! < entry.level) {
+    if (!this.shouldLog(entry)) {
       return;
     }
 
-    // log to grouped entries
-    if (this.options.grouped && isTargetLog) {
-      return this.logTargetEntryByGroup(entry);
+    if (this.options.grouped) {
+      this.logTargetEntryByGroup(entry);
+    } else {
+      this.logTargetEntry(entry);
     }
 
-    // log normal target entries
-    if (isTargetLog) {
-      return this.logTargetEntry(entry);
+    // If it's a status message for non-failure completion, delete the target's entries to free memory
+    if (isTargetStatusData(entry.data) && isNonFailureCompletionStatus(entry.data.status)) {
+      this.logEntries.delete(targetId);
     }
+  }
 
-    // log generic entries (not related to target)
-    if (entry.msg) {
-      return this.print(entry.msg);
-    }
+  /**
+   * Whether the entry should be logged based solely on its level compared to the reporter's `logLevel`
+   * (does not consider `entry.target.hidden` or message presence)
+   */
+  private shouldLog(entry: MaybeTargetLogEntry): boolean {
+    return this.options.logLevel! >= entry.level;
   }
 
   private printEntry(entry: TargetLogEntry, message: string) {
@@ -146,7 +148,7 @@ export class LogReporter implements TargetReporter {
     const colorFn = colors[entry.level];
     const data = entry.data!;
 
-    if (!isTargetStatusLogEntry(data)) {
+    if (!isTargetStatusData(data)) {
       return this.printEntry(entry, colorFn(":  " + stripAnsi(entry.msg)));
     }
 
@@ -186,10 +188,7 @@ export class LogReporter implements TargetReporter {
     const target = data.target;
     const { id } = target;
 
-    if (
-      isTargetStatusLogEntry(data) &&
-      (data.status === "success" || data.status === "failed" || data.status === "skipped" || data.status === "aborted")
-    ) {
+    if (isTargetStatusData(data) && isCompletionStatus(data.status)) {
       const entries = this.logEntries.get(id)!;
 
       for (const targetEntry of entries) {
@@ -215,9 +214,6 @@ export class LogReporter implements TargetReporter {
 
       for (const wrappedTarget of slowestTargets) {
         const { target, status, duration } = wrappedTarget;
-        if (target.hidden) {
-          continue;
-        }
 
         const colorFn = statusColorFn[status] ?? chalk.white;
         const queueDuration = hrtimeDiff(wrappedTarget.queueTime, wrappedTarget.startTime);
@@ -246,25 +242,23 @@ export class LogReporter implements TargetReporter {
 
     this.print(hrLine);
 
-    if (failed.length > 0) {
-      for (const targetId of failed) {
-        const target = targetRuns.get(targetId)?.target;
+    for (const targetId of failed) {
+      const target = targetRuns.get(targetId)?.target;
 
-        if (target) {
-          const { packageName, task } = target;
-          const failureLogs = this.logEntries.get(targetId);
+      if (target) {
+        const { packageName, task } = target;
+        const failureLogs = this.logEntries.get(targetId);
 
-          this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
+        this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
 
-          if (failureLogs) {
-            for (const entry of failureLogs) {
-              // Log each entry separately to prevent truncation
-              this.print(entry.msg);
-            }
+        if (failureLogs) {
+          for (const entry of failureLogs) {
+            // Log each entry separately to prevent truncation
+            this.print(entry.msg);
           }
-
-          this.print(hrLine);
         }
+
+        this.print(hrLine);
       }
     }
 

--- a/packages/reporters/src/ProgressReporter.ts
+++ b/packages/reporters/src/ProgressReporter.ts
@@ -7,7 +7,6 @@ import {
   type TaskReporterOptions,
   type TaskReporterTask,
 } from "@ms-cloudpack/task-reporter";
-import type { Target } from "@lage-run/target-graph";
 import chalk from "chalk";
 import type { Writable } from "stream";
 import { formatHrtime, hrtimeDiff } from "./formatDuration.js";
@@ -16,6 +15,7 @@ import { slowestTargetRuns } from "./slowestTargetRuns.js";
 import { colors, statusColorFn } from "./LogReporter.js";
 import type { TargetLogEntry, MaybeTargetLogEntry, TargetReporter } from "./types/TargetReporter.js";
 import { isTargetLogEntry, isTargetStatusLogEntry } from "./isTargetLogEntry.js";
+import { isCompletionStatus } from "./isCompletionStatus.js";
 
 /**
  * Shows progress including the names of currently running targets using `@ms-cloudpack/task-reporter`.
@@ -25,10 +25,10 @@ import { isTargetLogEntry, isTargetStatusLogEntry } from "./isTargetLogEntry.js"
 export class ProgressReporter implements TargetReporter {
   private logStream: Writable;
   private hasLogStreamOverride: boolean;
+  /** Mapping from targetId log entries (the logs will be cleared for completed targets) */
   private logEntries: Map<string, TargetLogEntry[]> = new Map<string, TargetLogEntry[]>();
   private taskReporter: TaskReporter;
   private tasks: Map<string, TaskReporterTask> = new Map();
-  private logMemory: boolean;
 
   constructor(
     private options: {
@@ -45,7 +45,6 @@ export class ProgressReporter implements TargetReporter {
       taskReporterOptions?: TaskReporterOptions;
     }
   ) {
-    this.logMemory = !!options.logMemory;
     this.logStream = options.logStream || process.stdout;
     this.hasLogStreamOverride = !!options.logStream;
     if (this.hasLogStreamOverride) {
@@ -76,32 +75,37 @@ export class ProgressReporter implements TargetReporter {
 
   public log(entry: MaybeTargetLogEntry): void {
     const isTargetLog = isTargetLogEntry(entry);
+    if (!isTargetLog) {
+      return;
+    }
+    const target = entry.data.target;
 
     // save the logs for errors
-    if (isTargetLog && entry.data.target.id) {
-      if (!this.logEntries.has(entry.data.target.id)) {
-        this.logEntries.set(entry.data.target.id, []);
+    if (target.id) {
+      if (!this.logEntries.has(target.id)) {
+        this.logEntries.set(target.id, []);
       }
-      this.logEntries.get(entry.data.target.id)!.push(entry);
+      this.logEntries.get(target.id)!.push(entry);
     }
 
-    // if "hidden", do not even attempt to record or report the entry
-    if (isTargetLog && entry.data.target.hidden) {
+    // if "hidden", do not even attempt to record or report the entry.
+    // also if not a status message, nothing else to do.
+    if (target.hidden || !isTargetStatusLogEntry(entry)) {
       return;
     }
 
-    if (!isTargetLog || !isTargetStatusLogEntry(entry.data)) {
-      return;
-    }
-
-    const target: Target = entry.data.target;
+    const { status, memoryUsage } = entry.data;
+    const memoryMessage = formatMemoryUsage(memoryUsage, this.options.logMemory);
 
     const reporterTask = this.tasks.has(target.id) ? this.tasks.get(target.id)! : this.taskReporter.addTask(target.label, true);
 
-    this.tasks.set(target.id, reporterTask);
-
-    const { status, memoryUsage } = entry.data;
-    const memoryMessage = formatMemoryUsage(memoryUsage, this.logMemory);
+    if (isCompletionStatus(status)) {
+      // If the reporter task will be completed below (any status), delete it from memory
+      // since it's not used at all in the summary logging
+      this.tasks.delete(target.id);
+    } else {
+      this.tasks.set(target.id, reporterTask);
+    }
 
     switch (status) {
       case "running":
@@ -157,9 +161,6 @@ export class ProgressReporter implements TargetReporter {
 
       for (const wrappedTarget of slowestTargets) {
         const { target, status, duration, queueTime, startTime } = wrappedTarget;
-        if (target.hidden) {
-          continue;
-        }
 
         const colorFn = statusColorFn[status] ?? chalk.white;
         const queueDuration = duration && queueTime ? hrtimeDiff(queueTime, startTime) : undefined;
@@ -188,25 +189,23 @@ export class ProgressReporter implements TargetReporter {
 
     this.print(hrLine);
 
-    if (failed.length > 0) {
-      for (const targetId of failed) {
-        const target = targetRuns.get(targetId)?.target;
+    for (const targetId of failed) {
+      const target = targetRuns.get(targetId)?.target;
 
-        if (target) {
-          const { packageName, task } = target;
-          const failureLogs = this.logEntries.get(targetId);
+      if (target) {
+        const { packageName, task } = target;
+        const failureLogs = this.logEntries.get(targetId);
 
-          this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
+        this.print(`[${colors.pkg(packageName ?? "<root>")} ${colors.task(task)}] ${colors[LogLevel.error]("ERROR DETECTED")}`);
 
-          if (failureLogs) {
-            for (const entry of failureLogs) {
-              // Log each entry separately to prevent truncation
-              this.print(entry.msg);
-            }
+        if (failureLogs) {
+          for (const entry of failureLogs) {
+            // Log each entry separately to prevent truncation
+            this.print(entry.msg);
           }
-
-          this.print(hrLine);
         }
+
+        this.print(hrLine);
       }
     }
 

--- a/packages/reporters/src/VerboseFileLogReporter.ts
+++ b/packages/reporters/src/VerboseFileLogReporter.ts
@@ -1,5 +1,5 @@
 import { formatHrtime } from "./formatDuration.js";
-import { isTargetLogEntry, isTargetStatusLogEntry } from "./isTargetLogEntry.js";
+import { isTargetLogEntry, isTargetStatusData } from "./isTargetLogEntry.js";
 import { LogLevel } from "@lage-run/logger";
 import { Writable } from "stream";
 import fs from "fs";
@@ -96,7 +96,7 @@ export class VerboseFileLogReporter implements TargetReporter {
   private logTargetEntry(entry: TargetLogEntry) {
     const data = entry.data!;
 
-    if (isTargetStatusLogEntry(data)) {
+    if (isTargetStatusData(data)) {
       const { hash, duration, status, memoryUsage } = data;
       const mem = formatMemoryUsage(memoryUsage, this.logMemory);
 

--- a/packages/reporters/src/isCompletionStatus.ts
+++ b/packages/reporters/src/isCompletionStatus.ts
@@ -1,0 +1,11 @@
+import type { TargetStatus } from "@lage-run/scheduler-types";
+
+export type CompletionStatus = "success" | "failed" | "skipped" | "aborted";
+
+export function isCompletionStatus(status: TargetStatus): status is CompletionStatus {
+  return status === "success" || status === "failed" || status === "skipped" || status === "aborted";
+}
+
+export function isNonFailureCompletionStatus(status: TargetStatus): status is Exclude<CompletionStatus, "failed"> {
+  return status === "success" || status === "skipped" || status === "aborted";
+}

--- a/packages/reporters/src/isTargetLogEntry.ts
+++ b/packages/reporters/src/isTargetLogEntry.ts
@@ -6,6 +6,10 @@ export function isTargetLogEntry(entry: LogEntry<LogStructuredData>): entry is T
   return entry.data !== undefined && (entry.data as TargetData).target !== undefined;
 }
 
-export function isTargetStatusLogEntry(data?: LogStructuredData): data is TargetStatusData {
-  return data !== undefined && (data as TargetStatusData).target && (data as TargetStatusData).status !== undefined;
+export function isTargetStatusLogEntry(entry: LogEntry<any>): entry is Required<LogEntry<TargetStatusData>> {
+  return !!entry.data?.target && entry.data.status !== undefined;
+}
+
+export function isTargetStatusData(data: any | undefined): data is TargetStatusData {
+  return !!data?.target && data.status !== undefined;
 }

--- a/packages/reporters/src/slowestTargetRuns.ts
+++ b/packages/reporters/src/slowestTargetRuns.ts
@@ -1,8 +1,11 @@
 import { hrtimeDiff, hrToSeconds } from "./formatDuration.js";
 import type { TargetRun } from "@lage-run/scheduler-types";
 
+/**
+ * Sort the target runs by duration, with skipped and hidden targets removed.
+ */
 export function slowestTargetRuns(targetRuns: TargetRun[]): TargetRun<unknown>[] {
   return targetRuns
-    .sort((a, b) => parseFloat(hrToSeconds(hrtimeDiff(a.duration, b.duration))))
-    .filter((run) => run.status !== "skipped" && !run.target.hidden);
+    .filter((run) => run.status !== "skipped" && !run.target.hidden)
+    .sort((a, b) => parseFloat(hrToSeconds(hrtimeDiff(a.duration, b.duration))));
 }


### PR DESCRIPTION
This doesn't seem to be the main source of lage's memory issues, but it's good practice for reporters to delete the stored log entries when no longer needed.

Also start cleaning up and slightly unifying some of the duplicated logic across reporters.