### PR TITLE
Expose the --output-format option on the affected command

### DIFF
--- a/change/change-08d11dcf-a096-4421-b3e2-b3f0a1b6133c.json
+++ b/change/change-08d11dcf-a096-4421-b3e2-b3f0a1b6133c.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Add `affected` options to the `affected` command",
+      "packageName": "@lage-run/cli",
+      "email": "lutomanovic@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/commands/affected/index.ts
+++ b/packages/cli/src/commands/affected/index.ts
@@ -3,6 +3,10 @@ import { affectedAction } from "./action.js";
 import { addOptions } from "../addOptions.js";
 
 const affectedCommand: Command = new Command("affected");
-addOptions("filter", affectedCommand).action(affectedAction);
+
+addOptions("filter", affectedCommand);
+addOptions("affected", affectedCommand);
+
+affectedCommand.action(affectedAction);
 
 export { affectedCommand };


### PR DESCRIPTION
## Summary

The `affected` command only registered the `filter` option group, so its already-defined `--output-format` option was never exposed on the CLI. This change registers the `affected` option group so `--output-format <graph|json|default>` becomes available.

## Test
<img width="866" height="326" alt="image" src="https://github.com/user-attachments/assets/34b5fd08-7822-4d5b-9db1-61c6fce8aac1" />

<img width="529" height="26" alt="image" src="https://github.com/user-attachments/assets/f35ec5c7-8699-489a-9677-54e8bd43186f" />

