### PR TITLE
[workspace-tools] Improvements for determining the remote branch

### DIFF
--- a/change/change-5a9aba43-58fd-4854-819b-201fe3f3b7c5.json
+++ b/change/change-5a9aba43-58fd-4854-819b-201fe3f3b7c5.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Add `resolveRemoteBranch` which parses the remote from the provided branch if present, or gets the remote (and branch if not provided) from `getDefaultRemoteBranch`. Improve efficiency and reduce git operations for various remote-related helpers.",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -220,6 +220,7 @@ export type GetDefaultRemoteOptions = {
     cwd: string;
     strict?: boolean;
     verbose?: boolean;
+    remotes?: Record<string, string>;
 };
 
 // @public @deprecated (undocumented)
@@ -659,6 +660,11 @@ export interface PnpmLockFile {
 
 // @public (undocumented)
 export function queryLockFile(name: string, versionRange: string, lock: ParsedLock): LockDependency;
+
+// @public
+export function resolveRemoteBranch(options: Omit<GetDefaultRemoteBranchOptions, "branch" | "remotes"> & {
+    branch: string | undefined;
+}): string;
 
 // @public
 export function revertLocalChanges(options: GitCommonOptions): boolean;

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemote.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemote.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+import fs from "fs";
 import path from "path";
 import { cleanupFixtures, setupFixture, setupPackageJson } from "../setupFixture.js";
 import { addGitObserver, clearGitObservers, gitFailFast, type GitObserver } from "../../git/git.js";
@@ -42,12 +43,12 @@ describe("_matchRepositoryUrlToRemote", () => {
   it("returns undefined if no remotes (permissive)", () => {
     const result = _matchRepositoryUrlToRemote(remoteUrls.microsoft, {}, permissiveLog);
     expect(result).toBeUndefined();
-    expect(permissiveLog).toHaveBeenCalledWith('Could not find remote pointing to repository "microsoft/lage".');
+    expect(permissiveLog).toHaveBeenCalledWith('Could not find remote pointing to repository "microsoft/lage"');
   });
 
   it("throws if no remotes (strict)", () => {
     expect(() => _matchRepositoryUrlToRemote(remoteUrls.microsoft, {}, strictLog)).toThrow(
-      'Could not find remote pointing to repository "microsoft/lage".'
+      'Could not find remote pointing to repository "microsoft/lage"'
     );
   });
 
@@ -134,12 +135,12 @@ describe("getDefaultRemote", () => {
   const gitObserver = jest.fn<GitObserver>();
 
   // git commands issued by getDefaultRemote
+  const gitGetRemotesConfig = "config --local --get-regexp remote\\..*\\.url";
   const gitGetRoot = "rev-parse --show-toplevel";
-  const gitGetRemotesConfig = "config --get-regexp remote\\..*\\.url";
 
   const logMissingRepositoryKey = (dir: string) =>
-    expect.stringContaining(`Valid "repository" key not found in package.json at "${path.join(dir, "package.json")}"`);
-  const logMissingRemotes = (dir: string) => `Could not find any remotes in git repo at "${dir}".`;
+    expect.stringContaining(`Valid "repository" key not found in package.json at ${path.join(dir, "package.json")}`);
+  const logMissingRemotes = (dir: string) => `No remotes defined in git repo at ${dir}`;
 
   function gitRemote(...args: string[]) {
     gitFailFast(["remote", ...args], { cwd, noExitCode: true });
@@ -169,61 +170,59 @@ describe("getDefaultRemote", () => {
     clearGitObservers();
   });
 
-  it("throws if not in a git repo", () => {
-    // Use a completely invalid path since the it falls under the same error handling case
-    // and definitely won't be a git repo by accident
-    gitObserver.mockClear();
-    expect(() => getDefaultRemote({ cwd: "/nonexistent/dir" })).toThrow("is not in a git repository");
-    expect(getGitCalls()).toEqual([gitGetRoot]);
+  it("throws if not in a git repo (permissive)", () => {
+    cwd = setupFixture();
+    // sanity check: if this fails, there's a git repo in the OS temp dir
+    expect(() => getDefaultRemote({ cwd })).toThrow(`Directory "${cwd}" is not in a git repository`);
 
     gitObserver.mockClear();
-    expect(() => getDefaultRemote({ cwd: "/nonexistent/dir", strict: true })).toThrow("is not in a git repository");
-    expect(getGitCalls()).toEqual([gitGetRoot]);
+    expect(() => getDefaultRemote({ cwd })).toThrow(`Directory "${cwd}" is not in a git repository`);
+    // getting remotes doesn't throw, but findGitRoot does
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
 
-  it("returns 'origin' if no package.json and no remotes found (permissive)", () => {
+  it("throws if not in a git repo (strict)", () => {
+    cwd = setupFixture();
+    // sanity check: if this fails, there's a git repo in the OS temp dir
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(`${cwd} is not in a git repository`);
+
+    gitObserver.mockClear();
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(`${cwd} is not in a git repository`);
+    // getting remotes will throw in strict mode
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+  });
+
+  it("returns 'origin' if no remotes found (permissive)", () => {
     expect(getDefaultRemote({ cwd: emptyRepoCwd, verbose: true })).toBe("origin");
 
-    expect(getLogs()).toEqual([
-      `Could not read "${path.join(emptyRepoCwd, "package.json")}"`,
-      logMissingRepositoryKey(emptyRepoCwd),
-      logMissingRemotes(emptyRepoCwd),
-      'Assuming default remote "origin".',
-    ]);
-    // No repository URL in package.json → findGitRoot called.
+    expect(getLogs()).toEqual([logMissingRemotes(emptyRepoCwd), 'Assuming default remote "origin"']);
     // No remotes configured → config command runs but finds nothing.
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    // findGitRoot called to verify it's a git repo.
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
 
-  it("throws if no package.json (strict)", () => {
-    expect(() => getDefaultRemote({ cwd: emptyRepoCwd, strict: true })).toThrow(
-      `Could not read "${path.join(emptyRepoCwd, "package.json")}"`
-    );
-    // Throws after reading package.json fails — never reaches getRemotes.
-    expect(getGitCalls()).toEqual([gitGetRoot]);
-  });
-
-  it("returns 'origin' if no repository field and no remotes (permissive)", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd);
-    gitObserver.mockClear();
-
-    expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expect(getLogs()).toEqual([
-      logMissingRepositoryKey(cwd),
-      logMissingRemotes(cwd),
-      'Assuming default remote "origin".',
-    ]);
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
-  });
-
-  it("throws if no repository field and no remotes (strict)", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd);
+  it("throws if no remotes found (strict)", () => {
+    cwd = emptyRepoCwd;
     gitObserver.mockClear();
 
     expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(logMissingRemotes(cwd));
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+  });
+
+  it("throws if no package.json (strict)", () => {
+    cwd = setupFixture(undefined, { git: true });
+    gitRemote("add", "origin", remoteUrls.microsoft);
+    gitObserver.mockClear();
+
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(`Could not find package.json under ${cwd}`);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
+
+    // variant message for subfolder
+    const subfolder = path.join(cwd, "subfolder");
+    fs.mkdirSync(subfolder);
+    expect(() => getDefaultRemote({ cwd: subfolder, strict: true })).toThrow(
+      `Could not find package.json under ${subfolder} or git root ${cwd}`
+    );
   });
 
   it("uses provided remotes instead of getting from repo", () => {
@@ -235,8 +234,7 @@ describe("getDefaultRemote", () => {
     const remotes = { origin: remoteUrls.ecraig12345, default: remoteUrls.microsoft, another: remoteUrls.kenotron };
     expect(getDefaultRemote({ cwd, remotes })).toBe("default");
     expect(getDefaultRemote({ cwd, remotes, strict: true })).toBe("default");
-    // repository URL found in package.json → no findGitRoot. options.remotes provided → no getRemotes.
-    expect(getGitCalls()).toEqual([]);
+    expect(gitObserver).not.toHaveBeenCalled();
   });
 
   it("defaults to existing upstream remote without repository field", () => {
@@ -249,7 +247,7 @@ describe("getDefaultRemote", () => {
 
     // permissive/strict have same behavior
     expect(getDefaultRemote({ cwd, strict: true, verbose: true })).toBe("upstream");
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
     expect(getLogs()).toEqual([logMissingRepositoryKey(cwd), 'Default to remote "upstream"']);
   });
 
@@ -262,7 +260,7 @@ describe("getDefaultRemote", () => {
 
     // permissive/strict have same behavior
     expect(getDefaultRemote({ cwd, strict: true, verbose: true })).toBe("origin");
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
     expect(getLogs()).toEqual([logMissingRepositoryKey(cwd), 'Default to remote "origin"']);
   });
 
@@ -275,7 +273,7 @@ describe("getDefaultRemote", () => {
 
     // permissive/strict have same behavior
     expect(getDefaultRemote({ cwd, strict: true, verbose: true })).toBe("first");
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
     expect(getLogs()).toEqual([logMissingRepositoryKey(cwd), 'Default to remote "first"']);
   });
 
@@ -287,11 +285,6 @@ describe("getDefaultRemote", () => {
     gitRemote("add", "second", remoteUrls.microsoft);
     gitObserver.mockClear();
 
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
-
-    // repository URL found in package.json → findGitRoot is never called
-    gitObserver.mockClear();
     expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
@@ -303,30 +296,7 @@ describe("getDefaultRemote", () => {
     gitRemote("add", "second", remoteUrls.microsoft);
     gitObserver.mockClear();
 
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
-
-    gitObserver.mockClear();
     expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
-  });
-
-  it("returns 'origin' if no remotes and repository specified (permissive)", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: remoteUrls.microsoft, type: "git" } });
-    gitObserver.mockClear();
-
-    expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expect(getLogs()).toEqual([logMissingRemotes(cwd), 'Assuming default remote "origin".']);
-    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
-  });
-
-  it("throws if no remotes and repository specified (strict)", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: remoteUrls.microsoft, type: "git" } });
-    gitObserver.mockClear();
-
-    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(logMissingRemotes(cwd));
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
@@ -340,7 +310,7 @@ describe("getDefaultRemote", () => {
     expect(getDefaultRemote({ cwd, verbose: true })).toBe("first");
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
     expect(getLogs()).toEqual([
-      'Could not find remote pointing to repository "ecraig12345/lage".',
+      'Could not find remote pointing to repository "ecraig12345/lage"',
       'Default to remote "first"',
     ]);
   });
@@ -353,6 +323,19 @@ describe("getDefaultRemote", () => {
     gitObserver.mockClear();
 
     expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find remote pointing to repository");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+  });
+
+  it("respects repository field in non-git-root cwd package.json", () => {
+    cwd = setupFixture(undefined, { git: true });
+    const subfolder = path.join(cwd, "sub/folder");
+    fs.mkdirSync(subfolder, { recursive: true });
+    setupPackageJson(subfolder, { repository: remoteUrls.microsoft });
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "second", remoteUrls.microsoft);
+    gitObserver.mockClear();
+
+    expect(getDefaultRemote({ cwd: subfolder, strict: true })).toBe("second");
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 });

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemote.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemote.test.ts
@@ -1,301 +1,358 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
-import os from "os";
 import path from "path";
 import { cleanupFixtures, setupFixture, setupPackageJson } from "../setupFixture.js";
-import { gitFailFast } from "../../git/git.js";
-import { getDefaultRemote } from "../../git/getDefaultRemote.js";
+import { addGitObserver, clearGitObservers, gitFailFast, type GitObserver } from "../../git/git.js";
+import { _matchRepositoryUrlToRemote, getDefaultRemote } from "../../git/getDefaultRemote.js";
+
+/** some sample remote URLs */
+const remoteUrls = {
+  microsoft: "https://github.com/microsoft/lage.git",
+  microsoftNoGit: "https://github.com/microsoft/lage",
+  microsoftSsh: "git@github.com:microsoft/lage.git",
+  microsoftShorthand: "github:microsoft/lage",
+  kenotron: "https://github.com/kenotron/lage.git",
+  kenotronSsh: "git@github.com:kenotron/lage.git",
+  ecraig12345: "https://github.com/ecraig12345/lage.git",
+  // VSO/ADO URLs all referring to org=foo, project=bar, repo=some-repo
+  vsoHttps: "https://foo.visualstudio.com/bar/_git/some-repo",
+  vsoHttpsDefaultCollection: "https://foo.visualstudio.com/DefaultCollection/bar/_git/some-repo",
+  vsoHttpsOptimized: "https://foo.visualstudio.com/DefaultCollection/bar/_git/_optimized/some-repo",
+  vsoHttpsUserToken: "https://user:fakePAT@foo.visualstudio.com/bar/_git/some-repo",
+  vsoSsh: "foo@vs-ssh.visualstudio.com:v3/foo/bar/some-repo",
+  adoHttps: "https://dev.azure.com/foo/bar/_git/some-repo",
+  adoHttpsOptimized: "https://dev.azure.com/foo/bar/_git/_optimized/some-repo",
+  adoHttpsUser: "https://foo@dev.azure.com/foo/bar/_git/some-repo",
+  adoSsh: "git@ssh.dev.azure.com:v3/foo/bar/some-repo",
+  // Non-matching remotes (different org)
+  vsoOtherOrg: "https://baz.visualstudio.com/bar/_git/some-repo",
+  adoOtherOrg: "https://dev.azure.com/baz/bar/_git/some-repo",
+} as const;
+
+describe("_matchRepositoryUrlToRemote", () => {
+  // These simulate the logOrThrow callback with strict: true vs false/unset.
+  const permissiveLog = jest.fn();
+  const strictLog = (msg: string) => {
+    throw new Error(msg);
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns undefined if no remotes (permissive)", () => {
+    const result = _matchRepositoryUrlToRemote(remoteUrls.microsoft, {}, permissiveLog);
+    expect(result).toBeUndefined();
+    expect(permissiveLog).toHaveBeenCalledWith('Could not find remote pointing to repository "microsoft/lage".');
+  });
+
+  it("throws if no remotes (strict)", () => {
+    expect(() => _matchRepositoryUrlToRemote(remoteUrls.microsoft, {}, strictLog)).toThrow(
+      'Could not find remote pointing to repository "microsoft/lage".'
+    );
+  });
+
+  it("finds remote matching repository URL", () => {
+    const result = _matchRepositoryUrlToRemote(
+      remoteUrls.microsoft,
+      { first: remoteUrls.kenotron, second: remoteUrls.microsoft },
+      strictLog
+    );
+    expect(result).toBe("second");
+  });
+
+  it("works with repository URL missing .git suffix", () => {
+    const result = _matchRepositoryUrlToRemote(
+      remoteUrls.microsoftNoGit,
+      { first: remoteUrls.kenotron, second: remoteUrls.microsoft },
+      strictLog
+    );
+    expect(result).toBe("second");
+  });
+
+  it("works with SSH remote format", () => {
+    const result = _matchRepositoryUrlToRemote(
+      remoteUrls.microsoft,
+      { first: remoteUrls.kenotronSsh, second: remoteUrls.microsoftSsh },
+      strictLog
+    );
+    expect(result).toBe("second");
+  });
+
+  it("works with shorthand repository format", () => {
+    const result = _matchRepositoryUrlToRemote(
+      remoteUrls.microsoftShorthand,
+      { first: remoteUrls.kenotron, second: remoteUrls.microsoft },
+      strictLog
+    );
+    expect(result).toBe("second");
+  });
+
+  it.each([
+    ["VSO HTTPS", remoteUrls.vsoHttps],
+    ["VSO HTTPS DefaultCollection", remoteUrls.vsoHttpsDefaultCollection],
+    ["VSO HTTPS _optimized", remoteUrls.vsoHttpsOptimized],
+    ["VSO SSH", remoteUrls.vsoSsh],
+    ["ADO HTTPS", remoteUrls.adoHttps],
+    ["ADO HTTPS _optimized", remoteUrls.adoHttpsOptimized],
+    ["ADO HTTPS user", remoteUrls.adoHttpsUser],
+    ["ADO SSH", remoteUrls.adoSsh],
+  ])("works with VSO HTTPS repository and %s remote", (_label, remoteUrl) => {
+    const result = _matchRepositoryUrlToRemote(
+      remoteUrls.vsoHttps,
+      // The multi-remote scenario is less common with VSO/ADO, but cover it just in case
+      { first: remoteUrls.vsoOtherOrg, second: remoteUrl },
+      strictLog
+    );
+    expect(result).toBe("second");
+  });
+
+  it.each([
+    ["ADO HTTPS", remoteUrls.adoHttps],
+    ["ADO HTTPS _optimized", remoteUrls.adoHttpsOptimized],
+    ["ADO HTTPS user", remoteUrls.adoHttpsUser],
+    ["ADO SSH", remoteUrls.adoSsh],
+    ["VSO HTTPS", remoteUrls.vsoHttps],
+    ["VSO HTTPS DefaultCollection", remoteUrls.vsoHttpsDefaultCollection],
+    ["VSO HTTPS _optimized", remoteUrls.vsoHttpsOptimized],
+    ["VSO HTTPS user and token", remoteUrls.vsoHttpsUserToken],
+    ["VSO SSH", remoteUrls.vsoSsh],
+  ])("works with ADO HTTPS repository and %s remote", (_label, remoteUrl) => {
+    const result = _matchRepositoryUrlToRemote(
+      remoteUrls.adoHttps,
+      { first: remoteUrls.adoOtherOrg, second: remoteUrl },
+      strictLog
+    );
+    expect(result).toBe("second");
+  });
+});
 
 describe("getDefaultRemote", () => {
   let cwd: string;
+  /** cwd for an empty git repo that should not be modified */
+  let emptyRepoCwd: string;
   let consoleMock: jest.SpiedFunction<typeof console.log>;
+  const gitObserver = jest.fn<GitObserver>();
+
+  // git commands issued by getDefaultRemote
+  const gitGetRoot = "rev-parse --show-toplevel";
+  const gitGetRemotesConfig = "config --get-regexp remote\\..*\\.url";
+
+  const logMissingRepositoryKey = (dir: string) =>
+    expect.stringContaining(`Valid "repository" key not found in package.json at "${path.join(dir, "package.json")}"`);
+  const logMissingRemotes = (dir: string) => `Could not find any remotes in git repo at "${dir}".`;
 
   function gitRemote(...args: string[]) {
     gitFailFast(["remote", ...args], { cwd, noExitCode: true });
   }
 
-  function expectConsole(n: number, message: string | RegExp) {
-    expect(consoleMock.mock.calls.length).toBeGreaterThanOrEqual(n);
-    expect(consoleMock.mock.calls[n - 1].join(" ")).toMatch(message);
+  function getLogs() {
+    return consoleMock.mock.calls.map((call) => call.join(" "));
+  }
+
+  function getGitCalls() {
+    return gitObserver.mock.calls.map(([args]) => args.join(" "));
   }
 
   beforeAll(() => {
     consoleMock = jest.spyOn(console, "log").mockImplementation(() => undefined);
+    addGitObserver(gitObserver);
+    emptyRepoCwd = setupFixture(undefined, { git: true });
   });
 
   afterEach(() => {
-    consoleMock.mockReset();
+    jest.clearAllMocks();
   });
 
   afterAll(() => {
-    consoleMock.mockRestore();
+    jest.restoreAllMocks();
     cleanupFixtures();
+    clearGitObservers();
   });
 
   it("throws if not in a git repo", () => {
-    // hopefully os.tmpdir() is never under a git repo...?
-    expect(() => getDefaultRemote({ cwd: os.tmpdir() })).toThrow("is not in a git repository");
-    expect(() => getDefaultRemote({ cwd: os.tmpdir(), strict: true })).toThrow("is not in a git repository");
+    // Use a completely invalid path since the it falls under the same error handling case
+    // and definitely won't be a git repo by accident
+    gitObserver.mockClear();
+    expect(() => getDefaultRemote({ cwd: "/nonexistent/dir" })).toThrow("is not in a git repository");
+    expect(getGitCalls()).toEqual([gitGetRoot]);
+
+    gitObserver.mockClear();
+    expect(() => getDefaultRemote({ cwd: "/nonexistent/dir", strict: true })).toThrow("is not in a git repository");
+    expect(getGitCalls()).toEqual([gitGetRoot]);
   });
 
-  it("handles no package.json at git root", () => {
-    cwd = setupFixture(undefined, { git: true });
-    expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expectConsole(1, `Valid "repository" key not found in package.json at "${path.join(cwd, "package.json")}"`);
+  it("returns 'origin' if no package.json and no remotes found (permissive)", () => {
+    expect(getDefaultRemote({ cwd: emptyRepoCwd, verbose: true })).toBe("origin");
 
-    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find any remotes in git repo");
+    expect(getLogs()).toEqual([
+      `Could not read "${path.join(emptyRepoCwd, "package.json")}"`,
+      logMissingRepositoryKey(emptyRepoCwd),
+      logMissingRemotes(emptyRepoCwd),
+      'Assuming default remote "origin".',
+    ]);
+    // No repository URL in package.json → findGitRoot called.
+    // No remotes configured → config command runs but finds nothing.
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
   });
 
-  it("handles no repository field or remotes", () => {
+  it("throws if no package.json (strict)", () => {
+    expect(() => getDefaultRemote({ cwd: emptyRepoCwd, strict: true })).toThrow(
+      `Could not read "${path.join(emptyRepoCwd, "package.json")}"`
+    );
+    // Throws after reading package.json fails — never reaches getRemotes.
+    expect(getGitCalls()).toEqual([gitGetRoot]);
+  });
+
+  it("returns 'origin' if no repository field and no remotes (permissive)", () => {
     cwd = setupFixture(undefined, { git: true });
     setupPackageJson(cwd);
+    gitObserver.mockClear();
 
-    // permissive: defaults to origin
     expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expectConsole(1, 'Valid "repository" key not found');
-    expectConsole(2, "Could not find any remotes in git repo");
-    expectConsole(3, 'Assuming default remote "origin".');
+    expect(getLogs()).toEqual([
+      logMissingRepositoryKey(cwd),
+      logMissingRemotes(cwd),
+      'Assuming default remote "origin".',
+    ]);
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+  });
 
-    // strict: throws
-    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find any remotes");
+  it("throws if no repository field and no remotes (strict)", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    gitObserver.mockClear();
+
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(logMissingRemotes(cwd));
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
   });
 
   it("uses provided remotes instead of getting from repo", () => {
     // no git here to verify it's not used
     cwd = setupFixture();
-    setupPackageJson(cwd, { repository: "https://github.com/microsoft/lage.git" });
+    setupPackageJson(cwd, { repository: remoteUrls.microsoft });
+    gitObserver.mockClear();
 
-    const remotes = {
-      origin: "https://github.com/ecraig12345/lage.git",
-      default: "https://github.com/microsoft/lage.git",
-      another: "https://github.com/otherfork/lage.git",
-    };
+    const remotes = { origin: remoteUrls.ecraig12345, default: remoteUrls.microsoft, another: remoteUrls.kenotron };
     expect(getDefaultRemote({ cwd, remotes })).toBe("default");
     expect(getDefaultRemote({ cwd, remotes, strict: true })).toBe("default");
+    // repository URL found in package.json → no findGitRoot. options.remotes provided → no getRemotes.
+    expect(getGitCalls()).toEqual([]);
   });
 
-  it("defaults to upstream remote without repository field", () => {
+  it("defaults to existing upstream remote without repository field", () => {
     cwd = setupFixture(undefined, { git: true });
     setupPackageJson(cwd);
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "origin", remoteUrls.ecraig12345);
+    gitRemote("add", "upstream", remoteUrls.microsoft);
+    gitObserver.mockClear();
 
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "origin", "https://github.com/ecraig12345/lage.git");
-    gitRemote("add", "upstream", "https://github.com/microsoft/lage.git");
-
-    // permissive
-    expect(getDefaultRemote({ cwd, verbose: true })).toBe("upstream");
-    expectConsole(1, 'Valid "repository" key not found');
-    expectConsole(2, 'Default to remote "upstream"');
-
-    // strict
+    // permissive/strict have same behavior
     expect(getDefaultRemote({ cwd, strict: true, verbose: true })).toBe("upstream");
-    expectConsole(3, 'Valid "repository" key not found');
-    expectConsole(4, 'Default to remote "upstream"');
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getLogs()).toEqual([logMissingRepositoryKey(cwd), 'Default to remote "upstream"']);
   });
 
-  it("defaults to origin remote without repository field or upstream remote", () => {
+  it("defaults to existing origin remote without repository field or upstream remote", () => {
     cwd = setupFixture(undefined, { git: true });
     setupPackageJson(cwd);
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "origin", remoteUrls.microsoft);
+    gitObserver.mockClear();
 
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
-
-    // permissive
-    expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expectConsole(1, 'Valid "repository" key not found');
-    expectConsole(2, 'Default to remote "origin"');
-
-    // strict
+    // permissive/strict have same behavior
     expect(getDefaultRemote({ cwd, strict: true, verbose: true })).toBe("origin");
-    expectConsole(3, 'Valid "repository" key not found');
-    expectConsole(4, 'Default to remote "origin"');
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getLogs()).toEqual([logMissingRepositoryKey(cwd), 'Default to remote "origin"']);
   });
 
   it("defaults to first remote without repository field, origin, or upstream", () => {
     cwd = setupFixture(undefined, { git: true });
     setupPackageJson(cwd);
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "second", remoteUrls.microsoft);
+    gitObserver.mockClear();
 
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "second", "https://github.com/microsoft/lage.git");
-
-    // permissive
-    expect(getDefaultRemote({ cwd, verbose: true })).toBe("first");
-    expectConsole(1, 'Valid "repository" key not found');
-    expectConsole(2, 'Default to remote "first"');
-
-    // strict
+    // permissive/strict have same behavior
     expect(getDefaultRemote({ cwd, strict: true, verbose: true })).toBe("first");
-    expectConsole(3, 'Valid "repository" key not found');
-    expectConsole(4, 'Default to remote "first"');
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getLogs()).toEqual([logMissingRepositoryKey(cwd), 'Default to remote "first"']);
   });
 
+  // package.json parsing is not covered by _matchRepositoryUrlToRemote
   it("finds remote matching repository string", () => {
     cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: "https://github.com/microsoft/lage.git" });
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "second", "https://github.com/microsoft/lage.git");
+    setupPackageJson(cwd, { repository: remoteUrls.microsoft });
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "second", remoteUrls.microsoft);
+    gitObserver.mockClear();
 
     expect(getDefaultRemote({ cwd })).toBe("second");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+
+    // repository URL found in package.json → findGitRoot is never called
+    gitObserver.mockClear();
     expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
   it("finds remote matching repository object", () => {
     cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "https://github.com/microsoft/lage.git", type: "git" } });
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "second", "https://github.com/microsoft/lage.git");
+    setupPackageJson(cwd, { repository: { url: remoteUrls.microsoft, type: "git" } });
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "second", remoteUrls.microsoft);
+    gitObserver.mockClear();
 
     expect(getDefaultRemote({ cwd })).toBe("second");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+
+    gitObserver.mockClear();
     expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
-  it("handles no remotes set and repository specified", () => {
+  it("returns 'origin' if no remotes and repository specified (permissive)", () => {
     cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "https://github.com/baz/some-repo", type: "git" } });
+    setupPackageJson(cwd, { repository: { url: remoteUrls.microsoft, type: "git" } });
+    gitObserver.mockClear();
 
-    // permissive: default to origin
     expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expectConsole(1, "Could not find any remotes in git repo");
-    expectConsole(2, 'Assuming default remote "origin".');
-
-    // strict: throws
-    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find any remotes in git repo");
+    expect(getLogs()).toEqual([logMissingRemotes(cwd), 'Assuming default remote "origin".']);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
-  it("handles remotes set but none matching repository", () => {
+  it("throws if no remotes and repository specified (strict)", () => {
     cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "https://github.com/ecraig12345/some-repo", type: "git" } });
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "second", "https://github.com/microsoft/lage.git");
+    setupPackageJson(cwd, { repository: { url: remoteUrls.microsoft, type: "git" } });
+    gitObserver.mockClear();
 
-    // permissive: defaults to first remote
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(logMissingRemotes(cwd));
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+  });
+
+  it("returns first remote if none match repository (permissive)", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd, { repository: { url: remoteUrls.ecraig12345, type: "git" } });
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "second", remoteUrls.microsoft);
+    gitObserver.mockClear();
+
     expect(getDefaultRemote({ cwd, verbose: true })).toBe("first");
-    expectConsole(1, "Could not find remote pointing to repository");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
+    expect(getLogs()).toEqual([
+      'Could not find remote pointing to repository "ecraig12345/lage".',
+      'Default to remote "first"',
+    ]);
+  });
 
-    // strict: throws
+  it("throws if no remotes match repository (strict)", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd, { repository: { url: remoteUrls.ecraig12345, type: "git" } });
+    gitRemote("add", "first", remoteUrls.kenotron);
+    gitRemote("add", "second", remoteUrls.microsoft);
+    gitObserver.mockClear();
+
     expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find remote pointing to repository");
-  });
-
-  it("works with SSH remote format", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "https://github.com/microsoft/lage", type: "git" } });
-    gitRemote("add", "first", "git@github.com:kenotron/lage.git");
-    gitRemote("add", "second", "git@github.com:microsoft/lage.git");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-  });
-
-  it("works with shorthand repository format", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "github:microsoft/lage", type: "git" } });
-
-    // HTTPS
-    gitRemote("add", "first", "https://github.com/kenotron/lage.git");
-    gitRemote("add", "second", "https://github.com/microsoft/lage.git");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // SSH
-    gitRemote("set-url", "second", "git@github.com:microsoft/lage.git");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-  });
-
-  it("works with VSO repository and mismatched remote format", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "https://foo.visualstudio.com/bar/_git/some-repo", type: "git" } });
-    // The multi-remote scenario is less common with VSO/ADO, but cover it just in case
-    gitRemote("add", "first", "https://baz.visualstudio.com/bar/_git/some-repo");
-
-    // VSO HTTPS
-    gitRemote("add", "second", "https://foo.visualstudio.com/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO HTTPS with DefaultCollection
-    gitRemote("set-url", "second", "https://foo.visualstudio.com/DefaultCollection/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO HTTPS with _optimized
-    gitRemote("set-url", "second", "https://foo.visualstudio.com/DefaultCollection/bar/_git/_optimized/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO SSH
-    gitRemote("set-url", "second", "foo@vs-ssh.visualstudio.com:v3/foo/bar/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO HTTPS
-    gitRemote("set-url", "second", "https://dev.azure.com/foo/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO HTTPS with _optimized
-    gitRemote("set-url", "second", "https://dev.azure.com/foo/bar/_git/_optimized/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO HTTPS with user
-    gitRemote("set-url", "second", "https://foo@dev.azure.com/foo/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO SSH
-    gitRemote("set-url", "second", "git@ssh.dev.azure.com:v3/foo/bar/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-  });
-
-  it("works with ADO repository and mismatched remote format", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupPackageJson(cwd, { repository: { url: "https://dev.azure.com/foo/bar/_git/some-repo", type: "git" } });
-    // The multi-remote scenario is less common with VSO/ADO, but cover it just in case
-    gitRemote("add", "first", "https://dev.azure.com/baz/bar/_git/some-repo");
-
-    // ADO HTTPS
-    gitRemote("add", "second", "https://dev.azure.com/foo/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO HTTPS with _optimized
-    gitRemote("set-url", "second", "https://dev.azure.com/foo/bar/_git/_optimized/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO HTTPS with user
-    gitRemote("set-url", "second", "https://foo@dev.azure.com/foo/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // ADO SSH
-    gitRemote("set-url", "second", "git@ssh.dev.azure.com:v3/foo/bar/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO HTTPS
-    gitRemote("set-url", "second", "https://foo.visualstudio.com/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO HTTPS with DefaultCollection
-    gitRemote("set-url", "second", "https://foo.visualstudio.com/DefaultCollection/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO HTTPS with _optimized
-    gitRemote("set-url", "second", "https://foo.visualstudio.com/DefaultCollection/bar/_git/_optimized/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO HTTPS with user and token
-    gitRemote("set-url", "second", "https://user:fakePAT@foo.visualstudio.com/bar/_git/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
-
-    // VSO SSH
-    gitRemote("set-url", "second", "foo@vs-ssh.visualstudio.com:v3/foo/bar/some-repo");
-    expect(getDefaultRemote({ cwd })).toBe("second");
-    expect(getDefaultRemote({ cwd, strict: true })).toBe("second");
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 });

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemote.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemote.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
 import os from "os";
+import path from "path";
 import { cleanupFixtures, setupFixture, setupPackageJson } from "../setupFixture.js";
 import { gitFailFast } from "../../git/git.js";
 import { getDefaultRemote } from "../../git/getDefaultRemote.js";
@@ -39,9 +40,9 @@ describe("getDefaultRemote", () => {
   it("handles no package.json at git root", () => {
     cwd = setupFixture(undefined, { git: true });
     expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expectConsole(1, /Could not read .*package\.json/);
+    expectConsole(1, `Valid "repository" key not found in package.json at "${path.join(cwd, "package.json")}"`);
 
-    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow(/Could not read .*package\.json/);
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find any remotes in git repo");
   });
 
   it("handles no repository field or remotes", () => {
@@ -56,6 +57,20 @@ describe("getDefaultRemote", () => {
 
     // strict: throws
     expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find any remotes");
+  });
+
+  it("uses provided remotes instead of getting from repo", () => {
+    // no git here to verify it's not used
+    cwd = setupFixture();
+    setupPackageJson(cwd, { repository: "https://github.com/microsoft/lage.git" });
+
+    const remotes = {
+      origin: "https://github.com/ecraig12345/lage.git",
+      default: "https://github.com/microsoft/lage.git",
+      another: "https://github.com/otherfork/lage.git",
+    };
+    expect(getDefaultRemote({ cwd, remotes })).toBe("default");
+    expect(getDefaultRemote({ cwd, remotes, strict: true })).toBe("default");
   });
 
   it("defaults to upstream remote without repository field", () => {
@@ -139,12 +154,11 @@ describe("getDefaultRemote", () => {
 
     // permissive: default to origin
     expect(getDefaultRemote({ cwd, verbose: true })).toBe("origin");
-    expectConsole(1, "Could not find remote pointing to");
-    expectConsole(2, "Could not find any remotes in git repo");
-    expectConsole(3, 'Assuming default remote "origin".');
+    expectConsole(1, "Could not find any remotes in git repo");
+    expectConsole(2, 'Assuming default remote "origin".');
 
     // strict: throws
-    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find remote pointing to repository");
+    expect(() => getDefaultRemote({ cwd, strict: true })).toThrow("Could not find any remotes in git repo");
   });
 
   it("handles remotes set but none matching repository", () => {

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
@@ -1,7 +1,13 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+import fs from "fs";
 import { cleanupFixtures, setupFixture, setupLocalRemote, setupPackageJson } from "../setupFixture.js";
 import { addGitObserver, clearGitObservers, gitFailFast, type GitObserver } from "../../git/git.js";
-import { getDefaultRemoteBranch, resolveRemoteBranch } from "../../git/getDefaultRemoteBranch.js";
+import {
+  getDefaultRemoteBranch,
+  resolveRemoteBranch,
+  type GetDefaultRemoteBranchOptions,
+} from "../../git/getDefaultRemoteBranch.js";
+import { findGitRoot } from "../../paths.js";
 
 let cwd: string;
 let consoleMock: jest.SpiedFunction<typeof console.log>;
@@ -15,7 +21,7 @@ function getGitCalls() {
   return gitObserver.mock.calls.map(([args]) => args.join(" "));
 }
 
-const gitGetRemotesConfig = "config --get-regexp remote\\..*\\.url";
+const gitGetRemotesConfig = "config --local --get-regexp remote\\..*\\.url";
 const gitGetOriginDefaultBranch = "ls-remote --symref origin HEAD";
 const gitGetFooDefaultBranch = "ls-remote --symref foo HEAD";
 const gitGetRoot = "rev-parse --show-toplevel";
@@ -38,6 +44,17 @@ afterAll(() => {
 // These tests focus on the logic specific to getDefaultRemoteBranch, not the parts handled
 // by getDefaultRemote.
 describe("getDefaultRemoteBranch", () => {
+  it("throws if not a git repo", () => {
+    cwd = setupFixture();
+    // sanity check: if this fails, there's a git repo in the OS temp dir
+    expect(() => findGitRoot(cwd)).toThrow();
+
+    // findGitRoot throws
+    expect(() => getDefaultRemoteBranch({ cwd })).toThrow(`Directory "${cwd}" is not in a git repository`);
+    // getRemotes throws
+    expect(() => getDefaultRemoteBranch({ cwd, strict: true })).toThrow(`${cwd} is not in a git repository`);
+  });
+
   // This case uses the result of getDefaultRemote, no extra logic
   it("with branch option, returns <defaultRemote>/<branch> without querying remote", () => {
     cwd = setupFixture(undefined, { git: true });
@@ -45,15 +62,16 @@ describe("getDefaultRemoteBranch", () => {
     gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
     gitObserver.mockClear();
 
-    expect(getDefaultRemoteBranch({ cwd, branch: "main" })).toBe("origin/main");
+    // Several tests use strict: true where the strict and permissive behavior should be the same
+    expect(getDefaultRemoteBranch({ cwd, branch: "main", strict: true })).toBe("origin/main");
 
     expect(consoleMock).toHaveBeenCalledTimes(1);
     expect(consoleMock).toHaveBeenCalledWith(expect.stringContaining('Valid "repository" key not found'));
 
     // For each test, verify the specific git commands that were invoked.
     // This increases visibility into internal behavior of specific cases, as well as if
-    // more operations are added later.
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    // more operations are added later (to be sure it's not accidental).
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
 
   it("with branch name that includes a slash, returns <defaultRemote>/<branch> without querying remote", () => {
@@ -63,49 +81,72 @@ describe("getDefaultRemoteBranch", () => {
     gitRemote("add", "upstream", "https://github.com/microsoft/lage.git");
     gitObserver.mockClear();
 
-    expect(getDefaultRemoteBranch({ cwd, branch: "feature/foo" })).toBe("upstream/feature/foo");
+    expect(getDefaultRemoteBranch({ cwd, branch: "feature/foo", strict: true })).toBe("upstream/feature/foo");
     expect(consoleMock).not.toHaveBeenCalled(); // no warning since repository field is valid
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
-  it("gets default branch from remote via ls-remote", () => {
-    cwd = setupFixture(undefined, { git: true });
-    setupLocalRemote({ cwd, remoteName: "foo" });
+  it("gets default branch from remote via ls-remote and handles errors", () => {
+    // Change the default branch name to verify it's really used
+    cwd = setupFixture(undefined, { git: true, defaultBranchName: "bar" });
+    const remoteDir = setupLocalRemote({ cwd, remoteName: "foo", defaultBranchName: "bar" });
     gitObserver.mockClear();
 
-    expect(getDefaultRemoteBranch({ cwd })).toBe("foo/main");
+    expect(getDefaultRemoteBranch({ cwd, strict: true })).toBe("foo/bar");
 
     // setupLocalRemote updates package.json so we don't get the warning
     expect(consoleMock).not.toHaveBeenCalled();
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetFooDefaultBranch]);
+    gitObserver.mockClear();
+    consoleMock.mockClear();
+
+    // Combine the error handling tests since this setup is expensive:
+    // make ls-remote fail
+    fs.rmdirSync(remoteDir, { recursive: true });
+    // allowed in permissive mode
+    expect(getDefaultRemoteBranch({ cwd })).toBe("foo/bar");
+    // in strict mode, it throws if ls-remote fails
+    expect(() => getDefaultRemoteBranch({ cwd, strict: true })).toThrow(
+      // it should also include stderr from git, which we can't test directly
+      `Fetching default branch info from remote "foo" failed\n`
+    );
   });
 
   // No remotes configured: getDefaultRemote falls back to "origin",
-  // ls-remote fails, and getDefaultBranch reads init.defaultBranch ("main").
-  it("falls back to init.defaultBranch when remote is unavailable", () => {
-    cwd = setupFixture(undefined, { git: true });
+  // ls-remote fails, and getDefaultBranch reads init.defaultBranch.
+  it("falls back to init.defaultBranch when remote is unavailable (permissive)", () => {
+    // Change the default branch name to verify it's really used
+    cwd = setupFixture(undefined, { git: true, defaultBranchName: "foo" });
     setupPackageJson(cwd);
-    // Override init.defaultBranch to a predictable value
-    gitFailFast(["config", "init.defaultBranch", "foo"], { cwd, noExitCode: true });
     gitObserver.mockClear();
 
     expect(getDefaultRemoteBranch({ cwd })).toBe("origin/foo");
 
     expect(getGitCalls()).toEqual([
-      gitGetRoot,
       gitGetRemotesConfig,
+      gitGetRoot,
       gitGetOriginDefaultBranch,
       "config init.defaultBranch",
     ]);
+  });
+
+  // The cases where it throws in strict mode are mostly the same as getDefaultRemote
+  it("throws when remote is unavailable (strict)", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    gitObserver.mockClear();
+
+    expect(() => getDefaultRemoteBranch({ cwd, strict: true })).toThrow(`No remotes defined in git repo at ${cwd}`);
   });
 });
 
 describe("resolveRemoteBranch", () => {
   it("returns branch as-is when it already has a known remote prefix (no git ops)", () => {
-    expect(resolveRemoteBranch({ branch: "origin/main", cwd: "fake" })).toBe("origin/main");
-    expect(resolveRemoteBranch({ branch: "upstream/develop", cwd: "fake" })).toBe("upstream/develop");
-    expect(resolveRemoteBranch({ branch: "origin/feature/foo", cwd: "fake" })).toBe("origin/feature/foo");
+    const opts: GetDefaultRemoteBranchOptions = { cwd: "fake", strict: true };
+    expect(resolveRemoteBranch({ branch: "origin/main", ...opts })).toBe("origin/main");
+    expect(resolveRemoteBranch({ branch: "upstream/develop", ...opts })).toBe("upstream/develop");
+    expect(resolveRemoteBranch({ branch: "origin/feature/foo", ...opts })).toBe("origin/feature/foo");
     expect(gitObserver).not.toHaveBeenCalled();
   });
 
@@ -115,9 +156,9 @@ describe("resolveRemoteBranch", () => {
     gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
     gitObserver.mockClear();
 
-    expect(resolveRemoteBranch({ branch: "main", cwd })).toBe("origin/main");
+    expect(resolveRemoteBranch({ branch: "main", cwd, strict: true })).toBe("origin/main");
 
-    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
 
   it("recognizes a non-default remote prefix in branch name", () => {
@@ -127,7 +168,7 @@ describe("resolveRemoteBranch", () => {
     gitRemote("add", "myremote", "https://github.com/myuser/lage.git");
     gitObserver.mockClear();
 
-    expect(resolveRemoteBranch({ branch: "myremote/feature", cwd })).toBe("myremote/feature");
+    expect(resolveRemoteBranch({ branch: "myremote/feature", cwd, strict: true })).toBe("myremote/feature");
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
@@ -139,7 +180,7 @@ describe("resolveRemoteBranch", () => {
     gitObserver.mockClear();
 
     // "feature" is not a remote, so the whole string is treated as the branch name
-    expect(resolveRemoteBranch({ branch: "feature/foo", cwd })).toBe("origin/feature/foo");
+    expect(resolveRemoteBranch({ branch: "feature/foo", cwd, strict: true })).toBe("origin/feature/foo");
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
@@ -149,7 +190,7 @@ describe("resolveRemoteBranch", () => {
     setupLocalRemote({ cwd, remoteName: "origin" });
     jest.clearAllMocks();
 
-    expect(resolveRemoteBranch({ branch: undefined, cwd })).toBe("origin/main");
+    expect(resolveRemoteBranch({ branch: undefined, cwd, strict: true })).toBe("origin/main");
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetOriginDefaultBranch]);
   });

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+import { cleanupFixtures, setupFixture, setupLocalRemote, setupPackageJson } from "../setupFixture.js";
+import { addGitObserver, clearGitObservers, gitFailFast, type GitObserver } from "../../git/git.js";
+import { getDefaultRemoteBranch, resolveRemoteBranch } from "../../git/getDefaultRemoteBranch.js";
+
+let cwd: string;
+let consoleMock: jest.SpiedFunction<typeof console.log>;
+const gitObserver = jest.fn<GitObserver>();
+
+function gitRemote(...args: string[]) {
+  gitFailFast(["remote", ...args], { cwd, noExitCode: true });
+}
+
+function getGitCalls() {
+  return gitObserver.mock.calls.map(([args]) => args.join(" "));
+}
+
+/** Expect `getRemotes` to have been called exactly once */
+function expectGetRemotesCalled() {
+  const gitCalls = getGitCalls();
+  expect(gitCalls).toContain("config --get-regexp remote\\..*\\.url");
+  expect(gitCalls.filter((call) => call === "config --get-regexp remote\\..*\\.url")).toHaveLength(1);
+}
+
+/** Expect `getDefaultRemoteBranch` to have fetched default branch info from the remote or not */
+function expectQueriedRemote(options?: { not?: boolean; remote?: string }) {
+  const { not, remote = "origin" } = options || {};
+  const gitCalls = getGitCalls();
+  (not ? expect(gitCalls).not : expect(gitCalls)).toContain(`ls-remote --symref ${remote} HEAD`);
+}
+
+beforeAll(() => {
+  consoleMock = jest.spyOn(console, "log").mockImplementation(() => undefined);
+  addGitObserver(gitObserver);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+  cleanupFixtures();
+  clearGitObservers();
+});
+
+// These tests focus on the logic specific to getDefaultRemoteBranch, not the parts handled
+// by getDefaultRemote.
+describe("getDefaultRemoteBranch", () => {
+  // This case uses the result of getDefaultRemote, no extra logic
+  it("with branch option, returns <defaultRemote>/<branch> without querying remote", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
+    gitObserver.mockClear();
+
+    expect(getDefaultRemoteBranch({ cwd, branch: "main" })).toBe("origin/main");
+    expectGetRemotesCalled();
+    expectQueriedRemote({ not: true });
+    expect(consoleMock).toHaveBeenCalledTimes(1);
+    expect(consoleMock).toHaveBeenCalledWith(expect.stringContaining('Valid "repository" key not found'));
+  });
+
+  it("with branch name that includes a slash, returns <defaultRemote>/<branch> without querying remote", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd, { repository: "https://github.com/microsoft/lage.git" });
+    gitRemote("add", "origin", "https://github.com/example/lage.git");
+    gitRemote("add", "upstream", "https://github.com/microsoft/lage.git");
+    gitObserver.mockClear();
+
+    expect(getDefaultRemoteBranch({ cwd, branch: "feature/foo" })).toBe("upstream/feature/foo");
+    expectGetRemotesCalled();
+    expectQueriedRemote({ not: true });
+    expect(consoleMock).not.toHaveBeenCalled(); // no warning since repository field is valid
+  });
+
+  it("gets default branch from remote via ls-remote", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupLocalRemote({ cwd, remoteName: "foo" });
+
+    expect(getDefaultRemoteBranch({ cwd })).toBe("foo/main");
+    expectQueriedRemote({ remote: "foo" });
+    // setupLocalRemote updates package.json so we don't get the warning
+    expect(consoleMock).not.toHaveBeenCalled();
+  });
+
+  // No remotes configured: getDefaultRemote falls back to "origin",
+  // ls-remote fails, and getDefaultBranch reads init.defaultBranch ("main").
+  it("falls back to init.defaultBranch when remote is unavailable", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    // Override init.defaultBranch to a predictable value
+    gitFailFast(["config", "init.defaultBranch", "foo"], { cwd, noExitCode: true });
+    gitObserver.mockClear();
+
+    expect(getDefaultRemoteBranch({ cwd })).toBe("origin/foo");
+
+    const gitCalls = getGitCalls();
+    expectQueriedRemote();
+    expect(gitCalls).toContain("config init.defaultBranch");
+  });
+});
+
+describe("resolveRemoteBranch", () => {
+  it("returns branch as-is when it already has a known remote prefix (no git ops)", () => {
+    expect(resolveRemoteBranch({ branch: "origin/main", cwd: "fake" })).toBe("origin/main");
+    expect(resolveRemoteBranch({ branch: "upstream/develop", cwd: "fake" })).toBe("upstream/develop");
+    expect(resolveRemoteBranch({ branch: "origin/feature/foo", cwd: "fake" })).toBe("origin/feature/foo");
+    expect(gitObserver).not.toHaveBeenCalled();
+  });
+
+  it("prepends default remote for plain branch with no slash", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
+    gitObserver.mockClear();
+
+    expect(resolveRemoteBranch({ branch: "main", cwd })).toBe("origin/main");
+    expectGetRemotesCalled();
+  });
+
+  it("recognizes a non-default remote prefix in branch name", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
+    gitRemote("add", "myremote", "https://github.com/myuser/lage.git");
+    gitObserver.mockClear();
+
+    expect(resolveRemoteBranch({ branch: "myremote/feature", cwd })).toBe("myremote/feature");
+    expectGetRemotesCalled();
+  });
+
+  it("prepends default remote when slash-containing branch prefix is not a real remote", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupPackageJson(cwd);
+    gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
+
+    // "feature" is not a remote, so the whole string is treated as the branch name
+    expect(resolveRemoteBranch({ branch: "feature/foo", cwd })).toBe("origin/feature/foo");
+    expectGetRemotesCalled();
+  });
+
+  it("queries remote for default branch when no branch is given", () => {
+    cwd = setupFixture(undefined, { git: true });
+    setupLocalRemote({ cwd, remoteName: "origin" });
+    jest.clearAllMocks();
+
+    expect(resolveRemoteBranch({ branch: undefined, cwd })).toBe("origin/main");
+    expectQueriedRemote();
+    expectGetRemotesCalled();
+  });
+});

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
@@ -15,19 +15,10 @@ function getGitCalls() {
   return gitObserver.mock.calls.map(([args]) => args.join(" "));
 }
 
-/** Expect `getRemotes` to have been called exactly once */
-function expectGetRemotesCalled() {
-  const gitCalls = getGitCalls();
-  expect(gitCalls).toContain("config --get-regexp remote\\..*\\.url");
-  expect(gitCalls.filter((call) => call === "config --get-regexp remote\\..*\\.url")).toHaveLength(1);
-}
-
-/** Expect `getDefaultRemoteBranch` to have fetched default branch info from the remote or not */
-function expectQueriedRemote(options?: { not?: boolean; remote?: string }) {
-  const { not, remote = "origin" } = options || {};
-  const gitCalls = getGitCalls();
-  (not ? expect(gitCalls).not : expect(gitCalls)).toContain(`ls-remote --symref ${remote} HEAD`);
-}
+const gitGetRemotesConfig = "config --get-regexp remote\\..*\\.url";
+const gitGetOriginDefaultBranch = "ls-remote --symref origin HEAD";
+const gitGetFooDefaultBranch = "ls-remote --symref foo HEAD";
+const gitGetRoot = "rev-parse --show-toplevel";
 
 beforeAll(() => {
   consoleMock = jest.spyOn(console, "log").mockImplementation(() => undefined);
@@ -55,10 +46,14 @@ describe("getDefaultRemoteBranch", () => {
     gitObserver.mockClear();
 
     expect(getDefaultRemoteBranch({ cwd, branch: "main" })).toBe("origin/main");
-    expectGetRemotesCalled();
-    expectQueriedRemote({ not: true });
+
     expect(consoleMock).toHaveBeenCalledTimes(1);
     expect(consoleMock).toHaveBeenCalledWith(expect.stringContaining('Valid "repository" key not found'));
+
+    // For each test, verify the specific git commands that were invoked.
+    // This increases visibility into internal behavior of specific cases, as well as if
+    // more operations are added later.
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
   });
 
   it("with branch name that includes a slash, returns <defaultRemote>/<branch> without querying remote", () => {
@@ -69,19 +64,21 @@ describe("getDefaultRemoteBranch", () => {
     gitObserver.mockClear();
 
     expect(getDefaultRemoteBranch({ cwd, branch: "feature/foo" })).toBe("upstream/feature/foo");
-    expectGetRemotesCalled();
-    expectQueriedRemote({ not: true });
     expect(consoleMock).not.toHaveBeenCalled(); // no warning since repository field is valid
+
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
   it("gets default branch from remote via ls-remote", () => {
     cwd = setupFixture(undefined, { git: true });
     setupLocalRemote({ cwd, remoteName: "foo" });
+    gitObserver.mockClear();
 
     expect(getDefaultRemoteBranch({ cwd })).toBe("foo/main");
-    expectQueriedRemote({ remote: "foo" });
+
     // setupLocalRemote updates package.json so we don't get the warning
     expect(consoleMock).not.toHaveBeenCalled();
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetFooDefaultBranch]);
   });
 
   // No remotes configured: getDefaultRemote falls back to "origin",
@@ -95,9 +92,12 @@ describe("getDefaultRemoteBranch", () => {
 
     expect(getDefaultRemoteBranch({ cwd })).toBe("origin/foo");
 
-    const gitCalls = getGitCalls();
-    expectQueriedRemote();
-    expect(gitCalls).toContain("config init.defaultBranch");
+    expect(getGitCalls()).toEqual([
+      gitGetRoot,
+      gitGetRemotesConfig,
+      gitGetOriginDefaultBranch,
+      "config init.defaultBranch",
+    ]);
   });
 });
 
@@ -116,7 +116,8 @@ describe("resolveRemoteBranch", () => {
     gitObserver.mockClear();
 
     expect(resolveRemoteBranch({ branch: "main", cwd })).toBe("origin/main");
-    expectGetRemotesCalled();
+
+    expect(getGitCalls()).toEqual([gitGetRoot, gitGetRemotesConfig]);
   });
 
   it("recognizes a non-default remote prefix in branch name", () => {
@@ -127,17 +128,20 @@ describe("resolveRemoteBranch", () => {
     gitObserver.mockClear();
 
     expect(resolveRemoteBranch({ branch: "myremote/feature", cwd })).toBe("myremote/feature");
-    expectGetRemotesCalled();
+
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
 
   it("prepends default remote when slash-containing branch prefix is not a real remote", () => {
     cwd = setupFixture(undefined, { git: true });
     setupPackageJson(cwd);
     gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
+    gitObserver.mockClear();
 
     // "feature" is not a remote, so the whole string is treated as the branch name
     expect(resolveRemoteBranch({ branch: "feature/foo", cwd })).toBe("origin/feature/foo");
-    expectGetRemotesCalled();
+
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
 
   it("queries remote for default branch when no branch is given", () => {
@@ -146,7 +150,7 @@ describe("resolveRemoteBranch", () => {
     jest.clearAllMocks();
 
     expect(resolveRemoteBranch({ branch: undefined, cwd })).toBe("origin/main");
-    expectQueriedRemote();
-    expectGetRemotesCalled();
+
+    expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetOriginDefaultBranch]);
   });
 });

--- a/packages/workspace-tools/src/__tests__/git/getRemotes.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getRemotes.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, it } from "@jest/globals";
 import { cleanupFixtures, setupFixture } from "../setupFixture.js";
 import { gitFailFast } from "../../git/git.js";
 import { getRemotes } from "../../git/getRemotes.js";
+import { findGitRoot } from "../../paths.js";
 
 describe("getRemotes", () => {
   function gitRemote(cwd: string, ...args: string[]) {
@@ -12,14 +13,30 @@ describe("getRemotes", () => {
     cleanupFixtures();
   });
 
-  it("returns undefined when not in a git repo", () => {
-    // here, a nonexistent path behaves the same as not in a git repo
-    expect(getRemotes({ cwd: "/fake/path" })).toBeUndefined();
+  it("returns empty object by default when not in a git repo", () => {
+    const cwd = setupFixture();
+    // sanity check: if this fails, there's a git repo in the OS temp dir
+    expect(() => findGitRoot(cwd)).toThrow();
+
+    expect(getRemotes({ cwd })).toEqual({});
   });
 
-  it("returns undefined when no remotes are configured", () => {
+  it("throws when not in a git repo with throwOnError: true", () => {
+    const cwd = setupFixture();
+    // sanity check: if this fails, there's a git repo in the OS temp dir
+    expect(() => findGitRoot(cwd)).toThrow();
+
+    expect(() => getRemotes({ cwd, throwOnError: true })).toThrow(`${cwd} is not in a git repository`);
+  });
+
+  it("returns empty object by default when no remotes are configured", () => {
     const cwd = setupFixture(undefined, { git: true });
-    expect(getRemotes({ cwd })).toBeUndefined();
+    expect(getRemotes({ cwd })).toEqual({});
+  });
+
+  it("throws when no remotes are configured with throwOnError: true", () => {
+    const cwd = setupFixture(undefined, { git: true });
+    expect(() => getRemotes({ cwd, throwOnError: true })).toThrow(`No remotes defined in git repo at ${cwd}`);
   });
 
   it("returns a single remote", () => {

--- a/packages/workspace-tools/src/__tests__/git/getRemotes.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getRemotes.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, it } from "@jest/globals";
+import { cleanupFixtures, setupFixture } from "../setupFixture.js";
+import { gitFailFast } from "../../git/git.js";
+import { getRemotes } from "../../git/getRemotes.js";
+
+describe("getRemotes", () => {
+  function gitRemote(cwd: string, ...args: string[]) {
+    gitFailFast(["remote", ...args], { cwd, noExitCode: true });
+  }
+
+  afterAll(() => {
+    cleanupFixtures();
+  });
+
+  it("returns undefined when not in a git repo", () => {
+    // here, a nonexistent path behaves the same as not in a git repo
+    expect(getRemotes({ cwd: "/fake/path" })).toBeUndefined();
+  });
+
+  it("returns undefined when no remotes are configured", () => {
+    const cwd = setupFixture(undefined, { git: true });
+    expect(getRemotes({ cwd })).toBeUndefined();
+  });
+
+  it("returns a single remote", () => {
+    const cwd = setupFixture(undefined, { git: true });
+    gitRemote(cwd, "add", "origin", "https://github.com/microsoft/lage.git");
+
+    expect(getRemotes({ cwd })).toEqual({ origin: "https://github.com/microsoft/lage.git" });
+  });
+
+  it("returns multiple remotes with correct names and URLs", () => {
+    const cwd = setupFixture(undefined, { git: true });
+    gitRemote(cwd, "add", "origin", "https://github.com/myuser/lage.git");
+    gitRemote(cwd, "add", "upstream", "https://github.com/microsoft/lage.git");
+    gitRemote(cwd, "add", "fork", "git@github.com:otherfork/lage.git");
+
+    expect(getRemotes({ cwd })).toEqual({
+      origin: "https://github.com/myuser/lage.git",
+      upstream: "https://github.com/microsoft/lage.git",
+      fork: "git@github.com:otherfork/lage.git",
+    });
+  });
+
+  it("handles remote names containing dots", () => {
+    const cwd = setupFixture(undefined, { git: true });
+    gitRemote(cwd, "add", "my.remote", "https://github.com/microsoft/lage.git");
+
+    expect(getRemotes({ cwd })).toEqual({ "my.remote": "https://github.com/microsoft/lage.git" });
+  });
+});

--- a/packages/workspace-tools/src/__tests__/git/parseRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/parseRemoteBranch.test.ts
@@ -1,28 +1,42 @@
-import { afterAll, describe, expect, it } from "@jest/globals";
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
 import { cleanupFixtures, setupFixture } from "../setupFixture.js";
-import { git as _git, type GitOptions } from "../../git/git.js";
+import { git as _git, addGitObserver, clearGitObservers, type GitObserver, type GitOptions } from "../../git/git.js";
 import { parseRemoteBranch } from "../../git/parseRemoteBranch.js";
 
 /** Call git helper but throw on error by default */
 const git = (args: string[], opts: GitOptions) => _git(args, { throwOnError: true, ...opts });
 
 describe("parseRemoteBranch", () => {
+  const gitObserver = jest.fn<GitObserver>();
+
+  beforeAll(() => {
+    addGitObserver(gitObserver);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterAll(() => {
     cleanupFixtures();
+    clearGitObservers();
   });
 
   describe("deprecated version", () => {
     it("parses simple remote/branch", () => {
       expect(parseRemoteBranch("origin/main")).toEqual({ remote: "origin", remoteBranch: "main" });
       expect(parseRemoteBranch("origin/feature/foo")).toEqual({ remote: "origin", remoteBranch: "feature/foo" });
+      expect(gitObserver).not.toHaveBeenCalled();
     });
 
     it("returns empty remote for branch without slash", () => {
       expect(parseRemoteBranch("main")).toEqual({ remote: "", remoteBranch: "main" });
+      expect(gitObserver).not.toHaveBeenCalled();
     });
 
     it("incorrectly assumes first part is remote even if not known", () => {
       expect(parseRemoteBranch("feature/foo")).toEqual({ remote: "feature", remoteBranch: "foo" });
+      expect(gitObserver).not.toHaveBeenCalled();
     });
   });
 
@@ -41,6 +55,7 @@ describe("parseRemoteBranch", () => {
       remote: "upstream",
       remoteBranch: "develop",
     });
+    expect(gitObserver).not.toHaveBeenCalled();
   });
 
   it("returns empty remote for branch without slash", () => {
@@ -48,6 +63,7 @@ describe("parseRemoteBranch", () => {
       remote: "",
       remoteBranch: "main",
     });
+    expect(gitObserver).not.toHaveBeenCalled();
   });
 
   it("uses custom knownRemotes", () => {
@@ -60,6 +76,7 @@ describe("parseRemoteBranch", () => {
       remote: "extra",
       remoteBranch: "feature/foo",
     });
+    expect(gitObserver).not.toHaveBeenCalled();
   });
 
   it("verifies against actual remotes if no knownRemotes match", () => {
@@ -68,6 +85,7 @@ describe("parseRemoteBranch", () => {
     // Add remotes
     git(["remote", "add", "origin", "https://example.com/origin.git"], { cwd });
     git(["remote", "add", "myremote", "https://example.com/repo.git"], { cwd });
+    gitObserver.mockClear();
 
     // Should recognize the actual remote
     const result = parseRemoteBranch({ branch: "myremote/feature", cwd });
@@ -75,6 +93,7 @@ describe("parseRemoteBranch", () => {
       remote: "myremote",
       remoteBranch: "feature",
     });
+    expect(gitObserver).toHaveBeenCalledTimes(1);
   });
 
   it("returns empty remote for unknown remote prefix", () => {
@@ -86,5 +105,21 @@ describe("parseRemoteBranch", () => {
       remote: "",
       remoteBranch: "unknown/feature",
     });
+    expect(gitObserver).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns matching remote when branch prefix matches a remote", () => {
+    const cwd = setupFixture(undefined, { git: true });
+
+    git(["remote", "add", "origin", "https://example.com/origin.git"], { cwd });
+    git(["remote", "add", "myremote", "https://example.com/repo.git"], { cwd });
+    gitObserver.mockClear();
+
+    const result = parseRemoteBranch({ branch: "myremote/feature", cwd });
+    expect(result).toEqual({
+      remote: "myremote",
+      remoteBranch: "feature",
+    });
+    expect(gitObserver).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/workspace-tools/src/__tests__/git/parseRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/parseRemoteBranch.test.ts
@@ -43,15 +43,16 @@ describe("parseRemoteBranch", () => {
   // Now the tests for the new version
 
   it("parses branch with default known remote as prefix", () => {
-    expect(parseRemoteBranch({ branch: "origin/main", cwd: "fake" })).toEqual({
+    // behavior is currently the same with and without throwOnError here
+    expect(parseRemoteBranch({ branch: "origin/main", cwd: "fake", throwOnError: true })).toEqual({
       remote: "origin",
       remoteBranch: "main",
     });
-    expect(parseRemoteBranch({ branch: "origin/feature/foo", cwd: "fake" })).toEqual({
+    expect(parseRemoteBranch({ branch: "origin/feature/foo", cwd: "fake", throwOnError: true })).toEqual({
       remote: "origin",
       remoteBranch: "feature/foo",
     });
-    expect(parseRemoteBranch({ branch: "upstream/develop", cwd: "fake" })).toEqual({
+    expect(parseRemoteBranch({ branch: "upstream/develop", cwd: "fake", throwOnError: true })).toEqual({
       remote: "upstream",
       remoteBranch: "develop",
     });
@@ -59,7 +60,7 @@ describe("parseRemoteBranch", () => {
   });
 
   it("returns empty remote for branch without slash", () => {
-    expect(parseRemoteBranch({ branch: "main", cwd: "fake" })).toEqual({
+    expect(parseRemoteBranch({ branch: "main", cwd: "fake", throwOnError: true })).toEqual({
       remote: "",
       remoteBranch: "main",
     });
@@ -71,6 +72,7 @@ describe("parseRemoteBranch", () => {
       branch: "extra/feature/foo",
       knownRemotes: ["extra"],
       cwd: "fake",
+      throwOnError: true,
     });
     expect(result).toEqual({
       remote: "extra",
@@ -88,7 +90,7 @@ describe("parseRemoteBranch", () => {
     gitObserver.mockClear();
 
     // Should recognize the actual remote
-    const result = parseRemoteBranch({ branch: "myremote/feature", cwd });
+    const result = parseRemoteBranch({ branch: "myremote/feature", cwd, throwOnError: true });
     expect(result).toEqual({
       remote: "myremote",
       remoteBranch: "feature",
@@ -98,24 +100,41 @@ describe("parseRemoteBranch", () => {
 
   it("returns empty remote for unknown remote prefix", () => {
     const cwd = setupFixture(undefined, { git: true });
+    git(["remote", "add", "origin", "https://github.com/microsoft/lage.git"], { cwd });
+    gitObserver.mockClear();
 
-    // No remotes configured, so "unknown" is not a remote
     const result = parseRemoteBranch({ branch: "unknown/feature", cwd });
     expect(result).toEqual({
       remote: "",
       remoteBranch: "unknown/feature",
     });
     expect(gitObserver).toHaveBeenCalledTimes(1);
+
+    // currently doesn't throw with throwOnError: true
+    const result2 = parseRemoteBranch({ branch: "unknown/feature", cwd, throwOnError: true });
+    expect(result2).toEqual({
+      remote: "",
+      remoteBranch: "unknown/feature",
+    });
+  });
+
+  it("throws if no defaults match and no remotes configured with throwOnError: true", () => {
+    const cwd = setupFixture(undefined, { git: true });
+
+    expect(() => parseRemoteBranch({ branch: "unknown/feature", cwd, throwOnError: true })).toThrow(
+      `No remotes defined in git repo at ${cwd}`
+    );
+    expect(gitObserver).toHaveBeenCalledTimes(1);
   });
 
   it("returns matching remote when branch prefix matches a remote", () => {
     const cwd = setupFixture(undefined, { git: true });
 
-    git(["remote", "add", "origin", "https://example.com/origin.git"], { cwd });
-    git(["remote", "add", "myremote", "https://example.com/repo.git"], { cwd });
+    git(["remote", "add", "origin", "https://github.com/microsoft/lage.git"], { cwd });
+    git(["remote", "add", "myremote", "https://github.com/ecraig12345/lage.git"], { cwd });
     gitObserver.mockClear();
 
-    const result = parseRemoteBranch({ branch: "myremote/feature", cwd });
+    const result = parseRemoteBranch({ branch: "myremote/feature", cwd, throwOnError: true });
     expect(result).toEqual({
       remote: "myremote",
       remoteBranch: "feature",

--- a/packages/workspace-tools/src/__tests__/setupFixture.ts
+++ b/packages/workspace-tools/src/__tests__/setupFixture.ts
@@ -47,9 +47,12 @@ export function setupFixture(
   options?: {
     /** Whether to set up a git repo */
     git?: boolean;
+    /** Default branch name for the git repo */
+    defaultBranchName?: string;
   }
 ): string {
   const useGit = !!options?.git;
+  const defaultBranchName = options?.defaultBranchName || "main";
 
   let fixturePath: string | undefined;
   const realFixtureName = fixtureName?.replace("-lerna-", "-") as RealFixtureName | undefined;
@@ -72,7 +75,7 @@ export function setupFixture(
 
   if (useGit) {
     // git init if requested
-    basicGit(["init"], { cwd });
+    basicGit(["init", "-b", defaultBranchName], { cwd });
     basicGit(["config", "user.name", "test user"], { cwd });
     basicGit(["config", "user.email", "test@test.email"], { cwd });
     // Ensure GPG signing doesn't interfere with tests
@@ -82,8 +85,8 @@ export function setupFixture(
     // ensure that the configuration for this repo does not collide
     // with any global configuration the user had made, so we have
     // a 'fixed' value for our tests, regardless of user configuration
-    basicGit(["symbolic-ref", "HEAD", "refs/heads/main"], { cwd });
-    basicGit(["config", "init.defaultBranch", "main"], { cwd });
+    // basicGit(["symbolic-ref", "HEAD", "refs/heads/main"], { cwd });
+    basicGit(["config", "init.defaultBranch", defaultBranchName], { cwd });
   }
 
   // Copy and commit the fixture if requested
@@ -135,15 +138,20 @@ export function setupPackageJson(cwd: string, packageJson: Record<string, any> =
  * Create a separate local git repo and configure it as a remote for `cwd`.
  * @returns The path to the remote repo directory.
  */
-export function setupLocalRemote(params: { cwd: string; remoteName: string; fixtureName?: TestFixtureName }): string {
-  const { cwd, remoteName, fixtureName } = params;
+export function setupLocalRemote(params: {
+  cwd: string;
+  remoteName: string;
+  defaultBranchName?: string;
+  fixtureName?: TestFixtureName;
+}): string {
+  const { cwd, remoteName, defaultBranchName = "main", fixtureName } = params;
 
   // Create a separate repo and configure it as a remote
-  const remoteCwd = setupFixture(fixtureName, { git: true });
+  const remoteCwd = setupFixture(fixtureName, { git: true, defaultBranchName });
   const remoteUrl = remoteCwd.replace(/\\/g, "/");
   basicGit(["remote", "add", remoteName, remoteUrl], { cwd });
   basicGit(["config", "pull.rebase", "false"], { cwd });
-  basicGit(["pull", "-X", "ours", remoteName, "main", "--allow-unrelated-histories"], { cwd });
+  basicGit(["pull", "-X", "ours", remoteName, defaultBranchName, "--allow-unrelated-histories"], { cwd });
 
   // Configure url in package.json (make the same commit in local and remote so there's no diff;
   // note that we can't just commit locally and push since the remote isn't a bare repo)
@@ -154,7 +162,7 @@ export function setupLocalRemote(params: { cwd: string; remoteName: string; fixt
   }
 
   // Ensure remote is available for comparison
-  basicGit(["fetch", remoteName, "main"], { cwd });
+  basicGit(["fetch", remoteName, defaultBranchName], { cwd });
 
   return remoteCwd;
 }

--- a/packages/workspace-tools/src/git/config.ts
+++ b/packages/workspace-tools/src/git/config.ts
@@ -14,6 +14,8 @@ export function getConfigValue(options: { key: string } & GitCommonOptions): str
 
 /**
  * Gets the user email from the git config.
+ * (Note: setting `throwOnError: true` will cause it to fail if the key is unset.)
+ *
  * @returns The email string if found, null otherwise
  */
 export function getUserEmail(options: GitCommonOptions): string | null;
@@ -26,6 +28,7 @@ export function getUserEmail(cwdOrOptions: string | GitCommonOptions): string | 
 
 /**
  * Gets the default branch based on `git config init.defaultBranch`, falling back to `master`.
+ * (Note: setting `throwOnError: true` will cause it to fail if the key is unset.)
  */
 export function getDefaultBranch(options: GitCommonOptions): string;
 /** @deprecated Use object params version */

--- a/packages/workspace-tools/src/git/getCurrentHash.ts
+++ b/packages/workspace-tools/src/git/getCurrentHash.ts
@@ -5,7 +5,6 @@ import type { GitCommonOptions } from "./types.js";
  * Gets the current commit hash (SHA).
  * @returns The hash if successful, null otherwise
  */
-
 export function getCurrentHash(options: GitCommonOptions): string | null;
 /** @deprecated Use object params version */
 export function getCurrentHash(cwd: string): string | null;

--- a/packages/workspace-tools/src/git/getDefaultRemote.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemote.ts
@@ -21,7 +21,7 @@ export type GetDefaultRemoteOptions = {
 
 /**
  * Get the name of the default remote: the one matching the `repository` field in package.json.
- * Throws if `options.cwd` is not in a git repo or there's no package.json at the repo root.
+ * Throws if `options.cwd` is not in a git repo or there's no package.json in either `cwd` or the repo root.
  *
  * The order of preference for returned remotes is:
  * 1. If `repository` is defined in package.json, the remote with a matching URL (if `options.strict`
@@ -50,25 +50,36 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
 
   // Try package.json from `cwd` first, since cwd is often the project root in actual usage,
   // and the repository URL should be the same throughout the repo.
-  let urlResult = getRepositoryUrlFromPackageJson(cwd, logOrThrow);
-  if (!urlResult.repositoryUrl) {
-    // If not found in cwd, try the git root (which may be a parent directory)
-    const gitRoot = findGitRoot(cwd);
-    if (gitRoot !== cwd) {
-      urlResult = getRepositoryUrlFromPackageJson(gitRoot, logOrThrow);
-    }
+  const cwdPackageJsonPath = path.join(cwd, "package.json");
+  const hasCwdPackageJson = fs.existsSync(cwdPackageJsonPath);
 
-    if (!urlResult.repositoryUrl) {
-      // This is always logged because it's strongly recommended to fix
-      console.log(
-        `Valid "repository" key not found in package.json at "${urlResult.packageJsonPath}". ` +
-          `Consider adding this info for more accurate git remote detection.`
-      );
+  let repositoryUrl: string | undefined;
+  if (hasCwdPackageJson) {
+    // Only try to read this if it exists (will fall back to git root)
+    repositoryUrl = getRepositoryUrlFromPackageJson(cwdPackageJsonPath, logOrThrow);
+  }
+
+  let rootPackageJsonPath: string | undefined;
+  if (!repositoryUrl) {
+    // If not found in cwd, try the git root (if a different directory or no package.json in cwd).
+    // This time allow it to throw if not found in strict mode.
+    const gitRoot = findGitRoot(cwd);
+    rootPackageJsonPath = path.join(gitRoot, "package.json");
+    if (!hasCwdPackageJson || gitRoot !== cwd) {
+      repositoryUrl = getRepositoryUrlFromPackageJson(rootPackageJsonPath, logOrThrow);
     }
   }
 
-  /** Repository full name (owner and repo name) specified in package.json */
-  const repositoryName = urlResult.repositoryUrl && getRepositoryName(urlResult.repositoryUrl);
+  if (!repositoryUrl) {
+    // This is always logged because it's strongly recommended to fix.
+    // Recommend putting it in package.json at cwd if it exists.
+    // (if there is no {cwd}/package.json, rootPackageJsonPath is always defined)
+    const jsonPath = hasCwdPackageJson ? cwdPackageJsonPath : rootPackageJsonPath!;
+    console.log(
+      `Valid "repository" key not found in package.json at "${jsonPath}". ` +
+        `Consider adding this info for more accurate git remote detection.`
+    );
+  }
 
   // Get remote names and URLs
   const remotes = options.remotes || getRemotes({ cwd });
@@ -80,6 +91,31 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
     log(`Assuming default remote "origin".`);
     return "origin";
   }
+
+  if (repositoryUrl) {
+    // Try to match the given remote
+    const remoteName = _matchRepositoryUrlToRemote(repositoryUrl, remotes, logOrThrow);
+    if (remoteName) {
+      return remoteName;
+    }
+  }
+
+  // Default to upstream or origin if available, or the first remote otherwise
+  const fallback = ["upstream", "origin"].find((name) => !!remotes[name]) || Object.keys(remotes)[0];
+  log(`Default to remote "${fallback}"`);
+  return fallback;
+}
+
+/** Match repository URL from package.json to a git remote. Exported for testing. */
+export function _matchRepositoryUrlToRemote(
+  /** repository.url from package.json */
+  repositoryUrl: string,
+  /** Mapping from remote name to remote URL */
+  remotes: Record<string, string>,
+  logOrThrow: (message: string) => void = () => {}
+): string | undefined {
+  // Repository full name (owner and repo name) specified in package.json
+  const repositoryName = getRepositoryName(repositoryUrl);
 
   for (const [remoteName, remoteUrl] of Object.entries(remotes)) {
     // There are many possible remote URL formats, so normalize before comparison
@@ -93,29 +129,21 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
     // If `strict` is true, and repositoryName is found, there MUST be a matching remote
     logOrThrow(`Could not find remote pointing to repository "${repositoryName}".`);
   }
-
-  // Default to upstream or origin if available, or the first remote otherwise
-  const fallback = ["upstream", "origin"].find((name) => !!remotes[name]) || Object.keys(remotes)[0];
-  log(`Default to remote "${fallback}"`);
-  return fallback;
 }
 
 function getRepositoryUrlFromPackageJson(
-  dir: string,
+  packageJsonPath: string,
   logOrThrow: (message: string) => void
-): { packageJsonPath: string; repositoryUrl: string | undefined } {
-  const packageJsonPath = path.join(dir, "package.json");
+): string | undefined {
   let repositoryUrl: string | undefined;
 
   try {
-    if (fs.existsSync(packageJsonPath)) {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageInfo;
-      const { repository } = packageJson;
-      repositoryUrl = typeof repository === "string" ? repository : repository?.url;
-    }
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageInfo;
+    const { repository } = packageJson;
+    repositoryUrl = typeof repository === "string" ? repository : repository?.url;
   } catch {
     logOrThrow(`Could not read "${packageJsonPath}"`);
   }
 
-  return { packageJsonPath, repositoryUrl };
+  return repositoryUrl;
 }

--- a/packages/workspace-tools/src/git/getDefaultRemote.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemote.ts
@@ -9,8 +9,8 @@ export type GetDefaultRemoteOptions = {
   /** Get repository info relative to this directory. */
   cwd: string;
   /**
-   * If true, throw an error if remote info can't be found, or if a `repository` is not specified
-   * in package.json and no matching remote is found.
+   * If true, throw an error if remote info can't be found, if no `package.json` is found, or if
+   * a `repository` is specified in package.json but no matching remote exists.
    */
   strict?: boolean;
   /** If true, log debug messages about how the remote was chosen */
@@ -21,7 +21,10 @@ export type GetDefaultRemoteOptions = {
 
 /**
  * Get the name of the default remote: the one matching the `repository` field in package.json.
- * Throws if `options.cwd` is not in a git repo or there's no package.json in either `cwd` or the repo root.
+ * Throws if `options.cwd` is not in a git repo.
+ *
+ * It's recommended to set `strict: true` to also throw if no remotes are defined, no package.json
+ * is found, or package.json has a `repository` field but no matching remote exists.
  *
  * The order of preference for returned remotes is:
  * 1. If `repository` is defined in package.json, the remote with a matching URL (if `options.strict`
@@ -48,6 +51,22 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
     log(message);
   };
 
+  // Get remote names and URLs via `git config`.
+  // In strict mode, it will throw if cwd isn't in a git repo or no remotes are found.
+  const remotes = options.remotes || getRemotes({ cwd, throwOnError: strict });
+  if (!Object.keys(remotes).length) {
+    // For non-strict, verify cwd is actually in a git repo (throws if not)
+    !strict && findGitRoot(cwd);
+
+    // It's a git repo with no remotes configured. This should probably always be an error (since
+    // subsequent operations which require a remote likely won't work), but to match old behavior,
+    // still default to "origin" unless `strict` is true.
+    logOrThrow(`No remotes defined in git repo at ${cwd}`);
+    log(`Assuming default remote "origin"`);
+    return "origin";
+  }
+
+  // Try to find the repository URL:
   // Try package.json from `cwd` first, since cwd is often the project root in actual usage,
   // and the repository URL should be the same throughout the repo.
   const cwdPackageJsonPath = path.join(cwd, "package.json");
@@ -55,17 +74,20 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
 
   let repositoryUrl: string | undefined;
   if (hasCwdPackageJson) {
-    // Only try to read this if it exists (will fall back to git root)
+    // Only try to read this if it exists (will fall back to git root later)
     repositoryUrl = getRepositoryUrlFromPackageJson(cwdPackageJsonPath, logOrThrow);
   }
 
   let rootPackageJsonPath: string | undefined;
   if (!repositoryUrl) {
-    // If not found in cwd, try the git root (if a different directory or no package.json in cwd).
-    // This time allow it to throw if not found in strict mode.
+    // If cwd doesn't have package.json or it doesn't specify a repository, try the git root
     const gitRoot = findGitRoot(cwd);
     rootPackageJsonPath = path.join(gitRoot, "package.json");
-    if (!hasCwdPackageJson || gitRoot !== cwd) {
+    if (!hasCwdPackageJson && !fs.existsSync(rootPackageJsonPath)) {
+      // no package.json found
+      const paths = cwd === gitRoot ? `${cwd}` : `${cwd} or git root ${gitRoot}`;
+      logOrThrow(`Could not find package.json under ${paths}`);
+    } else if (gitRoot !== cwd) {
       repositoryUrl = getRepositoryUrlFromPackageJson(rootPackageJsonPath, logOrThrow);
     }
   }
@@ -76,28 +98,15 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
     // (if there is no {cwd}/package.json, rootPackageJsonPath is always defined)
     const jsonPath = hasCwdPackageJson ? cwdPackageJsonPath : rootPackageJsonPath!;
     console.log(
-      `Valid "repository" key not found in package.json at "${jsonPath}". ` +
+      `Valid "repository" key not found in package.json at ${jsonPath}. ` +
         `Consider adding this info for more accurate git remote detection.`
     );
   }
 
-  // Get remote names and URLs
-  const remotes = options.remotes || getRemotes({ cwd });
-  if (!remotes || !Object.keys(remotes).length) {
-    // If we get here, no git remotes were found. This should probably always be an error (since
-    // subsequent operations which require a remote likely won't work), but to match old behavior,
-    // still default to "origin" unless `strict` is true.
-    logOrThrow(`Could not find any remotes in git repo at "${cwd}".`);
-    log(`Assuming default remote "origin".`);
-    return "origin";
-  }
-
-  if (repositoryUrl) {
-    // Try to match the given remote
-    const remoteName = _matchRepositoryUrlToRemote(repositoryUrl, remotes, logOrThrow);
-    if (remoteName) {
-      return remoteName;
-    }
+  // If a repository URL is found, try to match it with a remote
+  const remoteName = repositoryUrl && _matchRepositoryUrlToRemote(repositoryUrl, remotes, logOrThrow);
+  if (remoteName) {
+    return remoteName;
   }
 
   // Default to upstream or origin if available, or the first remote otherwise
@@ -127,23 +136,24 @@ export function _matchRepositoryUrlToRemote(
 
   if (repositoryName) {
     // If `strict` is true, and repositoryName is found, there MUST be a matching remote
-    logOrThrow(`Could not find remote pointing to repository "${repositoryName}".`);
+    logOrThrow(`Could not find remote pointing to repository "${repositoryName}"`);
   }
 }
 
+/**
+ * Read and parse `packageJsonPath` and return the `repository` URL if found.
+ * Calls `logOrThrow` if it can't be read or parsed.
+ */
 function getRepositoryUrlFromPackageJson(
   packageJsonPath: string,
   logOrThrow: (message: string) => void
 ): string | undefined {
-  let repositoryUrl: string | undefined;
-
   try {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageInfo;
     const { repository } = packageJson;
-    repositoryUrl = typeof repository === "string" ? repository : repository?.url;
+    return typeof repository === "string" ? repository : repository?.url;
   } catch {
-    logOrThrow(`Could not read "${packageJsonPath}"`);
+    logOrThrow(`Could not read ${packageJsonPath}`);
+    return undefined;
   }
-
-  return repositoryUrl;
 }

--- a/packages/workspace-tools/src/git/getDefaultRemote.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemote.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { findGitRoot } from "../paths.js";
 import { type PackageInfo } from "../types/PackageInfo.js";
 import { getRepositoryName } from "./getRepositoryName.js";
-import { git } from "./git.js";
+import { getRemotes } from "./getRemotes.js";
 
 export type GetDefaultRemoteOptions = {
   /** Get repository info relative to this directory. */
@@ -15,6 +15,8 @@ export type GetDefaultRemoteOptions = {
   strict?: boolean;
   /** If true, log debug messages about how the remote was chosen */
   verbose?: boolean;
+  /** Optional pre-fetched mapping from remote name to remote URL */
+  remotes?: Record<string, string>;
 };
 
 /**
@@ -46,66 +48,74 @@ export function getDefaultRemote(cwdOrOptions: string | GetDefaultRemoteOptions)
     log(message);
   };
 
-  const gitRoot = findGitRoot(cwd);
-
-  let packageJson: Partial<PackageInfo> = {};
-  const packageJsonPath = path.join(gitRoot, "package.json");
-  try {
-    packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8").trim());
-  } catch {
-    logOrThrow(`Could not read "${packageJsonPath}"`);
-  }
-
-  const { repository } = packageJson;
-  const repositoryUrl = typeof repository === "string" ? repository : (repository && repository.url) || "";
-  if (!repositoryUrl) {
-    // This is always logged because it's strongly recommended to fix
-    console.log(
-      `Valid "repository" key not found in "${packageJsonPath}". Consider adding this info for more accurate git remote detection.`
-    );
-  }
-  /** Repository full name (owner and repo name) specified in package.json */
-  const repositoryName = getRepositoryName(repositoryUrl);
-
-  const remotesResult = git(["remote", "-v"], { cwd });
-  if (!remotesResult.success) {
-    logOrThrow(`Could not determine available git remotes under "${cwd}"`);
-  }
-
-  /** Mapping from remote URL to full name (owner and repo name) */
-  const remotes: { [remoteRepoUrl: string]: string } = {};
-  remotesResult.stdout.split("\n").forEach((line) => {
-    const [remoteName, remoteUrl] = line.split(/\s+/);
-    const remoteRepoName = getRepositoryName(remoteUrl);
-    if (remoteRepoName) {
-      remotes[remoteRepoName] = remoteName;
+  // Try package.json from `cwd` first, since cwd is often the project root in actual usage,
+  // and the repository URL should be the same throughout the repo.
+  let urlResult = getRepositoryUrlFromPackageJson(cwd, logOrThrow);
+  if (!urlResult.repositoryUrl) {
+    // If not found in cwd, try the git root (which may be a parent directory)
+    const gitRoot = findGitRoot(cwd);
+    if (gitRoot !== cwd) {
+      urlResult = getRepositoryUrlFromPackageJson(gitRoot, logOrThrow);
     }
-  });
+
+    if (!urlResult.repositoryUrl) {
+      // This is always logged because it's strongly recommended to fix
+      console.log(
+        `Valid "repository" key not found in package.json at "${urlResult.packageJsonPath}". ` +
+          `Consider adding this info for more accurate git remote detection.`
+      );
+    }
+  }
+
+  /** Repository full name (owner and repo name) specified in package.json */
+  const repositoryName = urlResult.repositoryUrl && getRepositoryName(urlResult.repositoryUrl);
+
+  // Get remote names and URLs
+  const remotes = options.remotes || getRemotes({ cwd });
+  if (!remotes || !Object.keys(remotes).length) {
+    // If we get here, no git remotes were found. This should probably always be an error (since
+    // subsequent operations which require a remote likely won't work), but to match old behavior,
+    // still default to "origin" unless `strict` is true.
+    logOrThrow(`Could not find any remotes in git repo at "${cwd}".`);
+    log(`Assuming default remote "origin".`);
+    return "origin";
+  }
+
+  for (const [remoteName, remoteUrl] of Object.entries(remotes)) {
+    // There are many possible remote URL formats, so normalize before comparison
+    const remoteRepoName = getRepositoryName(remoteUrl);
+    if (remoteRepoName === repositoryName) {
+      return remoteName;
+    }
+  }
 
   if (repositoryName) {
-    // If the repository name was found in package.json, check for a matching remote
-    if (remotes[repositoryName]) {
-      return remotes[repositoryName];
-    }
-
     // If `strict` is true, and repositoryName is found, there MUST be a matching remote
     logOrThrow(`Could not find remote pointing to repository "${repositoryName}".`);
   }
 
   // Default to upstream or origin if available, or the first remote otherwise
-  const allRemoteNames = Object.values(remotes);
-  const fallbacks = ["upstream", "origin", ...allRemoteNames];
-  for (const fallback of fallbacks) {
-    if (allRemoteNames.includes(fallback)) {
-      log(`Default to remote "${fallback}"`);
-      return fallback;
+  const fallback = ["upstream", "origin"].find((name) => !!remotes[name]) || Object.keys(remotes)[0];
+  log(`Default to remote "${fallback}"`);
+  return fallback;
+}
+
+function getRepositoryUrlFromPackageJson(
+  dir: string,
+  logOrThrow: (message: string) => void
+): { packageJsonPath: string; repositoryUrl: string | undefined } {
+  const packageJsonPath = path.join(dir, "package.json");
+  let repositoryUrl: string | undefined;
+
+  try {
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageInfo;
+      const { repository } = packageJson;
+      repositoryUrl = typeof repository === "string" ? repository : repository?.url;
     }
+  } catch {
+    logOrThrow(`Could not read "${packageJsonPath}"`);
   }
 
-  // If we get here, no git remotes were found. This should probably always be an error (since
-  // subsequent operations which require a remote likely won't work), but to match old behavior,
-  // still default to "origin" unless `strict` is true.
-  logOrThrow(`Could not find any remotes in git repo at "${gitRoot}".`);
-  log(`Assuming default remote "origin".`);
-  return "origin";
+  return { packageJsonPath, repositoryUrl };
 }

--- a/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
@@ -1,16 +1,25 @@
 import { getDefaultRemote, type GetDefaultRemoteOptions } from "./getDefaultRemote.js";
 import { git } from "./git.js";
 import { getDefaultBranch } from "./gitUtilities.js";
+import { parseRemoteBranchPlusRemotes } from "./parseRemoteBranch.js";
 
 export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
-  /** Name of branch to use. If undefined, uses the default branch name (falling back to `master`). */
+  /**
+   * Name of branch to use, **without** a remote prefix. If you want to resolve a branch
+   * that may already include a remote prefix, use {@link resolveRemoteBranch}.
+   *
+   * If undefined, uses the default branch name (falling back to `master`).
+   */
   branch?: string;
 };
 
 /**
  * Gets a reference to `options.branch` or the default branch relative to the default remote.
  * (See {@link getDefaultRemote} for how the default remote is determined.)
- * Throws if `options.cwd` is not in a git repo or there's no package.json at the repo root.
+ *
+ * If you want to resolve a branch that may already include a remote prefix, use
+ * {@link resolveRemoteBranch} instead.
+ *
  * @returns A branch reference like `upstream/master` or `origin/master`.
  */
 export function getDefaultRemoteBranch(options: GetDefaultRemoteBranchOptions): string;
@@ -34,25 +43,51 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
     return `${defaultRemote}/${branch}`;
   }
 
-  const showRemote = git(["remote", "show", defaultRemote], { cwd });
   let remoteDefaultBranch: string | undefined;
 
-  if (showRemote.success) {
-    /**
-     * `showRemote.stdout` is something like this:
-     *
-     * * remote origin
-     *   Fetch URL: .../monorepo-upstream
-     *   Push  URL: .../monorepo-upstream
-     *   HEAD branch: main
-     */
-    remoteDefaultBranch = showRemote.stdout
-      .split(/\n/)
-      .find((line) => line.includes("HEAD branch"))
-      ?.replace(/^\s*HEAD branch:\s+/, "");
+  // Get the default branch name from the default remote.
+  // ls-remote is a plumbing command with stable, locale-independent output.
+  // Output format: "ref: refs/heads/main\tHEAD\n<hash>\tHEAD"
+  const lsRemote = git(["ls-remote", "--symref", defaultRemote, "HEAD"], { cwd });
+  if (lsRemote.success) {
+    const refRegex = /^ref: refs\/heads\/(.*?)\t/;
+    const symRefLine = lsRemote.stdout.split("\n").find((line) => refRegex.test(line));
+    remoteDefaultBranch = symRefLine && symRefLine.match(refRegex)?.[1];
   }
 
-  remoteDefaultBranch ||= getDefaultBranch({ cwd, throwOnError: options.strict });
+  // If no default branch found from the remote, fall back to the local git config or "master"
+  // (this can't use throwOnError in case the key isn't set)
+  remoteDefaultBranch ||= getDefaultBranch({ cwd });
 
   return `${defaultRemote}/${remoteDefaultBranch}`;
+}
+
+/**
+ * Resolve a user-provided branch (possibly with a remote) to a fully-qualified remote branch.
+ * First tries the less-expensive {@link parseRemoteBranchPlusRemotes} (`git remote`) to see if
+ * there's an explicit remote in the branch name, then tries {@link getDefaultRemoteBranch}.
+ *
+ * @returns A fully-qualified target remote branch reference (e.g. `origin/main`)
+ */
+export function resolveRemoteBranch(
+  options: Omit<GetDefaultRemoteBranchOptions, "branch" | "remotes"> & {
+    /** Branch which might include a remote prefix */
+    branch: string | undefined;
+  }
+): string {
+  const { branch } = options;
+
+  let parsed: ReturnType<typeof parseRemoteBranchPlusRemotes> | undefined;
+  if (branch) {
+    // A branch is provided, so see if it includes a remote name.
+    // The result is saved so the fetched list of remotes can be reused.
+    parsed = parseRemoteBranchPlusRemotes({ ...options, branch });
+    if (parsed.remote) {
+      return `${parsed.remote}/${parsed.remoteBranch}`;
+    }
+  }
+
+  // No branch provided, or the provided branch didn't include a remote.
+  // Get the default remote and possibly default branch.
+  return getDefaultRemoteBranch({ ...options, remotes: parsed?.remotes });
 }

--- a/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
@@ -1,7 +1,13 @@
 import { getDefaultRemote, type GetDefaultRemoteOptions } from "./getDefaultRemote.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced by docs
+import type { getRemotes } from "./getRemotes.js";
 import { git } from "./git.js";
 import { getDefaultBranch } from "./gitUtilities.js";
-import { parseRemoteBranchPlusRemotes } from "./parseRemoteBranch.js";
+import {
+  parseRemoteBranchPlusRemotes,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type parseRemoteBranch,
+} from "./parseRemoteBranch.js";
 
 export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
   /**
@@ -16,9 +22,13 @@ export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
 /**
  * Gets a reference to `options.branch` or the default branch relative to the default remote.
  * (See {@link getDefaultRemote} for how the default remote is determined.)
+ * Throws if `options.cwd` is not in a git repo.
  *
  * If you want to resolve a branch that may already include a remote prefix, use
  * {@link resolveRemoteBranch} instead.
+ *
+ * If `options.strict` is true, throws in the same cases as {@link getDefaultRemote}, {@link getRemotes},
+ * or if querying the default branch from the remote fails.
  *
  * @returns A branch reference like `upstream/master` or `origin/master`.
  */
@@ -48,11 +58,22 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
   // Get the default branch name from the default remote.
   // ls-remote is a plumbing command with stable, locale-independent output.
   // Output format: "ref: refs/heads/main\tHEAD\n<hash>\tHEAD"
-  const lsRemote = git(["ls-remote", "--symref", defaultRemote, "HEAD"], { cwd });
+  const lsRemoteCmd = ["ls-remote", "--symref", defaultRemote, "HEAD"];
+  const lsRemote = git(lsRemoteCmd, {
+    cwd,
+    throwOnError: options.strict,
+    description: `Fetching default branch info from remote "${defaultRemote}"`,
+  });
   if (lsRemote.success) {
     const refRegex = /^ref: refs\/heads\/(.*?)\t/;
     const symRefLine = lsRemote.stdout.split("\n").find((line) => refRegex.test(line));
     remoteDefaultBranch = symRefLine && symRefLine.match(refRegex)?.[1];
+
+    if (!remoteDefaultBranch && options.strict) {
+      throw new Error(
+        `Could not parse default branch from \`git ${lsRemoteCmd.join(" ")}\` output:\n${lsRemote.stdout}`
+      );
+    }
   }
 
   // If no default branch found from the remote, fall back to the local git config or "master"
@@ -64,8 +85,12 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
 
 /**
  * Resolve a user-provided branch (possibly with a remote) to a fully-qualified remote branch.
- * First tries the less-expensive {@link parseRemoteBranchPlusRemotes} (`git remote`) to see if
- * there's an explicit remote in the branch name, then tries {@link getDefaultRemoteBranch}.
+ * First tries the less-expensive {@link parseRemoteBranchPlusRemotes} (compares with remote names
+ * read from `git config`) to see if there's an explicit remote in the branch name, then tries
+ * {@link getDefaultRemoteBranch}.
+ *
+ * If `options.strict` is true, throws in the same cases as {@link parseRemoteBranch},
+ * {@link getDefaultRemoteBranch}, {@link getDefaultRemote}, or {@link getRemotes}.
  *
  * @returns A fully-qualified target remote branch reference (e.g. `origin/main`)
  */

--- a/packages/workspace-tools/src/git/getRemotes.ts
+++ b/packages/workspace-tools/src/git/getRemotes.ts
@@ -1,26 +1,45 @@
-import { git } from "./git.js";
+import { git, GitError, type GitProcessOutput } from "./git.js";
 import type { GitCommonOptions } from "./types.js";
 
 /**
  * Get a mapping from remote names to fetch URLs.
  *
- * Note this returns the URLs directly from `git config --get-regexp 'remote\..*\.url'`, which
- * doesn't respect any `url.<base>.insteadOf` remappings (such as for ssh). This should be fine
- * for current usage: `parseRemoteBranch` only needs the names, and `getDefaultRemote` compares
- * parsed URLs from `package.json` `repository` and should be flexible about formats.
+ * Note this returns the URLs directly from `git config --local --get-regexp 'remote\..*\.url'`,
+ * which doesn't respect any `url.<base>.insteadOf` remappings (such as for ssh). This should be
+ * fine for current usage: `parseRemoteBranch` only needs the names, and `getDefaultRemote`
+ * compares parsed URLs from `package.json` `repository` and should be flexible about formats.
  *
- * @param options git options. The config command exits with an error if there are no remotes configured,
- * so `throwOnError` is not supported.
+ * If `options.throwOnError` is true, throws if no remotes are found or `cwd` isn't in a git repo.
  *
- * @returns An object mapping remote names to URLs, or undefined if nothing found.
+ * @returns An object mapping remote names to URLs.
  */
-export function getRemotes(options: Omit<GitCommonOptions, "throwOnError">): Record<string, string> | undefined {
-  // Get remote names and URLs, similar to `git remote -v` but without localization concerns.
-  // It's expected that this will exit with an error if there are no remotes configured
-  // (so we override throwOnError in case it was present on a reused options object).
-  const remotesResult = git(["config", "--get-regexp", "remote\\..*\\.url"], { ...options, throwOnError: false });
+export function getRemotes(options: GitCommonOptions): Record<string, string> {
+  let remotesResult: GitProcessOutput;
+  try {
+    // Get remote names and URLs, similar to `git remote -v` but without localization concerns.
+    // --local ensures it errors if cwd is not in a git repo.
+    remotesResult = git(["config", "--local", "--get-regexp", "remote\\..*\\.url"], {
+      ...options,
+      description: "Getting git remotes",
+    });
+  } catch (e) {
+    if (e instanceof GitError) {
+      if (e.gitOutput?.status === 1) {
+        // Per git config docs, 1 means the key wasn't found, so fail with a clearer message
+        // (this case will only be hit with throwOnError: true)
+        throw new GitError(`No remotes defined in git repo at ${options.cwd}`, undefined, e.gitOutput);
+      }
+      if (e.gitOutput?.status === 128) {
+        // 128 most commonly means not a git repository
+        throw new GitError(`${options.cwd} is not in a git repository`, undefined, e.gitOutput);
+      }
+    }
+    throw e;
+  }
+
   if (!remotesResult.success) {
-    return undefined;
+    // throwOnError was false/unset but no remotes were found
+    return {};
   }
 
   const remotes: Record<string, string> = {};

--- a/packages/workspace-tools/src/git/getRemotes.ts
+++ b/packages/workspace-tools/src/git/getRemotes.ts
@@ -1,0 +1,36 @@
+import { git } from "./git.js";
+import type { GitCommonOptions } from "./types.js";
+
+/**
+ * Get a mapping from remote names to fetch URLs.
+ *
+ * Note this returns the URLs directly from `git config --get-regexp 'remote\..*\.url'`, which
+ * doesn't respect any `url.<base>.insteadOf` remappings (such as for ssh). This should be fine
+ * for current usage: `parseRemoteBranch` only needs the names, and `getDefaultRemote` compares
+ * parsed URLs from `package.json` `repository` and should be flexible about formats.
+ *
+ * @param options git options. The config command exits with an error if there are no remotes configured,
+ * so `throwOnError` is not supported.
+ *
+ * @returns An object mapping remote names to URLs, or undefined if nothing found.
+ */
+export function getRemotes(options: Omit<GitCommonOptions, "throwOnError">): Record<string, string> | undefined {
+  // Get remote names and URLs, similar to `git remote -v` but without localization concerns.
+  // It's expected that this will exit with an error if there are no remotes configured
+  // (so we override throwOnError in case it was present on a reused options object).
+  const remotesResult = git(["config", "--get-regexp", "remote\\..*\\.url"], { ...options, throwOnError: false });
+  if (!remotesResult.success) {
+    return undefined;
+  }
+
+  const remotes: Record<string, string> = {};
+  const remoteLines = remotesResult.stdout.trim().split("\n");
+  for (const line of remoteLines) {
+    const remoteMatch = line.match(/^remote\.(.+?)\.url\s+(.*)$/);
+    if (!remoteMatch) continue;
+    const [, remoteName, remoteUrl] = remoteMatch;
+    remotes[remoteName] = remoteUrl;
+  }
+
+  return remotes;
+}

--- a/packages/workspace-tools/src/git/index.ts
+++ b/packages/workspace-tools/src/git/index.ts
@@ -11,7 +11,11 @@ export {
 } from "./getChanges.js";
 export { getCurrentHash } from "./getCurrentHash.js";
 export { getDefaultRemote, type GetDefaultRemoteOptions } from "./getDefaultRemote.js";
-export { getDefaultRemoteBranch, type GetDefaultRemoteBranchOptions } from "./getDefaultRemoteBranch.js";
+export {
+  getDefaultRemoteBranch,
+  type GetDefaultRemoteBranchOptions,
+  resolveRemoteBranch,
+} from "./getDefaultRemoteBranch.js";
 export { getFileAddedHash } from "./getFileAddedHash.js";
 export { getFileFromRef } from "./getFileFromRef.js";
 export { getRecentCommitMessages } from "./getRecentCommitMessages.js";

--- a/packages/workspace-tools/src/git/parseRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/parseRemoteBranch.ts
@@ -4,7 +4,11 @@ import type { ParsedRemoteBranch, ParseRemoteBranchOptions } from "./types.js";
 /**
  * Get the remote and branch name from a full branch name that may include a remote prefix.
  * If the path doesn't start with one of `options.knownRemotes` (but has multiple segments),
- * the actual list of remotes will be fetched to see if one of those matches.
+ * the actual list of remotes will be read via `git config` to see if one of those matches.
+ *
+ * With `throwOnError: true`, currently it will NOT throw if the branch prefix matches `knownRemotes`
+ * regardless of the actual state of remotes in the repo. If it has to get the actual list of
+ * remotes, it will throw in the same cases as {@link getRemotes}.
  *
  * NOTE: The additional verification is new in the object params version; the original version
  * incorrectly assumes the first segment before a slash is always a remote.
@@ -31,12 +35,8 @@ export function parseRemoteBranch(branchOrOptions: string | ParseRemoteBranchOpt
 }
 
 /**
- * Get the remote and branch name from a full branch name that may include a remote prefix.
- * If the path doesn't start with one of `options.knownRemotes` (but has multiple segments),
- * the actual list of remotes will be fetched to see if one of those matches.
- *
- * This version also returns the remotes in the result if they were fetched from git,
- * for reuse by other operations.
+ * See {@link parseRemoteBranch}. This version also returns the remotes in the result if they were
+ * read from git, for reuse by other operations.
  */
 export function parseRemoteBranchPlusRemotes(
   options: ParseRemoteBranchOptions

--- a/packages/workspace-tools/src/git/parseRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/parseRemoteBranch.ts
@@ -1,4 +1,4 @@
-import { git } from "./git.js";
+import { getRemotes } from "./getRemotes.js";
 import type { ParsedRemoteBranch, ParseRemoteBranchOptions } from "./types.js";
 
 /**
@@ -25,21 +25,45 @@ export function parseRemoteBranch(branchOrOptions: string | ParseRemoteBranchOpt
     };
   }
 
-  const { branch, knownRemotes = ["origin", "upstream"], ...options } = branchOrOptions;
+  // Remove the list of remotes from the result
+  const { remote, remoteBranch } = parseRemoteBranchPlusRemotes(branchOrOptions);
+  return { remote, remoteBranch };
+}
+
+/**
+ * Get the remote and branch name from a full branch name that may include a remote prefix.
+ * If the path doesn't start with one of `options.knownRemotes` (but has multiple segments),
+ * the actual list of remotes will be fetched to see if one of those matches.
+ *
+ * This version also returns the remotes in the result if they were fetched from git,
+ * for reuse by other operations.
+ */
+export function parseRemoteBranchPlusRemotes(
+  options: ParseRemoteBranchOptions
+): ParsedRemoteBranch & { remotes: Record<string, string> | undefined } {
+  const { branch, knownRemotes = ["origin", "upstream"], ...otherOptions } = options;
 
   if (!branch.includes("/")) {
-    return { remote: "", remoteBranch: branch };
+    return { remote: "", remoteBranch: branch, remotes: undefined };
   }
 
+  // As a shortcut, check for the most common remote names before doing git operations
   let remote = knownRemotes.find((r) => branch.startsWith(`${r}/`));
 
+  let remotes: Record<string, string> | undefined;
   if (!remote) {
-    const remotes = git(["remote"], options).stdout.trim().split(/\n/);
-    remote = remotes.find((r) => branch.startsWith(`${r}/`));
+    // There's a slash in the branch name, but it doesn't start with one of the common remote names.
+    // Get the real list of remotes from git to see if it matches any of those, or is just a branch
+    // with a slash in the name (e.g. "feature/foo/bar"). This just reads the git config and isn't
+    // an expensive operation, but save the returned remotes for later anyway.
+    remotes = getRemotes(otherOptions);
+    if (remotes) {
+      remote = Object.keys(remotes).find((r) => branch.startsWith(`${r}/`));
+    }
   }
 
   if (remote) {
-    return { remote, remoteBranch: branch.slice(remote.length + 1) };
+    return { remote, remoteBranch: branch.slice(remote.length + 1), remotes };
   }
-  return { remote: "", remoteBranch: branch };
+  return { remote: "", remoteBranch: branch, remotes };
 }

--- a/packages/workspace-tools/src/git/types.ts
+++ b/packages/workspace-tools/src/git/types.ts
@@ -47,9 +47,12 @@ export type ParseRemoteBranchOptions = GitCommonOptions & {
 };
 
 export type ParsedRemoteBranch = {
-  /** Remote name, e.g. `origin` */
+  /**
+   * Remote name, e.g. `origin`.
+   * May be an empty string if the original branch reference didn't include a remote.
+   */
   remote: string;
-  /** Branch name without remote, e.g. `main` */
+  /** Branch name without remote, e.g. `main`. This is always set. */
   remoteBranch: string;
 };
 


### PR DESCRIPTION
Add `resolveRemoteBranch` which parses the remote from the provided branch if present, or gets the remote (and branch if not provided) from `getDefaultRemoteBranch`.

Improve efficiency and reduce git operations for various remote-related helpers:
- Split out the logic to get the list of remotes into a new helper `getRemotes` (not currently exported), and use `git config --regexp 'remote\\.*\\.url'` to get the URLs in a lower-level parseable way
- Share remotes result between `resolveRemoteBranch => getRemotes` and `getDefaultRemoteBranch => getRemotes`
- In `getDefaultRemote`, for matching the remote to package.json `repository` URL, try package.json from `cwd` first before finding the git root and trying there (`cwd` is often already the root). Also use `getRemotes` to get the remotes.
- In `getDefaultRemoteBranch`, use `git ls-remote --symref <remote> HEAD` to get the default branch from the remote (instead of `git remote show`) so it's minimal information and a stable format to parse.
- Split up `parseRemoteBranch` internals into a helper that can use pre-fetched remotes