### PR TITLE
Add resolveRemoteAndBranch helper

### DIFF
--- a/change/change-b2789cda-767b-4c1b-a713-4848e9932dbd.json
+++ b/change/change-b2789cda-767b-4c1b-a713-4848e9932dbd.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Add `resolveRemoteAndBranch` helper, and export `getRemotes`",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -21,6 +21,8 @@ const baseTestTarget = {
  * @type {Partial<Omit<ConfigOptions, 'cacheOptions'>> & { cacheOptions?: Partial<CacheOptions> }}
  */
 const config = {
+  // use fancy reporter locally and platform-specific ones for CI
+  reporter: process.env.CI || process.env.TF_BUILD ? undefined : "fancy",
   pipeline: {
     "lage#bundle": {
       dependsOn: ["^^transpile", "types"],

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-glob": "3.3.3",
     "husky": "^9.1.5",
     "jest": "^30.0.0",
-    "lage-npm": "npm:lage@<2.14.16",
+    "lage-npm": "npm:lage@2.15.12",
     "lint-staged": "^16.0.0",
     "patch-package": "^8.0.0",
     "prettier": "^3.0.0",

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -296,6 +296,9 @@ export function getRemoteBranch(options: GitBranchOptions): string | null;
 export function getRemoteBranch(branch: string, cwd: string): string | null;
 
 // @public
+export function getRemotes(options: GitCommonOptions): Record<string, string>;
+
+// @public
 export function getScopedPackages(search: string[], packages: {
     [pkg: string]: unknown;
 } | string[]): string[];
@@ -661,7 +664,20 @@ export interface PnpmLockFile {
 // @public (undocumented)
 export function queryLockFile(name: string, versionRange: string, lock: ParsedLock): LockDependency;
 
+// @public (undocumented)
+type RemoteBranch = {
+    remote: string;
+    branch: string;
+};
+
+// Warning: (ae-forgotten-export) The symbol "RemoteBranch" needs to be exported by the entry point index.d.ts
+//
 // @public
+export function resolveRemoteAndBranch(options: Omit<GetDefaultRemoteBranchOptions, "branch" | "remotes"> & {
+    branch: string | undefined;
+}): RemoteBranch;
+
+// @public @deprecated
 export function resolveRemoteBranch(options: Omit<GetDefaultRemoteBranchOptions, "branch" | "remotes"> & {
     branch: string | undefined;
 }): string;

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
@@ -4,7 +4,7 @@ import { cleanupFixtures, setupFixture, setupLocalRemote, setupPackageJson } fro
 import { addGitObserver, clearGitObservers, gitFailFast, type GitObserver } from "../../git/git.js";
 import {
   getDefaultRemoteBranch,
-  resolveRemoteBranch,
+  resolveRemoteAndBranch,
   type GetDefaultRemoteBranchOptions,
 } from "../../git/getDefaultRemoteBranch.js";
 import { findGitRoot } from "../../paths.js";
@@ -141,12 +141,18 @@ describe("getDefaultRemoteBranch", () => {
   });
 });
 
-describe("resolveRemoteBranch", () => {
+describe("resolveRemoteAndBranch", () => {
   it("returns branch as-is when it already has a known remote prefix (no git ops)", () => {
     const opts: GetDefaultRemoteBranchOptions = { cwd: "fake", strict: true };
-    expect(resolveRemoteBranch({ branch: "origin/main", ...opts })).toBe("origin/main");
-    expect(resolveRemoteBranch({ branch: "upstream/develop", ...opts })).toBe("upstream/develop");
-    expect(resolveRemoteBranch({ branch: "origin/feature/foo", ...opts })).toBe("origin/feature/foo");
+    expect(resolveRemoteAndBranch({ branch: "origin/main", ...opts })).toEqual({ remote: "origin", branch: "main" });
+    expect(resolveRemoteAndBranch({ branch: "upstream/develop", ...opts })).toEqual({
+      remote: "upstream",
+      branch: "develop",
+    });
+    expect(resolveRemoteAndBranch({ branch: "origin/feature/foo", ...opts })).toEqual({
+      remote: "origin",
+      branch: "feature/foo",
+    });
     expect(gitObserver).not.toHaveBeenCalled();
   });
 
@@ -156,7 +162,7 @@ describe("resolveRemoteBranch", () => {
     gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
     gitObserver.mockClear();
 
-    expect(resolveRemoteBranch({ branch: "main", cwd, strict: true })).toBe("origin/main");
+    expect(resolveRemoteAndBranch({ branch: "main", cwd, strict: true })).toEqual({ remote: "origin", branch: "main" });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
@@ -168,7 +174,10 @@ describe("resolveRemoteBranch", () => {
     gitRemote("add", "myremote", "https://github.com/myuser/lage.git");
     gitObserver.mockClear();
 
-    expect(resolveRemoteBranch({ branch: "myremote/feature", cwd, strict: true })).toBe("myremote/feature");
+    expect(resolveRemoteAndBranch({ branch: "myremote/feature", cwd, strict: true })).toEqual({
+      remote: "myremote",
+      branch: "feature",
+    });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
   });
@@ -180,7 +189,10 @@ describe("resolveRemoteBranch", () => {
     gitObserver.mockClear();
 
     // "feature" is not a remote, so the whole string is treated as the branch name
-    expect(resolveRemoteBranch({ branch: "feature/foo", cwd, strict: true })).toBe("origin/feature/foo");
+    expect(resolveRemoteAndBranch({ branch: "feature/foo", cwd, strict: true })).toEqual({
+      remote: "origin",
+      branch: "feature/foo",
+    });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
@@ -190,7 +202,10 @@ describe("resolveRemoteBranch", () => {
     setupLocalRemote({ cwd, remoteName: "origin" });
     jest.clearAllMocks();
 
-    expect(resolveRemoteBranch({ branch: undefined, cwd, strict: true })).toBe("origin/main");
+    expect(resolveRemoteAndBranch({ branch: undefined, cwd, strict: true })).toEqual({
+      remote: "origin",
+      branch: "main",
+    });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetOriginDefaultBranch]);
   });

--- a/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
@@ -8,11 +8,12 @@ import {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type parseRemoteBranch,
 } from "./parseRemoteBranch.js";
+import type { RemoteBranch } from "./types.js";
 
 export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
   /**
    * Name of branch to use, **without** a remote prefix. If you want to resolve a branch
-   * that may already include a remote prefix, use {@link resolveRemoteBranch}.
+   * that may already include a remote prefix, use {@link resolveRemoteAndBranch}.
    *
    * If undefined, uses the default branch name (falling back to `master`).
    */
@@ -25,7 +26,7 @@ export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
  * Throws if `options.cwd` is not in a git repo.
  *
  * If you want to resolve a branch that may already include a remote prefix, use
- * {@link resolveRemoteBranch} instead.
+ * {@link resolveRemoteAndBranch} instead.
  *
  * If `options.strict` is true, throws in the same cases as {@link getDefaultRemote}, {@link getRemotes},
  * or if querying the default branch from the remote fails.
@@ -45,12 +46,23 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
     typeof branchOrOptions === "string"
       ? ({ branch: branchOrOptions, cwd: argsCwd } as GetDefaultRemoteBranchOptions)
       : branchOrOptions;
+
+  const result = getDefaultRemoteAndBranch(options);
+  return `${result.remote}/${result.branch}`;
+}
+
+/**
+ * Like {@link getDefaultRemoteBranch} but it returns an object.
+ *
+ * @returns A branch reference like `{ remote: "upstream", branch: "master" }` or `{ remote: "origin", branch: "main" }`.
+ */
+function getDefaultRemoteAndBranch(options: GetDefaultRemoteBranchOptions): RemoteBranch {
   const { cwd, branch } = options;
 
   const defaultRemote = getDefaultRemote(options);
 
   if (branch) {
-    return `${defaultRemote}/${branch}`;
+    return { remote: defaultRemote, branch };
   }
 
   let remoteDefaultBranch: string | undefined;
@@ -80,7 +92,22 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
   // (this can't use throwOnError in case the key isn't set)
   remoteDefaultBranch ||= getDefaultBranch({ cwd });
 
-  return `${defaultRemote}/${remoteDefaultBranch}`;
+  return { remote: defaultRemote, branch: remoteDefaultBranch };
+}
+
+/**
+ * Resolve a user-provided branch (possibly with a remote) to a fully-qualified remote branch.
+ * @returns A fully-qualified target remote branch reference (e.g. `origin/main`)
+ * @deprecated Use {@link resolveRemoteAndBranch} instead
+ */
+export function resolveRemoteBranch(
+  options: Omit<GetDefaultRemoteBranchOptions, "branch" | "remotes"> & {
+    /** Branch which might include a remote prefix */
+    branch: string | undefined;
+  }
+): string {
+  const result = resolveRemoteAndBranch(options);
+  return `${result.remote}/${result.branch}`;
 }
 
 /**
@@ -92,14 +119,14 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
  * If `options.strict` is true, throws in the same cases as {@link parseRemoteBranch},
  * {@link getDefaultRemoteBranch}, {@link getDefaultRemote}, or {@link getRemotes}.
  *
- * @returns A fully-qualified target remote branch reference (e.g. `origin/main`)
+ * @returns A fully-qualified target remote branch reference (e.g. `{ remote: "origin", branch: "main" }`)
  */
-export function resolveRemoteBranch(
+export function resolveRemoteAndBranch(
   options: Omit<GetDefaultRemoteBranchOptions, "branch" | "remotes"> & {
     /** Branch which might include a remote prefix */
     branch: string | undefined;
   }
-): string {
+): RemoteBranch {
   const { branch } = options;
 
   let parsed: ReturnType<typeof parseRemoteBranchPlusRemotes> | undefined;
@@ -108,11 +135,11 @@ export function resolveRemoteBranch(
     // The result is saved so the fetched list of remotes can be reused.
     parsed = parseRemoteBranchPlusRemotes({ ...options, branch });
     if (parsed.remote) {
-      return `${parsed.remote}/${parsed.remoteBranch}`;
+      return { remote: parsed.remote, branch: parsed.remoteBranch };
     }
   }
 
   // No branch provided, or the provided branch didn't include a remote.
   // Get the default remote and possibly default branch.
-  return getDefaultRemoteBranch({ ...options, remotes: parsed?.remotes });
+  return getDefaultRemoteAndBranch({ ...options, remotes: parsed?.remotes });
 }

--- a/packages/workspace-tools/src/git/index.ts
+++ b/packages/workspace-tools/src/git/index.ts
@@ -15,10 +15,12 @@ export {
   getDefaultRemoteBranch,
   type GetDefaultRemoteBranchOptions,
   resolveRemoteBranch,
+  resolveRemoteAndBranch,
 } from "./getDefaultRemoteBranch.js";
 export { getFileAddedHash } from "./getFileAddedHash.js";
 export { getFileFromRef } from "./getFileFromRef.js";
 export { getRecentCommitMessages } from "./getRecentCommitMessages.js";
+export { getRemotes } from "./getRemotes.js";
 export {
   addGitObserver,
   clearGitObservers,

--- a/packages/workspace-tools/src/git/types.ts
+++ b/packages/workspace-tools/src/git/types.ts
@@ -56,6 +56,13 @@ export type ParsedRemoteBranch = {
   remoteBranch: string;
 };
 
+export type RemoteBranch = {
+  /** Remote name, e.g. `origin`. */
+  remote: string;
+  /** Branch name without remote, e.g. `main`. */
+  branch: string;
+};
+
 export type GitStageOptions = {
   /** File patterns to stage */
   patterns: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,7 +1730,7 @@ __metadata:
     fast-glob: "npm:3.3.3"
     husky: "npm:^9.1.5"
     jest: "npm:^30.0.0"
-    lage-npm: "npm:lage@<2.14.16"
+    lage-npm: "npm:lage@2.15.12"
     lint-staged: "npm:^16.0.0"
     patch-package: "npm:^8.0.0"
     prettier: "npm:^3.0.0"
@@ -6583,9 +6583,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lage-npm@npm:lage@<2.14.16":
-  version: 2.14.15
-  resolution: "lage@npm:2.14.15"
+"lage-npm@npm:lage@2.15.12":
+  version: 2.15.12
+  resolution: "lage@npm:2.15.12"
   dependencies:
     fsevents: "npm:~2.3.2"
     glob-hasher: "npm:^1.4.2"
@@ -6595,7 +6595,7 @@ __metadata:
   bin:
     lage: dist/lage.js
     lage-server: dist/lage-server.js
-  checksum: 10c0/002644c5e0318eaa3ac54a3689427cef3d772ed00c824484ac9bdc643153ce97ee7ee14f8ef82f9afbc9749bbd43680528b06d743ee9abe0999ae6f6e0962b21
+  checksum: 10c0/1bf1cc296a326647a69ea97c3c71004b4e02ee94b92e01b69c4e8e87ae74455b700f0dd65f5ad08598e6e178f4ab4aa25b7d2252b2963528847a283e4ccdf0f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a new helper which returns an object with the remote and branch separately. Also export `getRemotes`.