### PR TITLE
Revert to using fancier reporter except in slow terminals

### DIFF
--- a/change/change-ad6a24c6-619b-43b1-9369-b9cca461cac8.json
+++ b/change/change-ad6a24c6-619b-43b1-9369-b9cca461cac8.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Revert to using fancier reporter by default when running locally, except in known slow terminals (codespaces, SSH)",
+      "packageName": "@lage-run/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "minor"
+    },
+    {
+      "type": "none",
+      "comment": "update comment",
+      "packageName": "@lage-run/config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "minor",
+      "comment": "Remove unused `ChromeTraceEventsReporter` `concurrency` option that was not used",
+      "packageName": "@lage-run/reporters",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -243,7 +243,7 @@ Available reporters:
 | Name | Internal class | Description |
 | ---- | ----- | ----------- |
 | `default`/not specified | `ProgressReporter`, `BasicReporter` or `LogReporter` | If running in an interactive terminal without `--grouped` or `--verbose`, uses `basic` in known slow terminals (Codespaces, SSH) and `fancy` otherwise. Otherwise, uses `npmLog`. |
-| `fancy` | `ProgressReporter` | Shows progress including the names of currently running targets, but is slower. This was the default in v2 prior to 2.14.16, and is the default after 2.17.0 unless running in known slow terminals. |
+| `fancy` | `ProgressReporter` | Shows progress including the names of currently running targets, but is slower. This was the default in v2 prior to 2.14.16, and is the default in 2.17.0+ unless running in known slow terminals. |
 | `basic` | `BasicReporter` | Shows progress without the names of running targets. This was the default from 2.14.16 to 2.16.1, and is still the default if running in known slow terminals. |
 | `npmLog` (`old`) | `LogReporter` | This is the reporter from lage v1. It logs tasks without progress info. |
 | `azureDevops` (`adoLog`) | `AdoReporter` | Logs tasks with ADO-specific formatting prefixes |

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -242,8 +242,9 @@ Available reporters:
 <!-- prettier-ignore -->
 | Name | Internal class | Description |
 | ---- | ----- | ----------- |
-| `default`/not specified | `BasicReporter` or `LogReporter` | Usually if running in an interactive terminal, shows progress but not the names of currently running targets (unless progress is disabled or verbose or grouped are enabled). Otherwise, uses `npmLog`. |
-| `fancy` | `ProgressReporter` | Shows progress including the names of currently running targets, but is slower. This was the default in v2 prior to 2.14.16. |
+| `default`/not specified | `ProgressReporter`, `BasicReporter` or `LogReporter` | If running in an interactive terminal without `--grouped` or `--verbose`, uses `basic` in known slow terminals (Codespaces, SSH) and `fancy` otherwise. Otherwise, uses `npmLog`. |
+| `fancy` | `ProgressReporter` | Shows progress including the names of currently running targets, but is slower. This was the default in v2 prior to 2.14.16, and is the default after 2.17.0 unless running in known slow terminals. |
+| `basic` | `BasicReporter` | Shows progress without the names of running targets. This was the default from 2.14.16 to 2.16.1, and is still the default if running in known slow terminals. |
 | `npmLog` (`old`) | `LogReporter` | This is the reporter from lage v1. It logs tasks without progress info. |
 | `azureDevops` (`adoLog`) | `AdoReporter` | Logs tasks with ADO-specific formatting prefixes |
 | `githubActions` (`gha`) | `GithubActionsReporter` | Logs tasks with GitHub Actions formatting prefixes |

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7255,9 +7255,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 
@@ -8600,25 +8600,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 
@@ -10066,11 +10066,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 

--- a/lage.config.js
+++ b/lage.config.js
@@ -75,8 +75,10 @@ const config = {
     "@lage-run/e2e-tests#test": {
       ...baseTestTarget,
       dependsOn: ["^^transpile", "lage#bundle"],
-      // This runs last, so give it all available resources
-      weight: os.availableParallelism(),
+      // weight is used in scripts/worker/jest.js to determine max jest workers.
+      // Make this task run last and give it all available resources.
+      // But on CI, allow only one worker since this runs lage which internally creates workers.
+      weight: process.env.CI ? 1 : os.availableParallelism(),
       priority: -9999,
     },
   },

--- a/lage.config.js
+++ b/lage.config.js
@@ -21,8 +21,6 @@ const baseTestTarget = {
  * @type {Partial<Omit<ConfigOptions, 'cacheOptions'>> & { cacheOptions?: Partial<CacheOptions> }}
  */
 const config = {
-  // use fancy reporter locally and platform-specific ones for CI
-  reporter: process.env.CI || process.env.TF_BUILD ? undefined : "fancy",
   pipeline: {
     "lage#bundle": {
       dependsOn: ["^^transpile", "types"],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "checkchange": "beachball check",
     "ci": "lage transpile types build test lint bundle api",
     "release": "beachball publish -y --tag latest",
-    "test": "lage test --verbose",
+    "test": "lage test",
     "lage-local": "node packages/lage/dist/lage.js",
     "lint": "lage lint",
     "deps:check": "lage depcheck",

--- a/packages/cli/etc/cli.api.md
+++ b/packages/cli/etc/cli.api.md
@@ -27,7 +27,7 @@ import { WorkerRunnerOptions } from '@lage-run/runners';
 import { WorkerTargetOptions } from '@lage-run/runners';
 
 // @public
-type BuiltInReporterName = "default" | "profile" | "json" | "azureDevops" | "adoLog" | "githubActions" | "gha" | "npmLog" | "old" | "verboseFileLog" | "vfl" | "fancy";
+type BuiltInReporterName = "default" | "profile" | "json" | "azureDevops" | "adoLog" | "githubActions" | "gha" | "npmLog" | "old" | "verboseFileLog" | "vfl" | "fancy" | "basic";
 
 export { CacheOptions }
 

--- a/packages/cli/src/__tests__/customReporter.test.ts
+++ b/packages/cli/src/__tests__/customReporter.test.ts
@@ -71,7 +71,7 @@ describe("initializeReporters with custom reporters", () => {
         config: { reporters: {} },
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Invalid --reporter option: "nonExistentReporter123". Supported reporters are: json, azureDevops, npmLog, verboseFileLog, vfl, adoLog, githubActions, gha, fancy, default"`
+      `"Invalid --reporter option: "nonExistentReporter123". Supported reporters are: default, basic, fancy, npmLog, adoLog, azureDevops, githubActions, gha, json, verboseFileLog, vfl"`
     );
   });
 

--- a/packages/cli/src/__tests__/initializeReporters.test.ts
+++ b/packages/cli/src/__tests__/initializeReporters.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals
 import { Logger, type Reporter } from "@lage-run/logger";
 import {
   AdoReporter,
+  BasicReporter,
   ChromeTraceEventsReporter,
   GithubActionsReporter,
   JsonReporter,
@@ -53,8 +54,7 @@ describe("initializeReporters", () => {
 
   beforeEach(() => {
     // Clear CI env vars so default-reporter tests are environment-independent
-    delete process.env.GITHUB_ACTIONS;
-    delete process.env.TF_BUILD;
+    process.env = {};
     isInteractive.mockReturnValue(true);
   });
 
@@ -69,7 +69,8 @@ describe("initializeReporters", () => {
     jest.restoreAllMocks();
   });
 
-  it("should initialize progress reporter when param is progress passed as true", async () => {
+  // progress: true is the default in local runs
+  it("uses progress reporter with progress: true", async () => {
     reporters = await callInitializeReporters({
       options: { progress: true },
     });
@@ -78,99 +79,124 @@ describe("initializeReporters", () => {
     expect(reporters[0]).toBeInstanceOf(ProgressReporter);
   });
 
-  it("should initialize old reporter when shell is not interactive", async () => {
+  it("uses basic reporter in slow terminal with progress: true", async () => {
+    process.env.CODESPACES = "true";
+    reporters = await callInitializeReporters({
+      options: { progress: true },
+    });
+
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(BasicReporter);
+  });
+
+  it("uses old reporter when shell is not interactive", async () => {
     isInteractive.mockReturnValueOnce(false);
     reporters = await callInitializeReporters();
 
     expect(reporters).toEqual([expect.any(LogReporter)]);
   });
 
-  it("should initialize old reporter when grouped", async () => {
+  it("uses old reporter when grouped", async () => {
     reporters = await callInitializeReporters({
       options: { grouped: true },
     });
-    expect(reporters).toEqual([expect.any(LogReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(LogReporter);
   });
 
-  it("should initialize old reporter when verbose", async () => {
+  it("uses old reporter when verbose", async () => {
     reporters = await callInitializeReporters({
       options: { verbose: true },
     });
-    expect(reporters).toEqual([expect.any(LogReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(LogReporter);
   });
 
-  it("should initialize profile reporter", async () => {
+  it("uses profile reporter", async () => {
     tmpDir = createTempDir({ prefix: "lage-profile-" });
     reporters = await callInitializeReporters({
       options: { progress: true, profile: path.join(tmpDir, "profile.json") },
     });
 
-    expect(reporters.length).toBe(2);
+    expect(reporters).toHaveLength(2);
     expect(reporters).toContainEqual(expect.any(ChromeTraceEventsReporter));
   });
 
-  it("should initialize ADO reporter when reporter arg is adoLog", async () => {
+  it("uses ADO reporter when reporter arg is adoLog", async () => {
     reporters = await callInitializeReporters({
       options: { reporter: ["adoLog"] },
     });
-    expect(reporters).toEqual([expect.any(AdoReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(AdoReporter);
   });
 
-  it("should auto-detect GitHub Actions and use GithubActionsReporter", async () => {
+  it("auto-detects GitHub Actions and use GithubActionsReporter", async () => {
     process.env.GITHUB_ACTIONS = "true";
     reporters = await callInitializeReporters();
-    expect(reporters).toEqual([expect.any(GithubActionsReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(GithubActionsReporter);
   });
 
-  it("should auto-detect Azure DevOps and use AdoReporter", async () => {
+  it("auto-detects Azure DevOps and use AdoReporter", async () => {
     process.env.TF_BUILD = "True";
     reporters = await callInitializeReporters();
-    expect(reporters).toEqual([expect.any(AdoReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(AdoReporter);
   });
 
-  it("should use config.reporter string when no CLI --reporter is given", async () => {
+  it("uses config.reporter string when no CLI --reporter is given", async () => {
     reporters = await callInitializeReporters({
       config: { reporter: "json" },
+      // config.reporter overrides these
+      options: { verbose: true, grouped: true },
     });
-    expect(reporters).toEqual([expect.any(JsonReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(JsonReporter);
   });
 
-  it("should use config.reporter array when no CLI --reporter is given", async () => {
+  it("uses config.reporter array when no CLI --reporter is given", async () => {
     reporters = await callInitializeReporters({
       config: { reporter: ["adoLog", "json"] },
+      // config.reporter overrides these
+      options: { verbose: true, grouped: true },
     });
     expect(reporters).toEqual([expect.any(AdoReporter), expect.any(JsonReporter)]);
   });
 
-  it("should override config.reporter when CLI --reporter is given", async () => {
+  it("overrides config.reporter when CLI --reporter is given", async () => {
     reporters = await callInitializeReporters({
       options: { reporter: ["adoLog"] },
       config: { reporter: "json" },
     });
-    expect(reporters).toEqual([expect.any(AdoReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(AdoReporter);
   });
 
-  it("should add profile reporter alongside config.reporter when --profile is used", async () => {
+  it("adds profile reporter alongside config.reporter when --profile is used", async () => {
     tmpDir = createTempDir({ prefix: "lage-profile-" });
     reporters = await callInitializeReporters({
       options: { profile: path.join(tmpDir, "profile.json") },
       config: { reporter: "adoLog" },
     });
-    expect(reporters).toEqual([expect.any(AdoReporter), expect.any(ChromeTraceEventsReporter)]);
+    expect(reporters).toHaveLength(2);
+    expect(reporters[0]).toBeInstanceOf(AdoReporter);
+    expect(reporters[1]).toBeInstanceOf(ChromeTraceEventsReporter);
   });
 
-  it("should use config.reporter instead of defaultReporter", async () => {
+  it("uses config.reporter instead of defaultReporter", async () => {
     reporters = await callInitializeReporters({
       config: { reporter: "adoLog" },
       defaultReporter: "json",
     });
-    expect(reporters).toEqual([expect.any(AdoReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(AdoReporter);
   });
 
-  it("should fall back to defaultReporter when no other reporter option is set", async () => {
+  it("falls back to defaultReporter when no other reporter option is set", async () => {
     reporters = await callInitializeReporters({
       defaultReporter: "json",
     });
-    expect(reporters).toEqual([expect.any(JsonReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(JsonReporter);
   });
 });

--- a/packages/cli/src/__tests__/initializeReporters.test.ts
+++ b/packages/cli/src/__tests__/initializeReporters.test.ts
@@ -2,11 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals
 import { Logger, type Reporter } from "@lage-run/logger";
 import {
   AdoReporter,
-  BasicReporter,
   ChromeTraceEventsReporter,
   GithubActionsReporter,
   JsonReporter,
   LogReporter,
+  ProgressReporter,
 } from "@lage-run/reporters";
 import path from "path";
 import { createTempDir, removeTempDir } from "@lage-run/test-utilities";
@@ -74,7 +74,8 @@ describe("initializeReporters", () => {
       options: { progress: true },
     });
 
-    expect(reporters).toEqual([expect.any(BasicReporter)]);
+    expect(reporters).toHaveLength(1);
+    expect(reporters[0]).toBeInstanceOf(ProgressReporter);
   });
 
   it("should initialize old reporter when shell is not interactive", async () => {

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -69,6 +69,9 @@ export async function createReporter(reporter: string, options: ReporterInitOpti
     case "old":
       return new LogReporter({ grouped, logLevel, logMemory });
 
+    case "basic":
+      return new BasicReporter({ concurrency, version, logMemory });
+
     case "fancy":
       return new ProgressReporter({ concurrency, version, logMemory });
 

--- a/packages/cli/src/commands/createReporter.ts
+++ b/packages/cli/src/commands/createReporter.ts
@@ -40,7 +40,7 @@ export function setMockImportReporter(mock: MockImportReporter | undefined): voi
  */
 export async function createReporter(reporter: string, options: ReporterInitOptions, customReporterPath?: string): Promise<TargetReporter> {
   const { verbose, grouped, logLevel: logLevelName, concurrency, profile, progress, logFile, indented, logMemory } = options;
-  const logLevel = LogLevel[logLevelName];
+  const logLevel = verbose ? LogLevel.verbose : LogLevel[logLevelName];
 
   if (customReporterPath) {
     return loadCustomReporterModule(reporter, options, customReporterPath);
@@ -53,22 +53,21 @@ export async function createReporter(reporter: string, options: ReporterInitOpti
   switch (reporter as BuiltInReporterName) {
     case "profile":
       return new ChromeTraceEventsReporter({
-        concurrency,
         outputFile: typeof profile === "string" ? profile : undefined,
       });
     case "json":
       return new JsonReporter({ logLevel, indented: indented ?? false, logMemory });
     case "azureDevops":
     case "adoLog":
-      return new AdoReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel, logMemory });
+      return new AdoReporter({ grouped, logLevel, logMemory });
 
     case "githubActions":
     case "gha":
-      return new GithubActionsReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel, logMemory });
+      return new GithubActionsReporter({ grouped, logLevel, logMemory });
 
     case "npmLog":
     case "old":
-      return new LogReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel, logMemory });
+      return new LogReporter({ grouped, logLevel, logMemory });
 
     case "fancy":
       return new ProgressReporter({ concurrency, version, logMemory });
@@ -80,18 +79,22 @@ export async function createReporter(reporter: string, options: ReporterInitOpti
 
   // Default reporter behavior - auto-detect CI environments
   if (process.env.GITHUB_ACTIONS) {
-    return new GithubActionsReporter({ grouped: true, logLevel: verbose ? LogLevel.verbose : logLevel, logMemory });
+    return new GithubActionsReporter({ grouped: true, logLevel, logMemory });
   }
-
   if (process.env.TF_BUILD) {
-    return new AdoReporter({ grouped: true, logLevel: verbose ? LogLevel.verbose : logLevel, logMemory });
+    return new AdoReporter({ grouped: true, logLevel, logMemory });
   }
 
-  if (progress && isInteractive() && !(logLevel >= LogLevel.verbose || verbose || grouped)) {
-    return new BasicReporter({ concurrency, version, logMemory });
+  // --progress defaults to true in local runs but is overridden by --grouped or --verbose
+  if (progress && isInteractive() && !grouped && logLevel < LogLevel.verbose) {
+    // For known slow terminals, use the fastest BasicReporter.
+    // Otherwise use ProgressReporter which is more informative (and reasonably fast after fixes).
+    return process.env.CODESPACES || process.env.SSH_CONNECTION || process.env.SSH_CLIENT
+      ? new BasicReporter({ concurrency, version, logMemory })
+      : new ProgressReporter({ concurrency, version, logMemory });
   }
 
-  return new LogReporter({ grouped, logLevel: verbose ? LogLevel.verbose : logLevel, logMemory });
+  return new LogReporter({ grouped, logLevel, logMemory });
 }
 
 async function loadCustomReporterModule(reporter: string, options: ReporterInitOptions, resolvedPath: string): Promise<TargetReporter> {

--- a/packages/cli/src/commands/initializeReporters.ts
+++ b/packages/cli/src/commands/initializeReporters.ts
@@ -32,13 +32,9 @@ export async function initializeReporters(params: {
     [...builtInReporterNames, ...customReporterNames].map((name) => [name.toLowerCase(), name])
   );
 
-  // filter out falsy values (e.g. undefined) from the reporter array
-  const useReporterOption = options.reporter?.length ? options.reporter : config.reporter;
-  const reporterOptions = (Array.isArray(useReporterOption) ? [...useReporterOption] : [useReporterOption]).filter(
-    Boolean
-  ) as ReporterName[];
+  const reporterOptions = options.reporter?.length ? toArray(options.reporter) : toArray(config.reporter);
 
-  if (reporterOptions.length === 0) {
+  if (!reporterOptions.length) {
     // "default" is just a dummy name to trigger the default case in createReporter
     reporterOptions.push(params.defaultReporter || ("default" satisfies BuiltInReporterName));
   }
@@ -64,4 +60,8 @@ export async function initializeReporters(params: {
     }
     logger.addReporter(reporterInstance);
   }
+}
+
+function toArray(value: string | string[] | undefined = []): ReporterName[] {
+  return (Array.isArray(value) ? value : [value]).filter(Boolean);
 }

--- a/packages/cli/src/types/ReporterInitOptions.ts
+++ b/packages/cli/src/types/ReporterInitOptions.ts
@@ -2,33 +2,45 @@ import type { LogLevel } from "@lage-run/logger";
 
 /** All the built-in reporter names */
 export type BuiltInReporterName =
+  // See initializeReporters and createReporter
   | "default"
+  // ChromeTraceEventsReporter (via --profile)
   | "profile"
+  // JsonReporter
   | "json"
+  // AdoReporter
   | "azureDevops"
   | "adoLog"
+  // GithubActionsReporter
   | "githubActions"
   | "gha"
+  // LogReporter
   | "npmLog"
   | "old"
+  // VerboseFileLogReporter
   | "verboseFileLog"
   | "vfl"
-  | "fancy";
+  // ProgressReporter
+  | "fancy"
+  // BasicReporter
+  | "basic";
 /** Built-in or custom reporter name */
 export type ReporterName = BuiltInReporterName | string;
 
 /** Whether each built-in reporter name should be listed in doc output */
 const shouldListBuiltInReporters: Record<BuiltInReporterName, boolean> = {
-  json: true,
-  azureDevops: true,
+  // this determines the order in help output
+  default: true,
+  basic: true,
+  fancy: true,
   npmLog: true,
-  verboseFileLog: true,
-  vfl: true,
   adoLog: true,
+  azureDevops: true,
   githubActions: true,
   gha: true,
-  fancy: true,
-  default: true,
+  json: true,
+  verboseFileLog: true,
+  vfl: true,
   // Not encouraged
   old: false,
   // Intended to be set via --profile

--- a/packages/config/src/types/ConfigOptions.ts
+++ b/packages/config/src/types/ConfigOptions.ts
@@ -94,7 +94,8 @@ export interface ConfigOptions {
   enablePhantomTargetOptimization: boolean;
 
   /**
-   * Built-in or custom reporter name(s) to use. This is **overridden** by the `--reporter` CLI flag.
+   * Built-in or custom reporter name(s) to use. This is **overridden** by the `--reporter` flag,
+   * but **overrides** `--verbose`, `--grouped`, and other context-based defaults (such as CI env detection).
    *
    * See https://microsoft.github.io/lage/docs/reference/cli#reporter for the list of built-in reporters.
    */

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require("@lage-run/monorepo-scripts/config/jest.config.js");
 
 module.exports = {
   ...baseConfig,
-  testTimeout: baseConfig.testTimeout * 3,
+  testTimeout: baseConfig.testTimeout * 4,
 };

--- a/packages/reporters/etc/reporters.api.md
+++ b/packages/reporters/etc/reporters.api.md
@@ -65,8 +65,6 @@ interface ChromeTraceEventsReporterOptions {
     // (undocumented)
     categorize?: (targetRun?: TargetRun) => string;
     // (undocumented)
-    concurrency: number;
-    // (undocumented)
     outputFile?: string;
 }
 

--- a/packages/reporters/src/ChromeTraceEventsReporter.ts
+++ b/packages/reporters/src/ChromeTraceEventsReporter.ts
@@ -23,7 +23,6 @@ interface CompleteEvent {
 
 export interface ChromeTraceEventsReporterOptions {
   outputFile?: string;
-  concurrency: number;
   categorize?: (targetRun?: TargetRun) => string;
 }
 

--- a/packages/reporters/src/ProgressReporter.ts
+++ b/packages/reporters/src/ProgressReporter.ts
@@ -20,7 +20,7 @@ import { isCompletionStatus } from "./isCompletionStatus.js";
 /**
  * Shows progress including the names of currently running targets using `@ms-cloudpack/task-reporter`.
  * It may be slightly slower than `BasicReporter` (though its performance has been improved substantially
- * with `task-reporter` updates) and was the default reporter in lage v2 prior to 2.14.16.
+ * with `task-reporter` updates).
  */
 export class ProgressReporter implements TargetReporter {
   private logStream: Writable;

--- a/packages/reporters/src/__tests__/ChromeTraceEventsReporter.test.ts
+++ b/packages/reporters/src/__tests__/ChromeTraceEventsReporter.test.ts
@@ -22,7 +22,7 @@ describe("ChromeTraceEventsReporter", () => {
   it("can group verbose messages, displaying summary", () => {
     const writer = new MemoryStream();
 
-    const reporter = new ChromeTraceEventsReporter({ concurrency: 4, outputFile, consoleLogStream: writer });
+    const reporter = new ChromeTraceEventsReporter({ outputFile, consoleLogStream: writer });
 
     const aBuildTarget = createTarget("a", "build");
     const aTestTarget = createTarget("a", "test");

--- a/yarn.lock
+++ b/yarn.lock
@@ -4786,16 +4786,16 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^2.0.0, fast-uri@npm:^2.1.0":
-  version: 2.4.3
-  resolution: "fast-uri@npm:2.4.3"
-  checksum: 10c0/9207e3c401db8bdb47b4d09cfb5d71bc6f247754a434701273a4ec195f8d740ead9d91d1869ae29442b7ff8f49e18d57298d7d0c19d52bf0b8f23d22d1cb1e68
+  version: 2.4.4
+  resolution: "fast-uri@npm:2.4.4"
+  checksum: 10c0/999344391f328fdbc40f4495e43a1099055d026fc501c30a912844104479afc44202cee4aa37df056c965d925f8ee110935160434ccb24857e0ec7a01613f213
   languageName: node
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 
@@ -6349,7 +6349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.3.1":
+"js-yaml@npm:4.3.1, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0, js-yaml@npm:^4.3.0":
   version: 4.3.1
   resolution: "js-yaml@npm:4.3.1"
   dependencies:
@@ -6361,25 +6361,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0, js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 
@@ -7070,11 +7059,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#967 added a basic progress reporter which is very fast but doesn't show the running task names, which can be a source of confusion if a task is slow or entirely hangs (there's no way to see what is hanging). 

This PR reverts to using the fancier progress reporter by default, except in known slow terminals (codespaces, SSH). This should be okay in most cases after #1097 which updated `@ms-cloudpack/task-reporter` to pick up significant perf improvements.