### PR TITLE
Update parseRemoteBranchPlusRemotes API and fix docs

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -6,6 +6,7 @@ const config = {
   access: "public",
   groupChanges: true,
   branch: "main",
+  commit: false,
   changelog: {
     groups: [
       {

--- a/change/change-9bd3251f-08f1-4328-b882-70a0a84670bd.json
+++ b/change/change-9bd3251f-08f1-4328-b882-70a0a84670bd.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update `resolveRemoteAndBranch` to return `.remoteBranch` instead of `.branch` for consistency",
+      "packageName": "workspace-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/workspace-tools/etc/workspace-tools.api.md
+++ b/packages/workspace-tools/etc/workspace-tools.api.md
@@ -665,9 +665,8 @@ export interface PnpmLockFile {
 export function queryLockFile(name: string, versionRange: string, lock: ParsedLock): LockDependency;
 
 // @public (undocumented)
-type RemoteBranch = {
+type RemoteBranch = Pick<ParsedRemoteBranch, "remoteBranch"> & {
     remote: string;
-    branch: string;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RemoteBranch" needs to be exported by the entry point index.d.ts

--- a/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
+++ b/packages/workspace-tools/src/__tests__/git/getDefaultRemoteBranch.test.ts
@@ -144,14 +144,17 @@ describe("getDefaultRemoteBranch", () => {
 describe("resolveRemoteAndBranch", () => {
   it("returns branch as-is when it already has a known remote prefix (no git ops)", () => {
     const opts: GetDefaultRemoteBranchOptions = { cwd: "fake", strict: true };
-    expect(resolveRemoteAndBranch({ branch: "origin/main", ...opts })).toEqual({ remote: "origin", branch: "main" });
+    expect(resolveRemoteAndBranch({ branch: "origin/main", ...opts })).toEqual({
+      remote: "origin",
+      remoteBranch: "main",
+    });
     expect(resolveRemoteAndBranch({ branch: "upstream/develop", ...opts })).toEqual({
       remote: "upstream",
-      branch: "develop",
+      remoteBranch: "develop",
     });
     expect(resolveRemoteAndBranch({ branch: "origin/feature/foo", ...opts })).toEqual({
       remote: "origin",
-      branch: "feature/foo",
+      remoteBranch: "feature/foo",
     });
     expect(gitObserver).not.toHaveBeenCalled();
   });
@@ -162,7 +165,10 @@ describe("resolveRemoteAndBranch", () => {
     gitRemote("add", "origin", "https://github.com/microsoft/lage.git");
     gitObserver.mockClear();
 
-    expect(resolveRemoteAndBranch({ branch: "main", cwd, strict: true })).toEqual({ remote: "origin", branch: "main" });
+    expect(resolveRemoteAndBranch({ branch: "main", cwd, strict: true })).toEqual({
+      remote: "origin",
+      remoteBranch: "main",
+    });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
   });
@@ -176,7 +182,7 @@ describe("resolveRemoteAndBranch", () => {
 
     expect(resolveRemoteAndBranch({ branch: "myremote/feature", cwd, strict: true })).toEqual({
       remote: "myremote",
-      branch: "feature",
+      remoteBranch: "feature",
     });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig]);
@@ -191,7 +197,7 @@ describe("resolveRemoteAndBranch", () => {
     // "feature" is not a remote, so the whole string is treated as the branch name
     expect(resolveRemoteAndBranch({ branch: "feature/foo", cwd, strict: true })).toEqual({
       remote: "origin",
-      branch: "feature/foo",
+      remoteBranch: "feature/foo",
     });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetRoot]);
@@ -204,7 +210,7 @@ describe("resolveRemoteAndBranch", () => {
 
     expect(resolveRemoteAndBranch({ branch: undefined, cwd, strict: true })).toEqual({
       remote: "origin",
-      branch: "main",
+      remoteBranch: "main",
     });
 
     expect(getGitCalls()).toEqual([gitGetRemotesConfig, gitGetOriginDefaultBranch]);

--- a/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/getDefaultRemoteBranch.ts
@@ -1,13 +1,8 @@
 import { getDefaultRemote, type GetDefaultRemoteOptions } from "./getDefaultRemote.js";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced by docs
 import type { getRemotes } from "./getRemotes.js";
 import { git } from "./git.js";
 import { getDefaultBranch } from "./gitUtilities.js";
-import {
-  parseRemoteBranchPlusRemotes,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  type parseRemoteBranch,
-} from "./parseRemoteBranch.js";
+import { parseRemoteBranchPlusRemotes, type parseRemoteBranch } from "./parseRemoteBranch.js";
 import type { RemoteBranch } from "./types.js";
 
 export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
@@ -19,6 +14,9 @@ export type GetDefaultRemoteBranchOptions = GetDefaultRemoteOptions & {
    */
   branch?: string;
 };
+
+// Re-export these so the @link references in jsdoc comments work in the generated .d.ts
+export type { getDefaultRemote as _1, getRemotes as _2, parseRemoteBranch as _3, parseRemoteBranchPlusRemotes as _4 };
 
 /**
  * Gets a reference to `options.branch` or the default branch relative to the default remote.
@@ -48,7 +46,7 @@ export function getDefaultRemoteBranch(...args: (string | GetDefaultRemoteBranch
       : branchOrOptions;
 
   const result = getDefaultRemoteAndBranch(options);
-  return `${result.remote}/${result.branch}`;
+  return `${result.remote}/${result.remoteBranch}`;
 }
 
 /**
@@ -62,7 +60,8 @@ function getDefaultRemoteAndBranch(options: GetDefaultRemoteBranchOptions): Remo
   const defaultRemote = getDefaultRemote(options);
 
   if (branch) {
-    return { remote: defaultRemote, branch };
+    // For this specific function, `branch` has no remote prefix
+    return { remote: defaultRemote, remoteBranch: branch };
   }
 
   let remoteDefaultBranch: string | undefined;
@@ -92,7 +91,7 @@ function getDefaultRemoteAndBranch(options: GetDefaultRemoteBranchOptions): Remo
   // (this can't use throwOnError in case the key isn't set)
   remoteDefaultBranch ||= getDefaultBranch({ cwd });
 
-  return { remote: defaultRemote, branch: remoteDefaultBranch };
+  return { remote: defaultRemote, remoteBranch: remoteDefaultBranch };
 }
 
 /**
@@ -107,7 +106,7 @@ export function resolveRemoteBranch(
   }
 ): string {
   const result = resolveRemoteAndBranch(options);
-  return `${result.remote}/${result.branch}`;
+  return `${result.remote}/${result.remoteBranch}`;
 }
 
 /**
@@ -135,7 +134,8 @@ export function resolveRemoteAndBranch(
     // The result is saved so the fetched list of remotes can be reused.
     parsed = parseRemoteBranchPlusRemotes({ ...options, branch });
     if (parsed.remote) {
-      return { remote: parsed.remote, branch: parsed.remoteBranch };
+      // have to extract these to avoid returning `remotes`
+      return { remote: parsed.remote, remoteBranch: parsed.remoteBranch };
     }
   }
 

--- a/packages/workspace-tools/src/git/parseRemoteBranch.ts
+++ b/packages/workspace-tools/src/git/parseRemoteBranch.ts
@@ -1,6 +1,9 @@
 import { getRemotes } from "./getRemotes.js";
 import type { ParsedRemoteBranch, ParseRemoteBranchOptions } from "./types.js";
 
+// Re-export this so the @link references in jsdoc comments work in the generated .d.ts
+export type { getRemotes as _1 };
+
 /**
  * Get the remote and branch name from a full branch name that may include a remote prefix.
  * If the path doesn't start with one of `options.knownRemotes` (but has multiple segments),

--- a/packages/workspace-tools/src/git/types.ts
+++ b/packages/workspace-tools/src/git/types.ts
@@ -56,11 +56,9 @@ export type ParsedRemoteBranch = {
   remoteBranch: string;
 };
 
-export type RemoteBranch = {
+export type RemoteBranch = Pick<ParsedRemoteBranch, "remoteBranch"> & {
   /** Remote name, e.g. `origin`. */
   remote: string;
-  /** Branch name without remote, e.g. `main`. */
-  branch: string;
 };
 
 export type GitStageOptions = {


### PR DESCRIPTION
Update `resolveRemoteAndBranch` to return `.remoteBranch` instead of `.branch` for consistency with other APIs. (This is technically a breaking change, but the API was introduced yesterday and the one version it was in can be deprecated.)

Also fix `@link` references in the related API docs by adding type-only re-exports of referenced APIs--this is a hack but doesn't get exposed in the package's public API, so it's fine.